### PR TITLE
v0.4.68: hotfix — Caddy 2.6-compatible handle_errors block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.67",
+  "version": "0.4.68",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hosting-manager-caddyfile.test.ts
+++ b/packages/gateway-core/src/hosting-manager-caddyfile.test.ts
@@ -154,7 +154,7 @@ papa.ai.on {
     expect(projSection).toContain("reverse_proxy localhost:4002");
   });
 
-  it("adds handle_errors 502 503 504 fallback block in each project block", () => {
+  it("adds a 5xx-filtered handle_errors fallback block in each project block", () => {
     const out = buildCaddyfileContent({
       ...baseOpts,
       projects: [{ hostname: "my-app", port: 4001 }],
@@ -162,7 +162,14 @@ papa.ai.on {
     const projStart = out.indexOf("# === PROJECT DOMAINS ===");
     const projEnd = out.indexOf("# === END PROJECT DOMAINS ===");
     const projSection = out.slice(projStart, projEnd);
-    expect(projSection).toContain("handle_errors 502 503 504 {");
+    // Caddy 2.6 compatibility — use expression-matcher form, not the
+    // status-code filter (`handle_errors 502 503 504`) which requires
+    // Caddy 2.8+.
+    expect(projSection).toContain("handle_errors {");
+    expect(projSection).not.toContain("handle_errors 502 503 504");
+    expect(projSection).toContain("@5xx expression");
+    expect(projSection).toContain("{http.error.status_code} >= 500");
+    expect(projSection).toContain("handle @5xx {");
     expect(projSection).toContain("respond `");
     expect(projSection).toContain("503");
     expect(projSection).toContain("Container not running");

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -208,8 +208,18 @@ export function buildCaddyfileContent(opts: BuildCaddyfileOptions): string {
     blocks.push(`${fqdn} {`);
     blocks.push(`    tls internal`);
     blocks.push(`    reverse_proxy localhost:${String(project.port)}`);
-    blocks.push(`    handle_errors 502 503 504 {`);
-    blocks.push(`        respond \`${offlineHtml}\` 503`);
+    // `handle_errors <status_codes...>` (filter form) needs Caddy 2.8+.
+    // Plenty of deployments are still on 2.6.x which rejects that syntax
+    // with "Wrong argument count or unexpected line ending after '502'"
+    // and fails the whole reload. Use the expression-matcher form that
+    // works on 2.6 through 2.8 uniformly — still limits the offline
+    // page to 5xx responses so legitimate 4xx from the backend (403,
+    // 404, etc.) aren't hidden behind a "container not running" page.
+    blocks.push(`    handle_errors {`);
+    blocks.push(`        @5xx expression \`{http.error.status_code} >= 500\``);
+    blocks.push(`        handle @5xx {`);
+    blocks.push(`            respond \`${offlineHtml}\` 503`);
+    blocks.push(`        }`);
     blocks.push(`    }`);
     blocks.push(`}\n`);
   }


### PR DESCRIPTION
## Summary

**Blocking bug** surfaced right after PR #13 merge + upgrade. The per-project `handle_errors 502 503 504 { ... }` block in `hosting-manager.ts` uses a filter form that requires **Caddy 2.8+**. On a Caddy 2.6.2 host (what's deployed on the test gateway), the parse fails:

```
Error during parsing: Wrong argument count or unexpected line ending after '502'
```

Caddy's reload fails → it keeps running the previous in-memory config → new routes aren't wired up → the safemode banner's **Recover now** button hits 502.

Latent since v0.4.47 (per-container offline pages shipped the `handle_errors` block). Only exposed now because the CoreForkRepoPanel v0.4.64 work in PR #13 caused a fresh Caddyfile regen, and that was the first regen that actually tried to reload on this host.

## Fix

Switch to the expression-matcher form that works on Caddy 2.6 through 2.8 uniformly:

```caddy
handle_errors {
    @5xx expression `{http.error.status_code} >= 500`
    handle @5xx {
        respond `<offline html>` 503
    }
}
```

Semantically identical to the 2.8-only filter form — limits the "container offline" page to 5xx responses so legitimate 4xx from the backend (403, 404, etc.) aren't hidden behind a misleading offline page.

Validated with `caddy validate --adapter caddyfile` against the installed Caddy 2.6.2 binary → returns "Valid configuration".

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `hosting-manager-caddyfile.test.ts` updated and passing (13/13)
- [x] `caddy validate` against 2.6.2 → Valid configuration
- [ ] Post-merge: `agi upgrade` on the test gateway. Expect Caddy reload to succeed after boot regen, and the safemode Recover button to return 200/500 (depending on container recovery outcome), not 502.

## Related

Follow-up to PR #13 (v0.4.64–0.4.67). Unblocks the safemode Recover flow on Caddy 2.6.x deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)