### PR TITLE
v0.4.64–0.4.67: core-fork Repository tab, dashboard crash fix, Dev Mode AGI origin, VM + merge-remote fixes

### DIFF
--- a/containers/entrypoint_aion_micro.py
+++ b/containers/entrypoint_aion_micro.py
@@ -183,6 +183,160 @@ def diagnose(req: DiagnoseRequest):
     return {"analysis": content, "model": MODEL_ID}
 
 
+class MergeConflictRequest(BaseModel):
+    file_path: str
+    ours_label: str
+    theirs_label: str
+    conflict_text: str
+
+
+def _split_conflict_hunks(text: str) -> tuple[list[str], list[dict[str, str]]]:
+    """Walk a file with conflict markers and extract each `<<<<<<< ... =======
+    ... >>>>>>>` region. Returns `(prefix_parts, hunks)` where `prefix_parts`
+    is a list of text fragments (in order) and `hunks` is a list of
+    `{ours, theirs}` dicts. Prefixes + hunks alternate, so the caller can
+    reconstruct by zipping them.
+    """
+    out_prefixes: list[str] = []
+    hunks: list[dict[str, str]] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        # Look for the start marker on its own line.
+        start = text.find("<<<<<<<", i)
+        if start == -1:
+            out_prefixes.append(text[i:])
+            break
+        # Ensure the marker is at the start of a line.
+        if start > 0 and text[start - 1] != "\n":
+            i = start + 7
+            continue
+        out_prefixes.append(text[i:start])
+        # Skip to newline after <<<<<<< label
+        line_end = text.find("\n", start)
+        if line_end == -1:
+            out_prefixes.append(text[start:])
+            break
+        sep = text.find("\n=======", line_end)
+        if sep == -1:
+            out_prefixes.append(text[start:])
+            break
+        close = text.find("\n>>>>>>>", sep)
+        if close == -1:
+            out_prefixes.append(text[start:])
+            break
+        # Include trailing newline in both sides so the reconstructed
+        # file preserves line structure. `sep` points at the \n before
+        # `=======`, and `close` points at the \n before `>>>>>>>` —
+        # each hunk side runs from after its header newline up through
+        # (and including) that delimiting newline.
+        #   sep + 8 = position right after `\n=======` (so next char is
+        #             the \n terminating the `=======` line).
+        #   sep + 9 = start of `theirs` content proper.
+        ours = text[line_end + 1 : sep + 1]
+        theirs = text[sep + 9 : close + 1] if sep + 9 <= close + 1 else ""
+        hunks.append({"ours": ours, "theirs": theirs})
+        # Advance past the closing `>>>>>>>` line.
+        close_end = text.find("\n", close + 1)
+        i = close_end + 1 if close_end != -1 else n
+    return out_prefixes, hunks
+
+
+def _resolve_hunk_deterministic(ours: str, theirs: str) -> tuple[str, str] | None:
+    """Deterministic resolutions for trivial cases. Returns `(resolved, reason)`
+    or None when the conflict needs model assistance (or manual review)."""
+    if ours == theirs:
+        return ours, "both sides identical"
+    if ours.strip() == theirs.strip():
+        # Whitespace-only conflict: prefer upstream to respect their style.
+        return theirs, "whitespace-only — preferred upstream"
+    if ours.strip() == "":
+        # Fork deleted, upstream added: keep the addition.
+        return theirs, "fork deleted, upstream added"
+    if theirs.strip() == "":
+        # Upstream deleted, fork added: keep the addition.
+        return ours, "upstream deleted, fork added"
+    return None
+
+
+@app.post("/v1/resolve-merge-conflict")
+def resolve_merge_conflict(req: MergeConflictRequest):
+    """Resolve a single file's merge conflicts. Returns `high` confidence
+    only when every hunk can be resolved deterministically OR the model
+    emits an unambiguous pick. Everything else falls back to `low` so the
+    caller refuses to auto-commit.
+    """
+    prefixes, hunks = _split_conflict_hunks(req.conflict_text)
+    if not hunks:
+        # No conflict markers — nothing to resolve.
+        return {
+            "resolved_text": req.conflict_text,
+            "confidence": "high",
+            "unresolved_hunks": [],
+        }
+
+    resolved_parts: list[str] = []
+    unresolved: list[str] = []
+    overall_high = True
+
+    for idx, hunk in enumerate(hunks):
+        ours = hunk["ours"]
+        theirs = hunk["theirs"]
+        det = _resolve_hunk_deterministic(ours, theirs)
+        if det is not None:
+            resolved_text, _reason = det
+            resolved_parts.append(resolved_text)
+            continue
+
+        # Non-trivial — ask the model for a directional pick. We do NOT
+        # ask it to synthesize new code; only to pick a side. This keeps
+        # the 135M model in its comfort zone.
+        messages = [
+            ChatMessage(role="system", content=(
+                "You are reviewing a merge conflict for the AGI platform. The user's fork "
+                "('ours') has local work; upstream ('theirs') has the canonical release. "
+                "Your ONLY job is to pick which side to keep. Respond with exactly one of: "
+                "OURS, THEIRS, or UNCLEAR. Pick UNCLEAR if both sides have meaningful content "
+                "that neither overrides nor trivially merges."
+            )),
+            ChatMessage(role="user", content=(
+                f"File: {req.file_path}\n\nOURS (fork):\n{ours[:1500]}\n\n"
+                f"THEIRS (upstream):\n{theirs[:1500]}\n\nYour pick:"
+            )),
+        ]
+        answer = generate(messages, max_tokens=16, temperature=0.0).strip().upper()
+        pick = "UNCLEAR"
+        if answer.startswith("OURS"):
+            pick = "OURS"
+        elif answer.startswith("THEIRS"):
+            pick = "THEIRS"
+        if pick == "OURS":
+            resolved_parts.append(ours)
+        elif pick == "THEIRS":
+            resolved_parts.append(theirs)
+        else:
+            overall_high = False
+            unresolved.append(f"hunk {idx + 1} in {req.file_path}: model unsure")
+            # Preserve the original conflict markers so a human can resolve.
+            resolved_parts.append(
+                f"<<<<<<< {req.ours_label}\n{ours}=======\n{theirs}>>>>>>> {req.theirs_label}\n"
+            )
+
+    # Reassemble: prefix[0] + resolved[0] + prefix[1] + resolved[1] + ... + prefix[last]
+    result_parts: list[str] = []
+    for i, p in enumerate(prefixes):
+        result_parts.append(p)
+        if i < len(resolved_parts):
+            result_parts.append(resolved_parts[i])
+    resolved_text = "".join(result_parts)
+
+    return {
+        "resolved_text": resolved_text,
+        "confidence": "high" if overall_high else "low",
+        "unresolved_hunks": unresolved,
+    }
+
+
 class ConfigRequest(BaseModel):
     model_config_json: dict[str, Any]
     model_id: str

--- a/docs/human/dev-mode.md
+++ b/docs/human/dev-mode.md
@@ -93,3 +93,26 @@ Response includes the directories that will be active after restart:
   "note": "Restart required for path changes to take effect"
 }
 ```
+
+## Merging upstream into your fork
+
+Once Dev Mode has provisioned the five owner forks under `~/_projects/_aionima/`, each one shows up in the dashboard Projects list with a restricted UX: only an **Editor** and a **Repository** tab. The Repository tab is specialised for core forks.
+
+The tab surfaces three numbers: the branch the gateway is subscribed to (from `gateway.updateChannel`), the fork's HEAD SHA, and the upstream (Civicognita) HEAD SHA. Two badges — `↑ N ahead`, `↓ N behind` — summarise divergence vs `upstream/<branch>`.
+
+When upstream has moved ahead of your fork, the **Merge upstream → origin** button lights up. Clicking it walks three escalation steps automatically:
+
+1. **Fast-forward.** If your fork is purely behind (no local commits), the merge is a straight `git merge --ff-only`. The result pushes to `origin` so the next `agi upgrade` picks it up.
+2. **Merge commit.** If both sides have commits but no textual conflicts, a three-way merge commit is created with message `Merge upstream/<branch> into <branch>`.
+3. **Agentic resolution.** On a real conflict, the button flips to show the conflicting files and offers **Let Aion-Micro try**. Aion-Micro (a local SmolLM2-135M container) attempts to resolve each hunk with either deterministic rules (identical, whitespace-only, side-deletion) or an `OURS`/`THEIRS`/`UNCLEAR` pick. Only `high`-confidence resolutions get committed; anything else leaves the conflict markers in the working tree so you can finish the merge in the Editor tab.
+
+The **Open PR to upstream** button next to it opens a pre-filled GitHub compare URL (`Civicognita/<repo>/compare/<branch>...<your-login>:<branch>`) in a new tab — the fastest path to submitting work back upstream.
+
+### API reference
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/dev/core-forks/status` | Returns `{ forks: CoreForkStatus[], branch }` for all five core forks. Bounded `git fetch upstream` per repo. |
+| `POST` | `/api/dev/core-forks/:slug/merge` | Body `{ strategy?: "ff-only" \| "agentic" }`. Returns a `CoreForkMergeResult` — either `{ ok: true, ff, agentic, newSha, pushed }` on success, `{ ok: false, conflict: true, files, ... }` on conflict, or `{ ok: false, conflict: false, reason }` on refusal (dirty tree, unknown slug). |
+
+Both routes require the same private-network + admin-role guard as `/api/dev/status`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.63",
+  "version": "0.4.64",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.66",
+  "version": "0.4.67",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.64",
+  "version": "0.4.65",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/aion-micro-manager.ts
+++ b/packages/gateway-core/src/aion-micro-manager.ts
@@ -207,4 +207,50 @@ export class AionMicroManager {
       return "";
     }
   }
+
+  /**
+   * Ask aion-micro to resolve a single merge-conflict file. The caller
+   * passes the raw file contents with `<<<<<<<`/`=======`/`>>>>>>>`
+   * markers intact; aion-micro returns a fully resolved version plus a
+   * confidence label. Callers MUST refuse to commit `low`-confidence
+   * or partially-resolved results.
+   */
+  async resolveMergeConflict(
+    filePath: string,
+    oursLabel: string,
+    theirsLabel: string,
+    conflictText: string,
+  ): Promise<{ resolvedText: string; confidence: "high" | "low"; unresolvedHunks: string[] } | null> {
+    const available = await this.ensureAvailable();
+    if (!available) return null;
+
+    this.resetIdleTimer();
+    try {
+      const res = await fetch(`${this.getBaseUrl()}/v1/resolve-merge-conflict`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          file_path: filePath,
+          ours_label: oursLabel,
+          theirs_label: theirsLabel,
+          conflict_text: conflictText,
+        }),
+        signal: AbortSignal.timeout(90_000),
+      });
+      if (!res.ok) return null;
+      const data = await res.json() as {
+        resolved_text?: string;
+        confidence?: "high" | "low";
+        unresolved_hunks?: string[];
+      };
+      if (typeof data.resolved_text !== "string") return null;
+      return {
+        resolvedText: data.resolved_text,
+        confidence: data.confidence === "high" ? "high" : "low",
+        unresolvedHunks: Array.isArray(data.unresolved_hunks) ? data.unresolved_hunks : [],
+      };
+    } catch {
+      return null;
+    }
+  }
 }

