### PR TITLE
ci: workflow fix + v0.4.265 lint cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
+      # @agi/db-schema exports point at ./dist/* — must build before
+      # typecheck so consumers can resolve the package types.
+      - run: pnpm --filter @agi/db-schema build
       - run: pnpm typecheck
       - run: pnpm lint


### PR DESCRIPTION
Lands the keystone CI workflow fix (`pnpm --filter @agi/db-schema build` before typecheck) so dependabot PRs (#16 esbuild + future) can pass CI cleanly. Also bundles v0.4.265 lint fixes (15 oxlint errors → 0) + merge commits + the empty CI-trigger commit from earlier debugging.

After merge: PR #16 rebases against main + CI passes naturally + can merge without admin-bypass.