### PR TITLE
v0.4.266: drizzle-orm 0.45.2 + lodash 4.18.0 (clears remaining 10 HIGH alerts)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.265",
+  "version": "0.4.266",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",
@@ -91,7 +91,7 @@
       "defu": ">=6.1.5",
       "rollup": ">=4.59.0",
       "uuid": ">=11.0.0",
-      "lodash": ">=4.17.21"
+      "lodash": ">=4.18.0"
     }
   }
 }

--- a/packages/coa-chain/package.json
+++ b/packages/coa-chain/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@agi/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.3"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {}
 }

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -60,7 +60,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "drizzle-orm": "^0.38.3",
+    "drizzle-orm": "^0.45.2",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/packages/entity-model/package.json
+++ b/packages/entity-model/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@agi/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.3",
+    "drizzle-orm": "^0.45.2",
     "ulid": "^2.3.0"
   },
   "devDependencies": {}

--- a/packages/gateway-core/package.json
+++ b/packages/gateway-core/package.json
@@ -24,7 +24,7 @@
     "@anthropic-ai/sdk": "^0.90.0",
     "@fastify/static": "^9.1.1",
     "@trpc/server": "^11.0.0",
-    "drizzle-orm": "^0.38.3",
+    "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
     "node-pty": "^1.1.0",
     "ulid": "^2.3.0",

--- a/packages/marketplace/package.json
+++ b/packages/marketplace/package.json
@@ -7,7 +7,7 @@
   "types": "src/index.ts",
   "dependencies": {
     "@agi/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.3"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {}
 }

--- a/packages/model-runtime/package.json
+++ b/packages/model-runtime/package.json
@@ -7,7 +7,7 @@
   "types": "src/index.ts",
   "dependencies": {
     "@agi/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.3"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {}
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@agi/db-schema": "workspace:*",
-    "drizzle-orm": "^0.38.3",
+    "drizzle-orm": "^0.45.2",
     "minimatch": "^10.2.5"
   },
   "devDependencies": {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   defu: '>=6.1.5'
   rollup: '>=4.59.0'
   uuid: '>=11.0.0'
-  lodash: '>=4.17.21'
+  lodash: '>=4.18.0'
 
 importers:
 
@@ -295,14 +295,14 @@ importers:
         specifier: workspace:*
         version: link:../db-schema
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
 
   packages/db-schema:
     dependencies:
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -323,8 +323,8 @@ importers:
         specifier: workspace:*
         version: link:../db-schema
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
       ulid:
         specifier: ^2.3.0
         version: 2.4.0
@@ -383,8 +383,8 @@ importers:
         specifier: ^11.0.0
         version: 11.10.0(typescript@5.9.3)
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -417,8 +417,8 @@ importers:
         specifier: workspace:*
         version: link:../db-schema
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
 
   packages/mcp-client:
     dependencies:
@@ -441,8 +441,8 @@ importers:
         specifier: workspace:*
         version: link:../db-schema
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
 
   packages/plugins:
     dependencies:
@@ -466,8 +466,8 @@ importers:
         specifier: workspace:*
         version: link:../db-schema
       drizzle-orm:
-        specifier: ^0.38.3
-        version: 0.38.4(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/react@19.2.14)(better-sqlite3@11.10.0)(pg@8.20.0)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0)
       minimatch:
         specifier: '>=9.0.7'
         version: 10.2.5
@@ -4228,6 +4228,98 @@ packages:
       sqlite3:
         optional: true
 
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   dts-resolver@2.1.3:
     resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
     engines: {node: '>=20.19.0'}
@@ -5603,9 +5695,6 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -10371,7 +10460,7 @@ snapshots:
   '@sapphire/shapeshift@4.0.0':
     dependencies:
       fast-deep-equal: 3.1.3
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   '@sapphire/snowflake@3.5.3': {}
 
@@ -11757,6 +11846,15 @@ snapshots:
       better-sqlite3: 11.10.0
       pg: 8.20.0
       react: 19.2.4
+
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.4)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@11.10.0)(gel@2.2.0)(pg@8.20.0):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.4.4
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.20.0
+      better-sqlite3: 11.10.0
+      gel: 2.2.0
+      pg: 8.20.0
 
   dts-resolver@2.1.3: {}
 
@@ -13425,8 +13523,6 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
-  lodash@4.17.23: {}
-
   lodash@4.18.1: {}
 
   log-symbols@2.2.0:
@@ -14770,7 +14866,7 @@ snapshots:
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-is: 18.3.1


### PR DESCRIPTION
Final dependency bumps to clear t356's HIGH==0 exit criterion. Per the always-latest-deps directive: bumped drizzle-orm to current latest (0.45.2) across all 7 consumer packages + raised the lodash pnpm override to 4.18.0+. Typecheck passes; CI workflow now has the build step so this should sail through cleanly.