--- a/packages/gateway-core/src/dashboard-api.ts
+++ b/packages/gateway-core/src/dashboard-api.ts
@@ -140,8 +140,9 @@ export class DashboardApi {
   private handleOverview = (_req: IncomingMessage, res: ServerResponse, params: URLSearchParams): void => {
     const windowDays = intParam(params, "windowDays", 90);
     const recentLimit = intParam(params, "recentLimit", 20);
-    const overview = this.queries.getOverview(windowDays, recentLimit);
-    json(res, overview);
+    void this.queries.getOverview(windowDays, recentLimit)
+      .then((overview) => { json(res, overview); })
+      .catch(() => error(res, "Failed to fetch overview"));
   };
 
   private handleTimeline = (_req: IncomingMessage, res: ServerResponse, params: URLSearchParams): void => {
@@ -155,19 +156,19 @@ export class DashboardApi {
     const since = params.get("since") ?? undefined;
     const until = params.get("until") ?? undefined;
 
-    const buckets = this.queries.getTimeline(
+    void this.queries.getTimeline(
       bucket as TimeBucket,
       entityId,
       since,
       until,
-    );
-
-    json(res, {
-      buckets,
-      bucket,
-      since: since ?? "all-time",
-      until: until ?? "now",
-    });
+    ).then((buckets) => {
+      json(res, {
+        buckets,
+        bucket,
+        since: since ?? "all-time",
+        until: until ?? "now",
+      });
+    }).catch(() => error(res, "Failed to fetch timeline"));
   };
 
   private handleBreakdown = (_req: IncomingMessage, res: ServerResponse, params: URLSearchParams): void => {
@@ -219,18 +220,19 @@ export class DashboardApi {
     }
 
     const windowDays = intParam(params, "windowDays", 90);
-    const profile = this.queries.getEntityProfile(entityId, windowDays);
-
-    if (profile === null) {
-      error(res, "Entity not found", 404);
-      return;
-    }
-
-    json(res, profile);
+    void this.queries.getEntityProfile(entityId, windowDays)
+      .then((profile) => {
+        if (profile === null) {
+          error(res, "Entity not found", 404);
+          return;
+        }
+        json(res, profile);
+      })
+      .catch(() => error(res, "Failed to fetch entity profile"));
   };
 
   private handleCOA = (_req: IncomingMessage, res: ServerResponse, params: URLSearchParams): void => {
-    const result = this.queries.getCOAEntries({
+    void this.queries.getCOAEntries({
       entityId: params.get("entityId") ?? undefined,
       fingerprint: params.get("fingerprint") ?? undefined,
       workType: params.get("workType") ?? undefined,
@@ -238,8 +240,8 @@ export class DashboardApi {
       until: params.get("until") ?? undefined,
       limit: intParam(params, "limit", 50),
       offset: intParam(params, "offset", 0),
-    });
-
-    json(res, result);
+    })
+      .then((result) => { json(res, result); })
+      .catch(() => error(res, "Failed to fetch COA entries"));
   };
 }

--- a/packages/gateway-core/src/dev-mode-forks.ts
+++ b/packages/gateway-core/src/dev-mode-forks.ts
@@ -50,7 +50,12 @@ export interface ForkResolveResult {
   error?: string;
 }
 
-const CANONICAL_OWNER = "Civicognita";
+export const CANONICAL_OWNER = "Civicognita";
+
+/** Full `upstream` remote URL for a given core-repo spec. */
+export function upstreamRemoteUrl(spec: CoreRepoSpec): string {
+  return `https://github.com/${CANONICAL_OWNER}/${spec.upstream}.git`;
+}
 
 /**
  * Resolve (or create) the owner's fork for every core repo.
@@ -61,7 +66,7 @@ export async function resolveOrCreateForks(
 ): Promise<ForkResolveResult[]> {
   const results: ForkResolveResult[] = [];
   for (const spec of CORE_REPOS) {
-    const upstreamUrl = `https://github.com/${CANONICAL_OWNER}/${spec.upstream}.git`;
+    const upstreamUrl = upstreamRemoteUrl(spec);
     try {
       const existing = await lookupFork(ownerToken, ownerLogin, spec.upstream);
       if (existing) {

--- a/packages/gateway-core/src/dev-mode-merge.test.ts
+++ b/packages/gateway-core/src/dev-mode-merge.test.ts
@@ -1,0 +1,251 @@
+/**
+ * dev-mode-merge tests
+ *
+ * Covers:
+ *   - computeForkStatus: fresh-synced, behind, ahead+behind, missing upstream
+ *   - attemptMerge: ff-only path, merge-commit path, conflict returns files,
+ *     dirty-tree refusal, branch respected.
+ *
+ * Each test creates two bare repos in a temp dir and a checkout that
+ * points at both — no GitHub round-trips, just local file:// remotes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { attemptMerge, computeForkStatus } from "./dev-mode-merge.js";
+import type { CoreRepoSpec } from "./dev-mode-forks.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let tmpRoot: string;
+let upstreamRepo: string;
+let forkRepo: string;
+let workingClone: string;
+
+const TEST_SPEC: CoreRepoSpec = {
+  slug: "agi",
+  upstream: "agi",
+  displayName: "AGI",
+  configKey: "agiRepo",
+};
+
+const TEST_BRANCH = "main";
+
+function git(dir: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: dir, encoding: "utf-8", stdio: "pipe" });
+}
+
+function gitInit(dir: string, bare: boolean): void {
+  mkdirSync(dir, { recursive: true });
+  git(dir, ["init", "--initial-branch", TEST_BRANCH, ...(bare ? ["--bare"] : [])]);
+  if (!bare) {
+    git(dir, ["config", "user.email", "test@aionima.dev"]);
+    git(dir, ["config", "user.name", "Test"]);
+    // Disable GPG signing which some host configs force globally.
+    git(dir, ["config", "commit.gpgsign", "false"]);
+  }
+}
+
+function commit(dir: string, path: string, contents: string, msg: string): void {
+  writeFileSync(join(dir, path), contents);
+  git(dir, ["add", path]);
+  git(dir, ["commit", "-m", msg]);
+}
+
+const silentLog = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  // ComponentLogger has a few more but the merge helper only uses info/warn.
+};
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "agi-dev-merge-"));
+  upstreamRepo = join(tmpRoot, "upstream.git");
+  forkRepo = join(tmpRoot, "fork.git");
+  workingClone = join(tmpRoot, "clone");
+
+  // Seed a shared history on a scratch repo, then push to both bares.
+  gitInit(upstreamRepo, true);
+  gitInit(forkRepo, true);
+
+  const seed = join(tmpRoot, "seed");
+  gitInit(seed, false);
+  commit(seed, "README.md", "initial\n", "initial commit");
+  git(seed, ["remote", "add", "origin", forkRepo]);
+  git(seed, ["remote", "add", "upstream", upstreamRepo]);
+  git(seed, ["push", "origin", TEST_BRANCH]);
+  git(seed, ["push", "upstream", TEST_BRANCH]);
+  rmSync(seed, { recursive: true, force: true });
+
+  // Clone from the fork and wire upstream as a second remote.
+  execFileSync("git", ["clone", forkRepo, workingClone], { stdio: "pipe" });
+  git(workingClone, ["remote", "add", "upstream", upstreamRepo]);
+  git(workingClone, ["config", "user.email", "test@aionima.dev"]);
+  git(workingClone, ["config", "user.name", "Test"]);
+  git(workingClone, ["config", "commit.gpgsign", "false"]);
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// computeForkStatus
+// ---------------------------------------------------------------------------
+
+describe("computeForkStatus", () => {
+  it("reports ahead=0, behind=0 when fork and upstream are in sync", async () => {
+    const status = await computeForkStatus(workingClone, TEST_SPEC, TEST_BRANCH);
+    expect(status.error).toBeUndefined();
+    expect(status.ahead).toBe(0);
+    expect(status.behind).toBe(0);
+    expect(status.currentSha).toBeTruthy();
+    expect(status.currentSha).toBe(status.upstreamSha);
+  });
+
+  it("reports behind when upstream has commits the fork doesn't", async () => {
+    // Make upstream advance.
+    const upstreamWork = join(tmpRoot, "upstream-work");
+    execFileSync("git", ["clone", upstreamRepo, upstreamWork], { stdio: "pipe" });
+    git(upstreamWork, ["config", "user.email", "test@aionima.dev"]);
+    git(upstreamWork, ["config", "user.name", "Test"]);
+    git(upstreamWork, ["config", "commit.gpgsign", "false"]);
+    commit(upstreamWork, "feat.md", "upstream feature\n", "upstream commit");
+    git(upstreamWork, ["push", "origin", TEST_BRANCH]);
+
+    const status = await computeForkStatus(workingClone, TEST_SPEC, TEST_BRANCH);
+    expect(status.error).toBeUndefined();
+    expect(status.behind).toBe(1);
+    expect(status.ahead).toBe(0);
+  });
+
+  it("reports ahead when the fork has local commits upstream doesn't", async () => {
+    commit(workingClone, "local.md", "fork-only\n", "fork commit");
+    git(workingClone, ["push", "origin", TEST_BRANCH]);
+
+    const status = await computeForkStatus(workingClone, TEST_SPEC, TEST_BRANCH);
+    expect(status.error).toBeUndefined();
+    expect(status.behind).toBe(0);
+    expect(status.ahead).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attemptMerge
+// ---------------------------------------------------------------------------
+
+describe("attemptMerge", () => {
+  it("fast-forwards when only upstream has advanced", async () => {
+    // Advance upstream
+    const upstreamWork = join(tmpRoot, "upstream-work");
+    execFileSync("git", ["clone", upstreamRepo, upstreamWork], { stdio: "pipe" });
+    git(upstreamWork, ["config", "user.email", "test@aionima.dev"]);
+    git(upstreamWork, ["config", "user.name", "Test"]);
+    git(upstreamWork, ["config", "commit.gpgsign", "false"]);
+    commit(upstreamWork, "feat.md", "upstream\n", "upstream commit");
+    git(upstreamWork, ["push", "origin", TEST_BRANCH]);
+
+    const result = await attemptMerge({
+      targetDir: workingClone,
+      spec: TEST_SPEC,
+      branch: TEST_BRANCH,
+      strategy: "ff-only",
+      log: silentLog as never,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ff).toBe(true);
+      expect(result.agentic).toBe(false);
+      expect(result.newSha).toBeTruthy();
+    }
+
+    // After ff merge, the working clone should match upstream.
+    const afterStatus = await computeForkStatus(workingClone, TEST_SPEC, TEST_BRANCH);
+    expect(afterStatus.behind).toBe(0);
+  });
+
+  it("creates a merge commit when both sides have divergent non-conflicting commits", async () => {
+    // Local commit on fork.
+    commit(workingClone, "local.md", "fork-only\n", "fork commit");
+
+    // Upstream commit on a different file (no conflict).
+    const upstreamWork = join(tmpRoot, "upstream-work");
+    execFileSync("git", ["clone", upstreamRepo, upstreamWork], { stdio: "pipe" });
+    git(upstreamWork, ["config", "user.email", "test@aionima.dev"]);
+    git(upstreamWork, ["config", "user.name", "Test"]);
+    git(upstreamWork, ["config", "commit.gpgsign", "false"]);
+    commit(upstreamWork, "upstream.md", "upstream-only\n", "upstream commit");
+    git(upstreamWork, ["push", "origin", TEST_BRANCH]);
+
+    const result = await attemptMerge({
+      targetDir: workingClone,
+      spec: TEST_SPEC,
+      branch: TEST_BRANCH,
+      strategy: "ff-only",
+      log: silentLog as never,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ff).toBe(false);
+      expect(result.newSha).toBeTruthy();
+    }
+  });
+
+  it("returns conflict files when both sides touch the same line", async () => {
+    // Fork changes README
+    commit(workingClone, "README.md", "fork version\n", "fork edit");
+
+    // Upstream also changes README
+    const upstreamWork = join(tmpRoot, "upstream-work");
+    execFileSync("git", ["clone", upstreamRepo, upstreamWork], { stdio: "pipe" });
+    git(upstreamWork, ["config", "user.email", "test@aionima.dev"]);
+    git(upstreamWork, ["config", "user.name", "Test"]);
+    git(upstreamWork, ["config", "commit.gpgsign", "false"]);
+    commit(upstreamWork, "README.md", "upstream version\n", "upstream edit");
+    git(upstreamWork, ["push", "origin", TEST_BRANCH]);
+
+    const result = await attemptMerge({
+      targetDir: workingClone,
+      spec: TEST_SPEC,
+      branch: TEST_BRANCH,
+      strategy: "ff-only",
+      log: silentLog as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.conflict) {
+      expect(result.files).toContain("README.md");
+      expect(result.agentic).toBe(false);
+    }
+  });
+
+  it("refuses to merge when the working tree is dirty", async () => {
+    writeFileSync(join(workingClone, "README.md"), "uncommitted change\n");
+
+    const result = await attemptMerge({
+      targetDir: workingClone,
+      spec: TEST_SPEC,
+      branch: TEST_BRANCH,
+      strategy: "ff-only",
+      log: silentLog as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.conflict).toBe(false);
+      if (result.conflict === false) {
+        expect(result.reason).toMatch(/uncommitted/i);
+      }
+    }
+  });
+});

--- a/packages/gateway-core/src/dev-mode-merge.ts
+++ b/packages/gateway-core/src/dev-mode-merge.ts
@@ -168,21 +168,19 @@ export async function getAllCoreForkStatuses(
 }
 
 /**
- * Ensure the `upstream` remote points at the canonical Civicognita URL.
- * Runs as a belt-and-braces step before merge ops so a legacy clone
- * that never went through the retrofit loop doesn't fail quietly.
+ * Ensure the `upstream` remote is configured, but don't overwrite a
+ * pre-existing one. The authoritative place that sets `upstream` is
+ * `/api/dev/switch` (retrofit loop) — this is a belt-and-braces step
+ * for clones that somehow ended up without the remote. Rewriting a
+ * valid existing remote would break local overrides (e.g. tests that
+ * pin `upstream` to a tmp bare repo, or owners who fork-of-fork).
  */
 function ensureUpstreamRemote(targetDir: string, spec: CoreRepoSpec, log: ComponentLogger): void {
-  const expected = upstreamRemoteUrl(spec);
   const current = gitSilent(["remote", "get-url", "upstream"], targetDir, REV_LIST_TIMEOUT_MS);
-  if (current.ok && current.stdout.trim() === expected) return;
-  if (current.ok) {
-    gitSilent(["remote", "set-url", "upstream", expected], targetDir, REV_LIST_TIMEOUT_MS);
-    log.info(`dev-merge: repointed ${spec.slug} upstream → ${expected}`);
-  } else {
-    gitSilent(["remote", "add", "upstream", expected], targetDir, REV_LIST_TIMEOUT_MS);
-    log.info(`dev-merge: added ${spec.slug} upstream remote`);
-  }
+  if (current.ok) return; // remote already exists — trust it
+  const expected = upstreamRemoteUrl(spec);
+  gitSilent(["remote", "add", "upstream", expected], targetDir, REV_LIST_TIMEOUT_MS);
+  log.info(`dev-merge: added ${spec.slug} upstream remote (was missing)`);
 }
 
 /**

--- a/packages/gateway-core/src/dev-mode-merge.ts
+++ b/packages/gateway-core/src/dev-mode-merge.ts
@@ -1,0 +1,378 @@
+/**
+ * Dev-Mode merge helpers — git operations for the core-fork Repository tab.
+ *
+ * Keeps the git plumbing out of server-runtime-state.ts so the route
+ * handlers stay thin: each exported function does one thing (compare,
+ * fetch, merge, push) and returns a structured result.
+ *
+ * All operations run against the five `_aionima/<slug>/` workspace
+ * clones that Dev Mode provisions. Every clone has two remotes:
+ *   - origin   → wishborn/<repo>   (owner's fork)
+ *   - upstream → Civicognita/<repo> (canonical release channel)
+ *
+ * The merge workflow is always "pull upstream into origin" — the
+ * reverse direction (fork → upstream) happens via GitHub PR, not here.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ComponentLogger } from "./logger.js";
+import { CORE_REPOS, upstreamRemoteUrl, type CoreRepoSpec } from "./dev-mode-forks.js";
+import type { AionMicroManager } from "./aion-micro-manager.js";
+
+const FETCH_TIMEOUT_MS = 20_000;
+const MERGE_TIMEOUT_MS = 30_000;
+const PUSH_TIMEOUT_MS = 30_000;
+const REV_LIST_TIMEOUT_MS = 5_000;
+
+export interface CoreForkStatus {
+  slug: CoreRepoSpec["slug"];
+  displayName: string;
+  branch: string;
+  currentSha: string | null;
+  upstreamSha: string | null;
+  /** Commits present on origin/<branch> but not on upstream/<branch>. */
+  ahead: number;
+  /** Commits on upstream/<branch> not yet pulled into the fork. */
+  behind: number;
+  lastFetchedAt: string;
+  error?: string;
+}
+
+export interface MergeResultOk {
+  ok: true;
+  ff: boolean;
+  agentic: boolean;
+  newSha: string;
+  pushed: boolean;
+}
+
+export interface MergeResultConflict {
+  ok: false;
+  conflict: true;
+  agentic: boolean;
+  /** When true, aion-micro tried and couldn't confidently resolve — user must review. */
+  reviewNeeded?: boolean;
+  files: string[];
+  aionSummary?: string;
+  reason?: string;
+}
+
+export interface MergeResultError {
+  ok: false;
+  conflict: false;
+  reason: string;
+}
+
+export type MergeResult = MergeResultOk | MergeResultConflict | MergeResultError;
+
+function gitSilent(args: string[], cwd: string, timeoutMs = MERGE_TIMEOUT_MS): { ok: boolean; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("git", args, { cwd, stdio: "pipe", timeout: timeoutMs }).toString();
+    return { ok: true, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer };
+    return {
+      ok: false,
+      stdout: e.stdout ? e.stdout.toString() : "",
+      stderr: e.stderr ? e.stderr.toString() : (err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+/**
+ * Fetch `upstream <branch>` and compute ahead/behind relative to HEAD.
+ * `git rev-list --left-right --count A...B` emits `<left>\t<right>`
+ * where left = commits unique to A and right = commits unique to B.
+ * We request `upstream/<branch>...HEAD`, so:
+ *   left  = behind (commits on upstream we don't have)
+ *   right = ahead  (commits on our fork upstream doesn't have)
+ */
+export async function computeForkStatus(
+  targetDir: string,
+  spec: CoreRepoSpec,
+  branch: string,
+): Promise<CoreForkStatus> {
+  const base: CoreForkStatus = {
+    slug: spec.slug,
+    displayName: spec.displayName,
+    branch,
+    currentSha: null,
+    upstreamSha: null,
+    ahead: 0,
+    behind: 0,
+    lastFetchedAt: new Date().toISOString(),
+  };
+
+  if (!existsSync(join(targetDir, ".git"))) {
+    return { ...base, error: `not a git repo: ${targetDir}` };
+  }
+
+  const fetchRes = gitSilent(["fetch", "--no-tags", "upstream", branch], targetDir, FETCH_TIMEOUT_MS);
+  if (!fetchRes.ok) {
+    return { ...base, error: fetchRes.stderr.slice(0, 500) };
+  }
+
+  const headSha = gitSilent(["rev-parse", "HEAD"], targetDir, REV_LIST_TIMEOUT_MS);
+  const upstreamSha = gitSilent(["rev-parse", `upstream/${branch}`], targetDir, REV_LIST_TIMEOUT_MS);
+  const counts = gitSilent(
+    ["rev-list", "--left-right", "--count", `upstream/${branch}...HEAD`],
+    targetDir,
+    REV_LIST_TIMEOUT_MS,
+  );
+
+  if (!counts.ok) {
+    return { ...base, error: counts.stderr.slice(0, 500) };
+  }
+
+  const [behindStr, aheadStr] = counts.stdout.trim().split(/\s+/);
+  return {
+    ...base,
+    currentSha: headSha.ok ? headSha.stdout.trim() : null,
+    upstreamSha: upstreamSha.ok ? upstreamSha.stdout.trim() : null,
+    behind: Number.parseInt(behindStr ?? "0", 10) || 0,
+    ahead: Number.parseInt(aheadStr ?? "0", 10) || 0,
+  };
+}
+
+/**
+ * Aggregate status for every core fork in the workspace. Missing dirs
+ * are reported with an error rather than omitted, so the UI can tell
+ * "fork not provisioned yet" apart from "everything synced".
+ */
+export async function getAllCoreForkStatuses(
+  coreCollectionDir: string,
+  branch: string,
+): Promise<CoreForkStatus[]> {
+  const out: CoreForkStatus[] = [];
+  for (const spec of CORE_REPOS) {
+    const targetDir = join(coreCollectionDir, spec.slug);
+    if (!existsSync(targetDir)) {
+      out.push({
+        slug: spec.slug,
+        displayName: spec.displayName,
+        branch,
+        currentSha: null,
+        upstreamSha: null,
+        ahead: 0,
+        behind: 0,
+        lastFetchedAt: new Date().toISOString(),
+        error: "fork not provisioned — toggle Dev Mode to provision",
+      });
+      continue;
+    }
+    out.push(await computeForkStatus(targetDir, spec, branch));
+  }
+  return out;
+}
+
+/**
+ * Ensure the `upstream` remote points at the canonical Civicognita URL.
+ * Runs as a belt-and-braces step before merge ops so a legacy clone
+ * that never went through the retrofit loop doesn't fail quietly.
+ */
+function ensureUpstreamRemote(targetDir: string, spec: CoreRepoSpec, log: ComponentLogger): void {
+  const expected = upstreamRemoteUrl(spec);
+  const current = gitSilent(["remote", "get-url", "upstream"], targetDir, REV_LIST_TIMEOUT_MS);
+  if (current.ok && current.stdout.trim() === expected) return;
+  if (current.ok) {
+    gitSilent(["remote", "set-url", "upstream", expected], targetDir, REV_LIST_TIMEOUT_MS);
+    log.info(`dev-merge: repointed ${spec.slug} upstream → ${expected}`);
+  } else {
+    gitSilent(["remote", "add", "upstream", expected], targetDir, REV_LIST_TIMEOUT_MS);
+    log.info(`dev-merge: added ${spec.slug} upstream remote`);
+  }
+}
+
+/**
+ * Merge `upstream/<branch>` into the current branch, pushing to origin
+ * on success. Escalation order:
+ *   1. ff-only merge — works when the fork has no divergent commits.
+ *   2. Three-way merge commit — works when no textual conflicts.
+ *   3. Surface conflict files (caller decides: return to user OR escalate
+ *      to aion-micro when `strategy === "agentic"`).
+ */
+export interface AttemptMergeOptions {
+  targetDir: string;
+  spec: CoreRepoSpec;
+  branch: string;
+  strategy: "ff-only" | "agentic";
+  aionMicro?: AionMicroManager;
+  log: ComponentLogger;
+}
+
+export async function attemptMerge(opts: AttemptMergeOptions): Promise<MergeResult> {
+  const { targetDir, spec, branch, strategy, aionMicro, log } = opts;
+
+  if (!existsSync(join(targetDir, ".git"))) {
+    return { ok: false, conflict: false, reason: `not a git repo: ${targetDir}` };
+  }
+
+  ensureUpstreamRemote(targetDir, spec, log);
+
+  // Refuse to operate on a dirty tree — merging on top of uncommitted
+  // work could entangle the user's changes with upstream's. Better to
+  // surface the state and let them commit/stash first.
+  const statusRes = gitSilent(["status", "--porcelain"], targetDir);
+  if (!statusRes.ok) {
+    return { ok: false, conflict: false, reason: statusRes.stderr.slice(0, 300) };
+  }
+  if (statusRes.stdout.trim().length > 0) {
+    return {
+      ok: false,
+      conflict: false,
+      reason: "Working tree has uncommitted changes — commit or stash them before merging upstream.",
+    };
+  }
+
+  const fetchRes = gitSilent(["fetch", "--no-tags", "upstream", branch], targetDir, FETCH_TIMEOUT_MS);
+  if (!fetchRes.ok) {
+    return { ok: false, conflict: false, reason: `fetch failed: ${fetchRes.stderr.slice(0, 300)}` };
+  }
+
+  // Step 1 — ff-only.
+  const ffRes = gitSilent(
+    ["merge", "--ff-only", `upstream/${branch}`],
+    targetDir,
+    MERGE_TIMEOUT_MS,
+  );
+  if (ffRes.ok) {
+    const newSha = gitSilent(["rev-parse", "HEAD"], targetDir, REV_LIST_TIMEOUT_MS);
+    const pushed = pushToOrigin(targetDir, branch, log);
+    log.info(`dev-merge: ff-merged ${spec.slug} → ${newSha.stdout.trim().slice(0, 7)}`);
+    return { ok: true, ff: true, agentic: false, newSha: newSha.stdout.trim(), pushed };
+  }
+
+  // Step 2 — non-ff merge commit.
+  const mergeRes = gitSilent(
+    ["merge", "--no-ff", "--no-commit", `upstream/${branch}`],
+    targetDir,
+    MERGE_TIMEOUT_MS,
+  );
+  const conflictFiles = listConflictFiles(targetDir);
+
+  if (conflictFiles.length === 0 && mergeRes.ok) {
+    gitSilent(
+      ["commit", "-m", `Merge upstream/${branch} into ${branch}`],
+      targetDir,
+      MERGE_TIMEOUT_MS,
+    );
+    const newSha = gitSilent(["rev-parse", "HEAD"], targetDir, REV_LIST_TIMEOUT_MS);
+    const pushed = pushToOrigin(targetDir, branch, log);
+    log.info(`dev-merge: merge-commit ${spec.slug} → ${newSha.stdout.trim().slice(0, 7)}`);
+    return { ok: true, ff: false, agentic: false, newSha: newSha.stdout.trim(), pushed };
+  }
+
+  // Step 3 — conflicts. Aion-micro only engages when asked.
+  if (strategy !== "agentic" || !aionMicro) {
+    gitSilent(["merge", "--abort"], targetDir, MERGE_TIMEOUT_MS);
+    return { ok: false, conflict: true, agentic: false, files: conflictFiles };
+  }
+
+  const agenticResult = await resolveConflictsWithAion(targetDir, conflictFiles, aionMicro, log);
+  if (!agenticResult.ok) {
+    gitSilent(["merge", "--abort"], targetDir, MERGE_TIMEOUT_MS);
+    return {
+      ok: false,
+      conflict: true,
+      agentic: true,
+      reviewNeeded: true,
+      files: conflictFiles,
+      aionSummary: agenticResult.summary,
+      reason: agenticResult.reason,
+    };
+  }
+
+  // All conflicts resolved with high confidence — commit + push.
+  gitSilent(["add", ...conflictFiles], targetDir, MERGE_TIMEOUT_MS);
+  gitSilent(
+    ["commit", "-m", `Merge upstream/${branch} (aion-micro resolved)`],
+    targetDir,
+    MERGE_TIMEOUT_MS,
+  );
+  const newSha = gitSilent(["rev-parse", "HEAD"], targetDir, REV_LIST_TIMEOUT_MS);
+  const pushed = pushToOrigin(targetDir, branch, log);
+  log.info(`dev-merge: agentic-merge ${spec.slug} → ${newSha.stdout.trim().slice(0, 7)}`);
+  return { ok: true, ff: false, agentic: true, newSha: newSha.stdout.trim(), pushed };
+}
+
+function listConflictFiles(targetDir: string): string[] {
+  const res = gitSilent(["diff", "--name-only", "--diff-filter=U"], targetDir, REV_LIST_TIMEOUT_MS);
+  if (!res.ok) return [];
+  return res.stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function pushToOrigin(targetDir: string, branch: string, log: ComponentLogger): boolean {
+  const res = gitSilent(["push", "origin", branch], targetDir, PUSH_TIMEOUT_MS);
+  if (!res.ok) {
+    log.warn(`dev-merge: push to origin/${branch} failed: ${res.stderr.slice(0, 200)}`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Delegate per-file conflict resolution to aion-micro. The caller
+ * already attempted a 3-way merge and left the conflict markers in
+ * the working tree, so we read each file as-is and ask aion-micro for
+ * a full resolved version. Only commits if EVERY file comes back with
+ * `confidence === "high"` and no unresolved hunks.
+ */
+interface ResolveOutcome {
+  ok: boolean;
+  reason?: string;
+  summary?: string;
+}
+
+async function resolveConflictsWithAion(
+  targetDir: string,
+  conflictFiles: string[],
+  aionMicro: AionMicroManager,
+  log: ComponentLogger,
+): Promise<ResolveOutcome> {
+  const available = await aionMicro.ensureAvailable();
+  if (!available) {
+    return { ok: false, reason: "aion-micro unavailable — enable the aion-micro container or resolve manually" };
+  }
+
+  const summaries: string[] = [];
+  for (const relPath of conflictFiles) {
+    const absPath = join(targetDir, relPath);
+    let conflictText: string;
+    try {
+      conflictText = readFileSync(absPath, "utf8");
+    } catch (err) {
+      return { ok: false, reason: `cannot read ${relPath}: ${err instanceof Error ? err.message : String(err)}` };
+    }
+
+    const result = await aionMicro.resolveMergeConflict(relPath, "fork", "upstream", conflictText);
+    if (!result) {
+      return { ok: false, reason: `aion-micro did not respond for ${relPath}` };
+    }
+    if (result.confidence !== "high" || result.unresolvedHunks.length > 0) {
+      summaries.push(
+        `${relPath}: confidence=${result.confidence}` +
+          (result.unresolvedHunks.length > 0 ? `, unresolved=${String(result.unresolvedHunks.length)}` : ""),
+      );
+      return {
+        ok: false,
+        reason: `low-confidence resolution for ${relPath}`,
+        summary: summaries.join("; "),
+      };
+    }
+
+    try {
+      writeFileSync(absPath, result.resolvedText, "utf8");
+    } catch (err) {
+      return { ok: false, reason: `cannot write resolved ${relPath}: ${err instanceof Error ? err.message : String(err)}` };
+    }
+    summaries.push(`${relPath}: resolved`);
+    log.info(`dev-merge: aion-micro resolved ${relPath}`);
+  }
+
+  return { ok: true, summary: summaries.join("; ") };
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -246,6 +246,8 @@ export interface RuntimeStateDeps {
   webhookSecret?: string;
   /** PrimeLoader instance — enables GET /api/prime/status + POST /api/prime/switch. */
   primeLoader?: import("./prime-loader.js").PrimeLoader;
+  /** AionMicroManager — enables agentic merge conflict resolution for core forks. */
+  aionMicro?: import("./aion-micro-manager.js").AionMicroManager;
   /** Resolved prime directory path. */
   primeDir?: string;
   /** Resolved bots directory path. */
@@ -975,14 +977,14 @@ export async function createGatewayRuntimeState(
       return reply.code(403).send({ error: "Projects API only allowed from private network" });
     }
     const projectDirs = deps.workspaceProjects ?? [];
-    const projects: { name: string; path: string; hasGit: boolean; tynnToken: string | null; hosting: unknown; detectedHosting?: { projectType: string; suggestedStacks: string[]; docRoot: string; startCommand: string | null }; projectType?: { id: string; label: string; category: string; hostable: boolean; hasCode: boolean; tools: { id: string; label: string; description: string; action: string; command?: string; endpoint?: string }[] }; category?: string; description?: string; magicApps?: string[]; coreCollection?: string }[] = [];
+    const projects: { name: string; path: string; hasGit: boolean; tynnToken: string | null; hosting: unknown; detectedHosting?: { projectType: string; suggestedStacks: string[]; docRoot: string; startCommand: string | null }; projectType?: { id: string; label: string; category: string; hostable: boolean; hasCode: boolean; tools: { id: string; label: string; description: string; action: string; command?: string; endpoint?: string }[] }; category?: string; description?: string; magicApps?: string[]; coreCollection?: string; coreForkSlug?: string }[] = [];
 
-    // Expand top-level entries into (fullPath, coreCollection) pairs.
+    // Expand top-level entries into (fullPath, coreCollection, coreForkSlug) triples.
     // A directory that contains a `collection.json` with
     // `type: "aionima-collection"` is treated as a group — we skip the
     // parent and list its children as projects, each flagged with the
     // collection slug so the dashboard can render them as "core".
-    const expanded: Array<{ fullPath: string; name: string; coreCollection?: string }> = [];
+    const expanded: Array<{ fullPath: string; name: string; coreCollection?: string; coreForkSlug?: string }> = [];
     for (const dir of projectDirs) {
       try {
         const entries = readdirSync(dir, { withFileTypes: true });
@@ -1004,6 +1006,7 @@ export async function createGatewayRuntimeState(
                     fullPath: resolvePath(fullPath, ce.name),
                     name: ce.name,
                     coreCollection: "aionima",
+                    coreForkSlug: ce.name,
                   });
                 }
                 continue;
@@ -1020,7 +1023,7 @@ export async function createGatewayRuntimeState(
       } catch { /* directory may not exist */ }
     }
 
-    for (const { fullPath, name: entryName, coreCollection } of expanded) {
+    for (const { fullPath, name: entryName, coreCollection, coreForkSlug } of expanded) {
       try {
         const hasGit = existsSync(join(fullPath, ".git"));
         let tynnToken: string | null = null;
@@ -1062,6 +1065,7 @@ export async function createGatewayRuntimeState(
           description: metaDescription,
           magicApps: metaMagicApps,
           coreCollection,
+          coreForkSlug,
         });
       } catch { /* directory may not exist */ }
     }
@@ -1932,6 +1936,135 @@ export async function createGatewayRuntimeState(
     });
 
     // -----------------------------------------------------------------------
+    // GET /api/dev/core-forks/status — ahead/behind per core fork (tynn #276)
+    // -----------------------------------------------------------------------
+    //
+    // Surfaces each of the five `_aionima/<slug>/` clones with its
+    // ahead/behind count vs `upstream/<branch>`. Branch defaults to
+    // `gateway.updateChannel` — whatever release channel the owner's
+    // gateway subscribes to. Fetch is bounded per-repo so one slow
+    // network link can't stall the whole listing.
+
+    fastify.get("/api/dev/core-forks/status", async (request, reply) => {
+      const clientIp = getClientIp(request.raw);
+      if (!isPrivateNetwork(clientIp)) {
+        return reply.code(403).send({ error: "Dev API only allowed from private network" });
+      }
+      if (dashboardUserStore) {
+        const session = extractDashboardSession(request.raw, dashboardUserStore);
+        if (!session || !hasRole(session.role, "admin")) {
+          return reply.code(403).send({ error: "Admin role required" });
+        }
+      }
+
+      const projectsRoot = (deps.workspaceProjects ?? [])[0];
+      if (!projectsRoot) {
+        return reply.send({ forks: [], error: "no workspace projects dir configured" });
+      }
+      const coreCollectionDir = join(projectsRoot, "_aionima");
+      if (!existsSync(coreCollectionDir)) {
+        return reply.send({ forks: [], error: "core-fork collection not provisioned — enable Dev Mode" });
+      }
+
+      let branch = "main";
+      if (deps.configPath !== undefined) {
+        try {
+          const cfg = JSON.parse(readFileSync(deps.configPath, "utf-8")) as {
+            gateway?: { updateChannel?: string };
+          };
+          if (typeof cfg.gateway?.updateChannel === "string" && cfg.gateway.updateChannel.length > 0) {
+            branch = cfg.gateway.updateChannel;
+          }
+        } catch { /* fall back to main */ }
+      }
+
+      const { getAllCoreForkStatuses } = await import("./dev-mode-merge.js");
+      const forks = await getAllCoreForkStatuses(coreCollectionDir, branch);
+      return reply.send({ forks, branch });
+    });
+
+    // -----------------------------------------------------------------------
+    // POST /api/dev/core-forks/:slug/merge — merge upstream into owner fork
+    // -----------------------------------------------------------------------
+    //
+    // Body `{ strategy?: "ff-only" | "agentic" }`, default `"ff-only"`.
+    // Attempts ff → merge-commit → (if strategy === "agentic") aion-micro
+    // assisted resolution. Successful merges get pushed to origin so the
+    // next `agi upgrade` picks them up; failures return a structured
+    // conflict response that the dashboard can render.
+
+    fastify.post("/api/dev/core-forks/:slug/merge", async (request, reply) => {
+      const clientIp = getClientIp(request.raw);
+      if (!isPrivateNetwork(clientIp)) {
+        return reply.code(403).send({ error: "Dev API only allowed from private network" });
+      }
+      if (dashboardUserStore) {
+        const session = extractDashboardSession(request.raw, dashboardUserStore);
+        if (!session || !hasRole(session.role, "admin")) {
+          return reply.code(403).send({ error: "Admin role required" });
+        }
+      }
+
+      const { slug } = request.params as { slug: string };
+      const { CORE_REPOS: CORE_REPO_SPECS } = await import("./dev-mode-forks.js");
+      const spec = CORE_REPO_SPECS.find((s) => s.slug === slug);
+      if (!spec) {
+        return reply.code(404).send({ error: `unknown core fork: ${slug}` });
+      }
+
+      const projectsRoot = (deps.workspaceProjects ?? [])[0];
+      if (!projectsRoot) {
+        return reply.code(500).send({ error: "no workspace projects dir configured" });
+      }
+      const targetDir = join(projectsRoot, "_aionima", spec.slug);
+      if (!existsSync(targetDir)) {
+        return reply.code(404).send({ error: `fork not provisioned — toggle Dev Mode to provision ${slug}` });
+      }
+
+      let branch = "main";
+      if (deps.configPath !== undefined) {
+        try {
+          const cfg = JSON.parse(readFileSync(deps.configPath, "utf-8")) as {
+            gateway?: { updateChannel?: string };
+          };
+          if (typeof cfg.gateway?.updateChannel === "string" && cfg.gateway.updateChannel.length > 0) {
+            branch = cfg.gateway.updateChannel;
+          }
+        } catch { /* fall back to main */ }
+      }
+
+      const body = (request.body as { strategy?: string } | undefined) ?? {};
+      const strategy: "ff-only" | "agentic" = body.strategy === "agentic" ? "agentic" : "ff-only";
+
+      const { attemptMerge } = await import("./dev-mode-merge.js");
+      const mergeLog = createComponentLogger(deps.logger ?? undefined, "dev-merge");
+      const result = await attemptMerge({
+        targetDir,
+        spec,
+        branch,
+        strategy,
+        aionMicro: strategy === "agentic" ? deps.aionMicro : undefined,
+        log: mergeLog,
+      });
+
+      // Notify the dashboard to re-poll status after a successful merge.
+      if (result.ok) {
+        try {
+          deps.wsRef?.server?.broadcast("dashboard_event", {
+            type: "dev:core-fork-updated" as const,
+            data: {
+              slug: spec.slug,
+              newSha: result.newSha,
+              agentic: result.agentic,
+            },
+          });
+        } catch { /* best-effort */ }
+      }
+
+      return reply.send(result);
+    });
+
+    // -----------------------------------------------------------------------
     // POST /api/dev/switch — toggle dev mode (private network only)
     // -----------------------------------------------------------------------
 
@@ -2061,13 +2194,13 @@ export async function createGatewayRuntimeState(
                 devCfg = (cfgRaw.dev as Record<string, unknown>) ?? {};
               } catch { /* use empty defaults */ }
             }
-            const CORE_REPOS: Array<{ slug: string; name: string; repoKey: string }> = [
-              { slug: "agi", name: "AGI", repoKey: "agiRepo" },
-              { slug: "prime", name: "PRIME", repoKey: "primeRepo" },
-              { slug: "id", name: "ID", repoKey: "idRepo" },
-              { slug: "marketplace", name: "Marketplace", repoKey: "marketplaceRepo" },
-              { slug: "mapp-marketplace", name: "MApp Marketplace", repoKey: "mappMarketplaceRepo" },
-            ];
+            const { CORE_REPOS: CORE_REPO_SPECS, upstreamRemoteUrl: upstreamRemoteUrlFn } = await import("./dev-mode-forks.js");
+            const CORE_REPOS: Array<{ slug: string; name: string; repoKey: string; upstreamUrl: string }> = CORE_REPO_SPECS.map((s) => ({
+              slug: s.slug,
+              name: s.displayName,
+              repoKey: s.configKey,
+              upstreamUrl: upstreamRemoteUrlFn(s),
+            }));
 
             // Fetch the owner's GitHub token once for all clones — Dev Mode
             // forks live under wishborn/*, which may be private. HTTPS with
@@ -2132,6 +2265,23 @@ export async function createGatewayRuntimeState(
                   } catch {
                     /* non-fatal — clone succeeded, token stays in origin */
                   }
+                  // Configure `upstream` remote so the Repository tab can
+                  // compare the fork against the canonical Civicognita repo.
+                  // Without this, `git rev-list upstream/<branch>...HEAD`
+                  // fails and the dashboard has no way to show ahead/behind
+                  // against the release channel.
+                  try {
+                    execFileSync("git", ["remote", "add", "upstream", repo.upstreamUrl], {
+                      cwd: targetDir, stdio: "pipe",
+                    });
+                  } catch {
+                    /* already configured — overwrite below */
+                    try {
+                      execFileSync("git", ["remote", "set-url", "upstream", repo.upstreamUrl], {
+                        cwd: targetDir, stdio: "pipe",
+                      });
+                    } catch { /* ignore */ }
+                  }
                 }
                 // Migrate legacy clones that still have a token-bearing origin
                 // (produced by earlier versions of Dev Mode). Safe no-op if
@@ -2147,6 +2297,30 @@ export async function createGatewayRuntimeState(
                     log.info(`dev: scrubbed token from ${repo.slug} origin URL`);
                   }
                 } catch { /* ignore */ }
+                // Retrofit `upstream` remote on clones made before this
+                // commit. Newer clones set it inside the if-not-exists
+                // block above; pre-existing clones (the five that landed
+                // in earlier v0.4.x iterations) reach this code path
+                // instead and get the remote added on the next toggle.
+                try {
+                  let hasUpstream = false;
+                  try {
+                    execFileSync("git", ["remote", "get-url", "upstream"], {
+                      cwd: targetDir, stdio: "pipe",
+                    });
+                    hasUpstream = true;
+                  } catch { /* missing — add below */ }
+                  if (hasUpstream) {
+                    execFileSync("git", ["remote", "set-url", "upstream", repo.upstreamUrl], {
+                      cwd: targetDir, stdio: "pipe",
+                    });
+                  } else {
+                    execFileSync("git", ["remote", "add", "upstream", repo.upstreamUrl], {
+                      cwd: targetDir, stdio: "pipe",
+                    });
+                    log.info(`dev: added upstream remote for ${repo.slug}`);
+                  }
+                } catch { /* non-fatal — merge UI will surface the error */ }
                 // Write/update project.json with aionima type
                 const metaPath = projectConfigPath(targetDir);
                 mkdirSync(dirname(metaPath), { recursive: true });
@@ -2197,7 +2371,7 @@ export async function createGatewayRuntimeState(
               reason: "passwordless sudo required for dnsmasq / Caddy setup — grant NOPASSWD in /etc/sudoers.d/ to enable test VM provisioning",
             });
           } else try {
-            const vmIpRaw = execSync("multipass info aionima-test --format csv 2>/dev/null", { encoding: "utf-8", stdio: "pipe", timeout: 5000 });
+            const vmIpRaw = execSync("multipass info agi-test --format csv 2>/dev/null", { encoding: "utf-8", stdio: "pipe", timeout: 5000 });
             const vmIpLine = vmIpRaw.trim().split("\n").pop() ?? "";
             const vmIp = vmIpLine.split(",")[2]?.trim();
             if (vmIp && vmIp.length > 0) {
@@ -2208,10 +2382,10 @@ export async function createGatewayRuntimeState(
 
               // Update VM Caddy — add test.ai.on site
               const caddySnippet = `\\ntest.ai.on {\\n  tls internal\\n  reverse_proxy localhost:3100\\n}`;
-              execSync(`multipass exec aionima-test -- sudo bash -c "grep -q 'test.ai.on' /etc/caddy/Caddyfile || echo -e '${caddySnippet}' >> /etc/caddy/Caddyfile && sudo systemctl restart caddy"`, { stdio: "pipe", timeout: 15000 });
+              execSync(`multipass exec agi-test -- sudo bash -c "grep -q 'test.ai.on' /etc/caddy/Caddyfile || echo -e '${caddySnippet}' >> /etc/caddy/Caddyfile && sudo systemctl restart caddy"`, { stdio: "pipe", timeout: 15000 });
 
               // Update VM /etc/hosts
-              execSync(`multipass exec aionima-test -- sudo bash -c "grep -q 'test.ai.on' /etc/hosts || sudo sed -i 's/ai.on/ai.on test.ai.on/' /etc/hosts"`, { stdio: "pipe", timeout: 5000 });
+              execSync(`multipass exec agi-test -- sudo bash -c "grep -q 'test.ai.on' /etc/hosts || sudo sed -i 's/ai.on/ai.on test.ai.on/' /etc/hosts"`, { stdio: "pipe", timeout: 5000 });
 
               log.info("dev: test.ai.on provisioned (VM IP: " + vmIp + ")");
             }

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -1995,6 +1995,7 @@ export async function startGatewayServer(
       pluginPrefs,
       primeLoader,
       primeDir,
+      aionMicro: aionMicroManager,
       botsDir: undefined, // Workers are file-driven prompts
       marketplaceManager,
       onPluginInstalled: async (installPath: string) => {

--- a/scripts/test-vm-run.sh
+++ b/scripts/test-vm-run.sh
@@ -14,7 +14,7 @@ E2E_SCRIPT="$SCRIPT_DIR/test-e2e-vm.sh"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FIXTURE_CONFIG="$REPO_DIR/test/fixtures/gateway-test.json"
 
-VM_NAME="aionima-test"
+VM_NAME="agi-test"
 
 # ---------------------------------------------------------------------------
 # Preflight: ensure VM is created, running, and set up

--- a/scripts/test-vm.sh
+++ b/scripts/test-vm.sh
@@ -35,9 +35,26 @@ VM_DISK="${VM_DISK:-20G}"
 # Structured JSON emitter for gateway streaming
 emit_json() { echo "{\"phase\":\"$1\",\"status\":\"$2\",\"details\":\"${3:-}\"}"; }
 
-# Detect paths: AGI repo dir and workspace root (parent of agi/)
-REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-WORKSPACE_DIR="$(cd "$REPO_DIR/.." && pwd)"
+# Detect paths: AGI repo dir and workspace root (parent of agi/).
+# Use `-P` so symlinks get resolved — if this script is invoked via a
+# symlinked path (e.g. a user-workspace convenience link like
+# ~/temp_core/agi → ~/_projects/_aionima/agi), we still want the VM
+# mounts anchored at the *physical* Dev-Mode workspace, NOT the user's
+# scratchpad. temp_core is the user's workspace, not AGI's.
+REPO_DIR="$(cd -P "$(dirname "$0")/.." && pwd)"
+WORKSPACE_DIR="$(cd -P "$REPO_DIR/.." && pwd)"
+
+# Sibling layout detection: Dev-Mode provisioned workspace uses slugs
+# (prime, id, marketplace, mapp-marketplace) under `_aionima/`. Ops /
+# vanilla installs use the legacy dashed names (agi-prime, agi-local-id)
+# under /opt. Pick the right set for mount sources.
+if [ "$(basename "$WORKSPACE_DIR")" = "_aionima" ]; then
+  PRIME_PATH="$WORKSPACE_DIR/prime"
+  ID_PATH="$WORKSPACE_DIR/id"
+else
+  PRIME_PATH="$WORKSPACE_DIR/agi-prime"
+  ID_PATH="$WORKSPACE_DIR/agi-local-id"
+fi
 
 # Cloud-init: install Node 22, pnpm, and build deps so the VM is ready faster
 CLOUD_INIT=$(cat <<'YAML'
@@ -143,8 +160,8 @@ cmd_create() {
 
   echo "==> Mounting workspace repos..."
   mount_repo "$REPO_DIR"                          "/mnt/agi"                 "AGI"
-  mount_repo "$WORKSPACE_DIR/aionima-prime"        "/mnt/agi-prime"           "PRIME"
-  mount_repo "$WORKSPACE_DIR/agi-local-id"         "/mnt/agi-local-id"        "ID"
+  mount_repo "$PRIME_PATH"                        "/mnt/agi-prime"           "PRIME"
+  mount_repo "$ID_PATH"                           "/mnt/agi-local-id"        "ID"
 
   echo "==> Waiting for cloud-init to finish..."
   multipass exec "$VM_NAME" -- cloud-init status --wait 2>/dev/null || true
@@ -243,8 +260,8 @@ cmd_remount() {
   multipass umount "$VM_NAME":/mnt/agi-local-id 2>/dev/null || true
 
   mount_repo "$REPO_DIR"                          "/mnt/agi"                 "AGI"
-  mount_repo "$WORKSPACE_DIR/aionima-prime"        "/mnt/agi-prime"           "PRIME"
-  mount_repo "$WORKSPACE_DIR/agi-local-id"         "/mnt/agi-local-id"        "ID"
+  mount_repo "$PRIME_PATH"                        "/mnt/agi-prime"           "PRIME"
+  mount_repo "$ID_PATH"                           "/mnt/agi-local-id"        "ID"
 
   echo "Done."
 }

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -28,9 +28,19 @@ _DEV_CFG="$(node -e "
 " 2>/dev/null || echo '{"enabled":false,"agi":"","prime":"","id":""}')"
 
 _dev_enabled="$(echo "$_DEV_CFG" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).enabled))")"
+_dev_agi="$(echo "$_DEV_CFG" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).agi))")"
 _dev_prime="$(echo "$_DEV_CFG" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).prime))")"
 _dev_id="$(echo "$_DEV_CFG" | node -e "process.stdin.on('data',d=>console.log(JSON.parse(d).id))")"
 
+# AGI self-repo: Dev Mode needs this too. Without it, /opt/agi's origin
+# stays pinned to Civicognita, so owner commits pushed to wishborn/agi
+# never reach the production gateway until they land upstream. This
+# defeats the entire Dev Mode "work in fork → see it live" promise.
+if [ "$_dev_enabled" = "true" ] && [ -n "$_dev_agi" ]; then
+  AGI_REPO="${AIONIMA_AGI_REPO:-$_dev_agi}"
+else
+  AGI_REPO="${AIONIMA_AGI_REPO:-https://github.com/Civicognita/agi.git}"
+fi
 if [ "$_dev_enabled" = "true" ] && [ -n "$_dev_prime" ]; then
   PRIME_REPO="${AIONIMA_PRIME_REPO:-$_dev_prime}"
 else
@@ -200,6 +210,27 @@ ensure_https_remote() {
 ensure_https_remote "$DEPLOY_DIR"
 ensure_https_remote "$PRIME_DIR"
 ensure_https_remote "$ID_DIR"
+
+# Repoint `origin` to the right upstream when Dev Mode toggles. Idempotent:
+# if the existing origin matches, this is a no-op. If it doesn't (Dev Mode
+# just flipped, or the env override changed), we rewrite it so the next
+# `git fetch origin` pulls from the intended source. Mirrors what
+# `/api/dev/switch` already does for the `_aionima/<slug>/` core-fork
+# workspace clones — the same treatment was missing here for /opt/agi.
+ensure_origin_remote() {
+  local dir="$1" expected="$2" label="$3"
+  [ -d "$dir/.git" ] || return
+  [ -n "$expected" ] || return
+  local current
+  current="$(git -C "$dir" remote get-url origin 2>/dev/null)" || return
+  if [ "$current" != "$expected" ]; then
+    git -C "$dir" remote set-url origin "$expected" 2>/dev/null && \
+      emit "$label" "info" "origin repointed: $expected"
+  fi
+}
+ensure_origin_remote "$DEPLOY_DIR" "$AGI_REPO"   "origin-agi"
+ensure_origin_remote "$PRIME_DIR"  "$PRIME_REPO" "origin-prime"
+ensure_origin_remote "$ID_DIR"     "$ID_REPO"    "origin-id"
 
 # ---------------------------------------------------------------------------
 # Snapshot versions BEFORE pull (must happen before git checkout changes package.json)

--- a/ui/dashboard/src/components/CoreForkRepoPanel.tsx
+++ b/ui/dashboard/src/components/CoreForkRepoPanel.tsx
@@ -1,0 +1,259 @@
+/**
+ * CoreForkRepoPanel — specialized Repository tab for Dev-Mode core forks.
+ *
+ * Replaces the generic RepoPanel for projects under the `_aionima/`
+ * collection. Three purposes:
+ *   1. Show ahead/behind vs `upstream/<channel>` (Civicognita).
+ *   2. One-shot "Merge upstream → origin" action with ff → merge-commit
+ *      → aion-micro agentic fallback.
+ *   3. "Open PR to upstream" jump-link to the GitHub compare page.
+ *
+ * Everything happens through `/api/dev/core-forks/*` — the generic
+ * `/api/projects/git` endpoint is not used here.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useCoreForkStatus } from "../hooks.js";
+import { fetchDevStatus } from "../api.js";
+import type { CoreForkMergeResult, CoreForkStatus, DevStatus } from "../types.js";
+
+export interface CoreForkRepoPanelProps {
+  slug: string;
+}
+
+// Slug → upstream Civicognita repo name. Mirrors CORE_REPOS in
+// `packages/gateway-core/src/dev-mode-forks.ts` — we keep a small
+// client-side copy so the PR button can construct the compare URL
+// without an extra round-trip.
+const UPSTREAM_REPO_BY_SLUG: Record<string, string> = {
+  "agi": "agi",
+  "prime": "aionima",
+  "id": "agi-local-id",
+  "marketplace": "agi-marketplace",
+  "mapp-marketplace": "agi-mapp-marketplace",
+};
+
+function shortSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : "—";
+}
+
+export function CoreForkRepoPanel({ slug }: CoreForkRepoPanelProps) {
+  const { data, isLoading, refetch } = useCoreForkStatus();
+  const [devStatus, setDevStatus] = useState<DevStatus | null>(null);
+  const [merging, setMerging] = useState(false);
+  const [mergeResult, setMergeResult] = useState<CoreForkMergeResult | null>(null);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [aionBusy, setAionBusy] = useState(false);
+
+  useEffect(() => {
+    fetchDevStatus().then(setDevStatus).catch(() => setDevStatus(null));
+  }, []);
+
+  const fork: CoreForkStatus | undefined = data?.forks.find((f) => f.slug === slug);
+  const branch = fork?.branch ?? data?.branch ?? "main";
+  const upstreamRepo = UPSTREAM_REPO_BY_SLUG[slug];
+  const ownerLogin = devStatus?.githubAccount ?? null;
+
+  const handleMerge = useCallback(async (strategy: "ff-only" | "agentic") => {
+    if (merging) return;
+    setMerging(true);
+    setMergeError(null);
+    if (strategy === "agentic") setAionBusy(true);
+    try {
+      const res = await fetch(`/api/dev/core-forks/${encodeURIComponent(slug)}/merge`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ strategy }),
+      });
+      const body = (await res.json()) as CoreForkMergeResult;
+      setMergeResult(body);
+      if (body.ok) {
+        // Refresh status — the WS event should also trigger this, but a
+        // direct refetch keeps the UI responsive on local dev setups.
+        await refetch();
+      }
+    } catch (err) {
+      setMergeError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setMerging(false);
+      setAionBusy(false);
+    }
+  }, [merging, slug, refetch]);
+
+  const handleOpenPR = useCallback(() => {
+    if (!upstreamRepo || !ownerLogin || !branch) return;
+    const url = `https://github.com/Civicognita/${upstreamRepo}/compare/${branch}...${ownerLogin}:${branch}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [upstreamRepo, ownerLogin, branch]);
+
+  if (isLoading) {
+    return (
+      <div className="p-4 text-[13px] text-muted-foreground">
+        Loading fork status…
+      </div>
+    );
+  }
+
+  if (!fork) {
+    return (
+      <div className="p-4 text-[13px] text-muted-foreground">
+        This fork isn't in the Dev-Mode collection yet — toggle Dev Mode in Settings to provision it.
+      </div>
+    );
+  }
+
+  if (fork.error) {
+    return (
+      <div className="p-4 rounded-lg border border-red/40 bg-red/10 text-[13px] text-red">
+        <div className="font-semibold mb-1">{fork.displayName}</div>
+        <div className="text-[12px] opacity-80">{fork.error}</div>
+      </div>
+    );
+  }
+
+  const behind = fork.behind;
+  const ahead = fork.ahead;
+  const canMerge = behind > 0 && !merging;
+  const showConflictPanel = mergeResult !== null && mergeResult.ok === false && mergeResult.conflict;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header row: branch + SHAs + badges */}
+      <div className="flex flex-wrap items-center gap-3 p-3 rounded-lg border border-border bg-mantle">
+        <div className="flex flex-col gap-0.5">
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Branch</div>
+          <div className="font-mono text-[13px]">{fork.branch}</div>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Fork HEAD</div>
+          <div className="font-mono text-[13px]">{shortSha(fork.currentSha)}</div>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">Upstream HEAD</div>
+          <div className="font-mono text-[13px]">{shortSha(fork.upstreamSha)}</div>
+        </div>
+        <div className="flex-1" />
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "text-[12px] font-semibold px-2 py-0.5 rounded-full",
+              ahead > 0 ? "bg-green/20 text-green" : "text-muted-foreground",
+            )}
+          >
+            ↑ {ahead} ahead
+          </span>
+          <span
+            className={cn(
+              "text-[12px] font-semibold px-2 py-0.5 rounded-full",
+              behind > 0 ? "bg-peach/20 text-peach" : "text-muted-foreground",
+            )}
+          >
+            ↓ {behind} behind
+          </span>
+        </div>
+      </div>
+
+      {/* Action row */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          onClick={() => { void handleMerge("ff-only"); }}
+          disabled={!canMerge}
+          title={canMerge ? "Merge upstream commits into your fork" : "Fork is up to date with upstream"}
+        >
+          {merging ? "Merging…" : behind > 0 ? `Merge upstream → origin (${behind})` : "Up to date"}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleOpenPR}
+          disabled={!upstreamRepo || !ownerLogin}
+          title={
+            !ownerLogin
+              ? "Connect GitHub in Settings → Contributing first"
+              : `Open PR from ${ownerLogin}/${upstreamRepo} → Civicognita/${upstreamRepo}`
+          }
+        >
+          Open PR to upstream
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => { void refetch(); }}
+          disabled={merging}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {/* Merge result feedback */}
+      {mergeError && (
+        <div className="p-3 rounded-lg border border-red/40 bg-red/10 text-[12px] text-red">
+          {mergeError}
+        </div>
+      )}
+
+      {mergeResult?.ok && (
+        <div className="p-3 rounded-lg border border-green/40 bg-green/10 text-[13px] text-green">
+          {mergeResult.agentic
+            ? `Aion-Micro resolved conflicts and merged upstream at ${shortSha(mergeResult.newSha)}.`
+            : mergeResult.ff
+              ? `Fast-forwarded to upstream at ${shortSha(mergeResult.newSha)}.`
+              : `Merged upstream with a merge commit at ${shortSha(mergeResult.newSha)}.`}
+          {!mergeResult.pushed && (
+            <div className="text-[11px] opacity-80 mt-1">
+              Local merge succeeded but push to origin failed — run <code>git push</code> manually.
+            </div>
+          )}
+        </div>
+      )}
+
+      {mergeResult?.ok === false && !mergeResult.conflict && (
+        <div className="p-3 rounded-lg border border-peach/40 bg-peach/10 text-[12px] text-peach">
+          {mergeResult.reason}
+        </div>
+      )}
+
+      {showConflictPanel && mergeResult?.ok === false && mergeResult.conflict && (
+        <div className="p-3 rounded-lg border border-peach/40 bg-peach/10 text-[12px]">
+          <div className="font-semibold text-peach mb-1">
+            {mergeResult.agentic && mergeResult.reviewNeeded
+              ? "Aion-Micro couldn't confidently resolve this merge"
+              : "Merge conflict"}
+          </div>
+          <div className="opacity-90 mb-2">
+            {mergeResult.files.length > 0
+              ? `Conflicting files: ${mergeResult.files.join(", ")}`
+              : "No files reported."}
+          </div>
+          {mergeResult.aionSummary && (
+            <div className="opacity-80 font-mono text-[11px] mb-2 whitespace-pre-wrap">
+              {mergeResult.aionSummary}
+            </div>
+          )}
+          {!mergeResult.agentic && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => { void handleMerge("agentic"); }}
+              disabled={aionBusy}
+            >
+              {aionBusy ? "Aion-Micro thinking…" : "Let Aion-Micro try"}
+            </Button>
+          )}
+          {mergeResult.agentic && mergeResult.reviewNeeded && (
+            <div className="opacity-80 text-[11px]">
+              Open the Editor tab to resolve the conflicts manually — the file contents are in the working tree with conflict markers preserved.
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="text-[11px] text-muted-foreground mt-1">
+        Last checked {fork.lastFetchedAt ? new Date(fork.lastFetchedAt).toLocaleTimeString() : "—"}
+      </div>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/OverviewCards.tsx
+++ b/ui/dashboard/src/components/OverviewCards.tsx
@@ -39,7 +39,7 @@ export function OverviewCards({ data }: OverviewCardsProps) {
     },
     {
       label: "Activity",
-      value: String(data.recentActivity.length),
+      value: String(Array.isArray(data.recentActivity) ? data.recentActivity.length : 0),
       sub: "Recent events tracked",
       accent: "border-l-red",
     },

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -14,6 +14,7 @@ import { execGitAction, fetchProjectFileTree, fetchProjectFile, saveProjectFile,
 import type { FileNode } from "../api.js";
 import type { PluginAction, PluginPanel, ProjectActivity, ProjectInfo } from "../types.js";
 import { RepoPanel } from "./RepoPanel.js";
+import { CoreForkRepoPanel } from "./CoreForkRepoPanel.js";
 import { HostingPanel } from "./HostingPanel.js";
 import { EnvManager } from "./EnvManager.js";
 import { TaskmasterTab } from "./TaskmasterTab.js";
@@ -655,7 +656,9 @@ export function ProjectDetail({
 
         <TabsContent value="repository" className="mt-4 flex-1 min-h-0 overflow-y-auto">
           <div className="rounded-xl bg-card border border-border p-4">
-            {project.hasGit ? (
+            {isCoreFork && project?.coreForkSlug ? (
+              <CoreForkRepoPanel slug={project.coreForkSlug} />
+            ) : project.hasGit ? (
               <>
                 <div className="flex items-center justify-end mb-2">
                   <Button size="sm" variant="outline" className="text-[11px] h-7" onClick={handleRefreshRepo}>

--- a/ui/dashboard/src/hooks.ts
+++ b/ui/dashboard/src/hooks.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { DashboardEvent, LogEntry, AionimaConfig, ReportSummary, ReportDetail, HFModelSearchResult } from "./types.js";
+import type { DashboardEvent, LogEntry, AionimaConfig, ReportSummary, ReportDetail, HFModelSearchResult, CoreForkStatus } from "./types.js";
 import {
   fetchOverview, fetchConfig, saveConfig,
   fetchProjects, createProject, updateProject, deleteProject,
@@ -183,9 +183,29 @@ export function useProjectConfigWS() {
         case "config:changed":
           void queryClient.invalidateQueries({ queryKey: ["config"] });
           break;
+        case "dev:core-fork-updated":
+          void queryClient.invalidateQueries({ queryKey: ["dev", "core-forks", "status"] });
+          break;
       }
     }, [queryClient]),
   );
+}
+
+// ---------------------------------------------------------------------------
+// useCoreForkStatus — ahead/behind vs upstream for all five core forks
+// ---------------------------------------------------------------------------
+
+export function useCoreForkStatus() {
+  return useQuery({
+    queryKey: ["dev", "core-forks", "status"],
+    queryFn: async (): Promise<{ forks: CoreForkStatus[]; branch?: string; error?: string }> => {
+      const res = await fetch("/api/dev/core-forks/status");
+      if (!res.ok) throw new Error(`HTTP ${String(res.status)}`);
+      return (await res.json()) as { forks: CoreForkStatus[]; branch?: string; error?: string };
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/dashboard/src/routes/overview.tsx
+++ b/ui/dashboard/src/routes/overview.tsx
@@ -24,8 +24,14 @@ import { useRootContext } from "./root.js";
 export default function OverviewPage() {
   const { overview, liveActivity, timelineBucket, setTimelineBucket } = useRootContext();
 
+  // Defensive coalesce: if an older/broken backend ever returns `overview`
+  // without `recentActivity` (e.g. an un-awaited async handler), render with
+  // just the live buffer instead of throwing "not iterable" at runtime.
+  const recentActivity = Array.isArray(overview.data?.recentActivity)
+    ? overview.data.recentActivity
+    : [];
   const allActivity = overview.data !== null
-    ? [...liveActivity, ...overview.data.recentActivity]
+    ? [...liveActivity, ...recentActivity]
       .filter((e, i, arr) => arr.findIndex((a) => a.id === e.id) === i)
       .slice(0, 30)
     : liveActivity;

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -298,7 +298,8 @@ export type DashboardEvent =
   | { type: "tm:report_ready"; data: WorkerReportReady }
   | { type: "notification:new"; data: Notification }
   | { type: "config:changed"; data: { changedKeys: string[]; timestamp: string } }
-  | { type: "usage:recorded"; data: { source: "chat" | "worker"; projectPath: string; costUsd: number } };
+  | { type: "usage:recorded"; data: { source: "chat" | "worker"; projectPath: string; costUsd: number } }
+  | { type: "dev:core-fork-updated"; data: { slug: string; newSha: string; agentic: boolean } };
 
 /** Structured log entry streamed from the gateway. */
 export interface LogEntry {
@@ -378,7 +379,32 @@ export interface ProjectInfo {
   /** When set, this project is a child of a named collection (e.g. "aionima"
    *  for Dev Mode core forks). Dashboard groups + restricts UX accordingly. */
   coreCollection?: string;
+  /** For core forks only: the CORE_REPOS spec slug ("agi", "prime", "id",
+   *  "marketplace", "mapp-marketplace"). Lets the dashboard call the
+   *  `/api/dev/core-forks/:slug/merge` endpoint without parsing the path. */
+  coreForkSlug?: string;
 }
+
+/** A single row returned by GET /api/dev/core-forks/status. */
+export interface CoreForkStatus {
+  slug: string;
+  displayName: string;
+  branch: string;
+  currentSha: string | null;
+  upstreamSha: string | null;
+  /** Commits on the fork that upstream doesn't have. */
+  ahead: number;
+  /** Commits on upstream that haven't been merged into the fork yet. */
+  behind: number;
+  lastFetchedAt: string;
+  error?: string;
+}
+
+/** Response shape of POST /api/dev/core-forks/:slug/merge. */
+export type CoreForkMergeResult =
+  | { ok: true; ff: boolean; agentic: boolean; newSha: string; pushed: boolean }
+  | { ok: false; conflict: true; agentic: boolean; reviewNeeded?: boolean; files: string[]; aionSummary?: string; reason?: string }
+  | { ok: false; conflict: false; reason: string };
 
 /** Git info for a workspace project, returned by GET /api/projects/info. */
 export interface ProjectGitInfo {


### PR DESCRIPTION
## Summary

Three commits that land the last v0.4.0 Dev Mode piece, fix a latent dashboard crash, and repair two infrastructure bugs discovered during testing.

### v0.4.64 — Core-fork Repository tab (ahead/behind + agentic merge)
- `/api/dev/switch` clone loop now configures both `origin` (wishborn fork) and `upstream` (Civicognita) on every core-fork clone, and retrofits `upstream` on legacy clones.
- New `GET /api/dev/core-forks/status` and `POST /api/dev/core-forks/:slug/merge` with FF → merge-commit → aion-micro agentic fallback. Successful merges push to `origin` so the next `agi upgrade` picks them up.
- New `/v1/resolve-merge-conflict` endpoint on the aion-micro container. Deterministic pre-check for trivial cases (identical / whitespace-only / side-deletion); the 135M model only gets `OURS`/`THEIRS`/`UNCLEAR` picks. Low-confidence results preserve conflict markers.
- New `CoreForkRepoPanel` component replaces `RepoPanel` for core forks — shows fork/upstream SHAs, ahead/behind badges, **Merge upstream → origin**, **Open PR to upstream**, **Let Aion-Micro try** conflict escalation.
- WS event `dev:core-fork-updated` invalidates the status query after successful merges.
- Bonus: fixed VM name drift (`test-vm-run.sh` + two runtime refs) from pre-rename `aionima-test` to `agi-test`.

### v0.4.65 — Dashboard crash fix
- Phase 2 DB consolidation (v0.4.41) made `DashboardQueries.getOverview`/`getTimeline`/`getEntityProfile`/`getCOAEntries` async, but the matching handlers in `dashboard-api.ts` kept sync-style calls. They serialized unresolved Promises as `{}`, which made the overview page crash with `t.data.recentActivity is not iterable`.
- All four handlers switch to the same `.then().catch()` pattern the (correct) breakdown/leaderboard handlers already used.
- Client-side defensive coalesce in `overview.tsx` + `OverviewCards.tsx` so future shape drift degrades gracefully instead of crashing.
- The skipped DashboardApi integration tests (`describe.skip` in `dashboard.test.ts:1105`) are why CI missed the regression originally — worth a follow-up to re-enable with a real DB fixture.

### v0.4.66 — Dev Mode AGI origin + VM path fix
Two infrastructure bugs surfaced by post-v0.4.65 testing, both in the same story-#98 Dev Mode scope.

`scripts/upgrade.sh` — `PRIME_REPO` and `ID_REPO` already swap to `dev.primeRepo` / `dev.idRepo` when Dev Mode is enabled, but the AGI self-repo's origin stayed pinned to Civicognita/agi. That meant owner commits pushed to wishborn/agi never reached `/opt/agi` — `agi upgrade` dutifully fetched Civicognita, reported "up to date", and the gateway stayed on the stale version until the fork's work merged upstream. Defeats the whole Dev Mode "work in fork → live on gateway" promise.
- Add `_dev_agi` + `AGI_REPO` resolution alongside the existing PRIME/ID blocks.
- New `ensure_origin_remote()` helper idempotently repoints `/opt/agi`'s origin to `AGI_REPO` before the pull step — so Dev Mode toggling is self-healing. Same treatment for `PRIME_DIR` and `ID_DIR` for consistency.
- Symmetric: when Dev Mode flips OFF, origin repoints back to Civicognita on the next upgrade.

`scripts/test-vm.sh` — `REPO_DIR` was computed via plain `cd ... && pwd`, which returns the *logical* path in bash. Invoking the script through a symlink (e.g. `~/temp_core/agi` → `~/_projects/_aionima/agi`) anchored the VM mounts under `temp_core`, which is the owner's personal workspace and NOT part of AGI's workflow.
- `cd -P` resolves symlinks to the physical path, so `REPO_DIR` always points at `~/_projects/_aionima/agi` (or `/opt/agi` in Ops installs).
- Detect Dev-Mode workspace layout via `basename $WORKSPACE_DIR == "_aionima"` and use slug-based siblings (`prime`, `id`). Legacy Ops layout (`/opt/agi-prime`, `/opt/agi-local-id`) still works.
- Both the `create` and `remount` code paths use the new vars.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean across the monorepo
- [x] `oxlint` clean on all touched files
- [x] Python parser for aion-micro conflict extractor unit-tested against three scenarios (single hunk, two hunks, no conflict)
- [x] Both bash scripts pass `bash -n` syntax check
- [x] Fresh `agi-test` VM recreated after script fix — mounts correctly anchor at `_projects/_aionima/*`, not `temp_core/*` (verified via `multipass info agi-test`)
- [ ] VM unit-test run of `dev-mode-merge.test.ts` still in progress at PR update time; will retry locally after setup finishes.
- [ ] Post-merge: verify `/api/dev/core-forks/status` returns 5 entries against private network from the dashboard.
- [ ] Post-merge: verify the Overview page renders without the `recentActivity is not iterable` crash.
- [ ] Post-merge: toggle Dev Mode off→on, run `agi upgrade`, verify `/opt/agi/.git/config` shows `origin = wishborn/agi`.

## Related

tynn story #98 + tasks #275–#281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)