### PR TITLE
v0.4.271: s125 — MCP tab on project detail (per-project MCP + .env keys)

### DIFF
--- a/config/src/project-schema.ts
+++ b/config/src/project-schema.ts
@@ -151,6 +151,43 @@ export const ProjectIterativeWorkSchema = z
   .strict();
 
 // ---------------------------------------------------------------------------
+// Per-project MCP servers (s118 t446 / Wish #7) — surfaces on the project's
+// MCP tab. Each server reaches an external Model Context Protocol service
+// (tynn, github, custom plugins). Auth tokens reference values in the
+// project's .env file via $VAR notation; never store secrets in project.json.
+// ---------------------------------------------------------------------------
+
+export const ProjectMcpServerSchema = z
+  .object({
+    /** Stable id used to reference this server from agent tools / config.
+     *  Per-project ids are namespaced at boot as `<slug>:<id>` to avoid
+     *  collision across projects. */
+    id: z.string(),
+    /** Display name shown in UX. Defaults to id. */
+    name: z.string().optional(),
+    /** Transport selector. */
+    transport: z.enum(["stdio", "http", "websocket"]),
+    /** Stdio: command to spawn. */
+    command: z.array(z.string()).optional(),
+    /** Stdio: env vars to inject. Values may be `$VAR` to resolve from
+     *  the project's .env at registration time. */
+    env: z.record(z.string()).optional(),
+    /** http/websocket: server URL. May include `$VAR` for env-resolved bits. */
+    url: z.string().optional(),
+    /** Whether to register on gateway boot (auto) or lazily on first call. */
+    autoConnect: z.boolean().default(true),
+    /** Auth token, env-var-resolvable (e.g. `$TYNN_API_KEY`). */
+    authToken: z.string().optional(),
+  })
+  .strict();
+
+export const ProjectMcpSchema = z
+  .object({
+    servers: z.array(ProjectMcpServerSchema).default([]),
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
 // Root project config — the full ~/.agi/{slug}/project.json shape
 // ---------------------------------------------------------------------------
 
@@ -178,6 +215,8 @@ export const ProjectConfigSchema = z
     aiDatasets: z.array(ProjectAiDatasetBindingSchema).optional(),
     /** Iterative-work mode — toggles tynn-workflow prompt injection + cron-nudged scheduling. */
     iterativeWork: ProjectIterativeWorkSchema.optional(),
+    /** Per-project MCP servers (Wish #7) — surfaces on the project's MCP tab. */
+    mcp: ProjectMcpSchema.optional(),
   })
   .passthrough(); // Plugins can store custom keys at the root level
 
@@ -193,3 +232,5 @@ export type ProjectAiModelBinding = z.infer<typeof ProjectAiModelBindingSchema>;
 export type ProjectAiDatasetBinding = z.infer<typeof ProjectAiDatasetBindingSchema>;
 export type ProjectIterativeWork = z.infer<typeof ProjectIterativeWorkSchema>;
 export type IterativeWorkCadence = z.infer<typeof IterativeWorkCadenceSchema>;
+export type ProjectMcpServer = z.infer<typeof ProjectMcpServerSchema>;
+export type ProjectMcp = z.infer<typeof ProjectMcpSchema>;

--- a/config/src/schema.ts
+++ b/config/src/schema.ts
@@ -81,6 +81,38 @@ const ProviderConfigSchema = z
   })
   .strict();
 
+/**
+ * MCP server config block (s118 t446 D5). Wired at boot to the McpClient
+ * via mcpClient.registerServer(...) so TynnPmProvider + the `mcp` agent
+ * tool can reach external MCP servers (tynn, github, custom plugins).
+ *
+ * Per-server: id (stable ref), transport (stdio/http/websocket), command
+ * + env (stdio), url (http/websocket), authToken (env-var-resolvable
+ * via $VAR notation), autoConnect (default true).
+ */
+const McpServerConfigSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    transport: z.enum(["stdio", "http", "websocket"]),
+    command: z.array(z.string()).optional(),
+    env: z.record(z.string()).optional(),
+    url: z.string().optional(),
+    autoConnect: z.boolean().default(true),
+    authToken: z.string().optional(),
+  })
+  .strict();
+
+const McpConfigSchema = z
+  .object({
+    /** External MCP servers to register at gateway boot. Each entry passes
+     *  to mcpClient.registerServer(). When transport=stdio + autoConnect,
+     *  the subprocess spawns at startup and stays alive for the gateway's
+     *  lifetime. */
+    servers: z.array(McpServerConfigSchema).default([]),
+  })
+  .strict();
+
 const AgentPmConfigSchema = z
   .object({
     /** PM provider selector. Built-in: "tynn" (default — uses MCP to reach
@@ -607,6 +639,7 @@ export const AionimaConfigSchema = z
     nexus: LegacyNexusConfigSchema.optional(),
     hosting: HostingConfigSchema.optional(),
     plugins: z.record(z.string(), PluginPreferenceSchema).optional(),
+    mcp: McpConfigSchema.optional(),
     services: ServicesConfigSchema.optional(),
     owner: OwnerConfigSchema.optional(),
     logging: LoggingConfigSchema.optional(),

--- a/e2e/mcp-tab.spec.ts
+++ b/e2e/mcp-tab.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Per-project MCP tab e2e (Wish #7 / s125 t479).
+ *
+ * Verifies: tab visible on hostable project, available templates load,
+ * env keys list renders, add-server flow visible. Defensive: skips when
+ * no hostable project is available.
+ */
+
+async function findHostableProject(request: import("@playwright/test").APIRequestContext): Promise<{ name: string; path: string } | undefined> {
+  const res = await request.get("/api/projects").catch(() => null);
+  if (!res || !res.ok()) return undefined;
+  const projects = (await res.json()) as Array<{ name: string; path: string; projectType?: { hasCode?: boolean } }>;
+  const hostable = projects.find((p) => p.projectType?.hasCode);
+  return hostable ? { name: hostable.name, path: hostable.path } : undefined;
+}
+
+test.describe("MCP tab", () => {
+  test("MCP available templates endpoint returns at least Tynn", async ({ request }) => {
+    const res = await request.get("/api/projects/mcp/available");
+    expect(res.ok()).toBe(true);
+    const body = await res.json() as { templates: Array<{ id: string; name: string }> };
+    expect(body.templates.length).toBeGreaterThan(0);
+    expect(body.templates.some((t) => t.id === "tynn")).toBe(true);
+  });
+
+  test("MCP tab appears on hostable project detail page", async ({ page, request }) => {
+    const project = await findHostableProject(request);
+    test.skip(!project, "no hostable project available");
+    await page.goto(`/projects/${project!.name}`);
+    await page.waitForLoadState("domcontentloaded");
+    const tab = page.getByRole("tab", { name: /^MCP$/i });
+    await expect(tab).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Clicking MCP tab reveals the panel + add-server button", async ({ page, request }) => {
+    const project = await findHostableProject(request);
+    test.skip(!project, "no hostable project available");
+    await page.goto(`/projects/${project!.name}`);
+    await page.waitForLoadState("domcontentloaded");
+    await page.getByRole("tab", { name: /^MCP$/i }).click();
+    await expect(page.getByTestId("mcp-tab")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("mcp-add-button")).toBeVisible();
+    await expect(page.getByTestId("mcp-env-keys")).toBeVisible();
+  });
+
+  test("Add-server form opens with template dropdown + key field", async ({ page, request }) => {
+    const project = await findHostableProject(request);
+    test.skip(!project, "no hostable project available");
+    await page.goto(`/projects/${project!.name}`);
+    await page.waitForLoadState("domcontentloaded");
+    await page.getByRole("tab", { name: /^MCP$/i }).click();
+    await page.getByTestId("mcp-add-button").click();
+    await expect(page.getByTestId("mcp-add-template")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("mcp-add-save")).toBeVisible();
+    // Tynn is selected by default + has authTokenKey, so key field should appear.
+    await expect(page.getByTestId("mcp-add-key")).toBeVisible();
+  });
+
+  test("Save tynn server with key — env key persists, server added", async ({ page, request }) => {
+    const project = await findHostableProject(request);
+    test.skip(!project, "no hostable project available");
+    await page.goto(`/projects/${project!.name}`);
+    await page.waitForLoadState("domcontentloaded");
+    await page.getByRole("tab", { name: /^MCP$/i }).click();
+    await expect(page.getByTestId("mcp-tab")).toBeVisible({ timeout: 10_000 });
+    await page.getByTestId("mcp-add-button").click();
+    await page.getByTestId("mcp-add-key").fill("test-tynn-key-e2e-12345");
+    await page.getByTestId("mcp-add-save").click();
+    // Wait for the save to round-trip — config reload should re-render servers list.
+    await page.waitForResponse((r) => r.url().includes("/api/projects/mcp/list"), { timeout: 15_000 }).catch(() => undefined);
+    // Tynn server should now be in the list.
+    await expect(page.locator("text=tynn").first()).toBeVisible({ timeout: 5_000 });
+    // Env key TYNN_API_KEY should appear in the keys list (key NAME, never value).
+    await expect(page.locator("text=TYNN_API_KEY").first()).toBeVisible();
+
+    // Cleanup: remove via API to keep test idempotent.
+    await request.delete(`/api/projects/mcp/server?path=${encodeURIComponent(project!.path)}&id=tynn`);
+    await request.delete(`/api/projects/mcp/env?path=${encodeURIComponent(project!.path)}&key=TYNN_API_KEY`);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.270",
+  "version": "0.4.271",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.269",
+  "version": "0.4.270",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/project-env-store.ts
+++ b/packages/gateway-core/src/project-env-store.ts
@@ -1,0 +1,124 @@
+/**
+ * project-env-store — read + write per-project .env file (Wish #7 / s125 t476).
+ *
+ * Each hosted project has a `<projectPath>/.env` file used at runtime to
+ * inject env vars into containers + into MCP server registration. This
+ * module provides:
+ *
+ * - readProjectEnv(projectPath)  — parse current .env into key/value map
+ * - listProjectEnvKeys(projectPath) — return KEY names only (for redacted UI)
+ * - setProjectEnvVar(projectPath, key, value) — atomic write (temp + rename)
+ * - removeProjectEnvVar(projectPath, key) — remove a key from .env
+ * - resolveDollarVars(input, env) — replace $VAR refs in a string with env values
+ *
+ * Security note: never expose values through dashboard read endpoints —
+ * only listProjectEnvKeys (key NAMES). The Vault feature (Wish #10 / s128)
+ * is the long-term replacement; .env is the bridge.
+ */
+
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const ENV_FILE_NAME = ".env";
+
+/** Parse a .env file body into a key/value map. Skips comments + blank lines. */
+function parseEnvBody(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eqIdx = line.indexOf("=");
+    if (eqIdx < 0) continue;
+    const key = line.slice(0, eqIdx).trim();
+    let value = line.slice(eqIdx + 1).trim();
+    // Strip surrounding single or double quotes if present.
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key.length > 0) out[key] = value;
+  }
+  return out;
+}
+
+/** Render a key/value map to .env body (alphabetical for stable diffs). */
+function serializeEnvBody(env: Record<string, string>): string {
+  const lines: string[] = [];
+  const keys = Object.keys(env).sort();
+  for (const k of keys) {
+    const v = env[k] ?? "";
+    // Quote if value contains whitespace or special chars; bare otherwise.
+    const needsQuote = /[\s"'#$]/.test(v);
+    lines.push(`${k}=${needsQuote ? `"${v.replace(/"/g, '\\"')}"` : v}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+export function readProjectEnv(projectPath: string): Record<string, string> {
+  const envPath = join(projectPath, ENV_FILE_NAME);
+  if (!existsSync(envPath)) return {};
+  try {
+    const body = readFileSync(envPath, "utf-8");
+    return parseEnvBody(body);
+  } catch {
+    return {};
+  }
+}
+
+export function listProjectEnvKeys(projectPath: string): string[] {
+  return Object.keys(readProjectEnv(projectPath)).sort();
+}
+
+export function setProjectEnvVar(projectPath: string, key: string, value: string): void {
+  if (!/^[A-Z_][A-Z0-9_]*$/i.test(key)) {
+    throw new Error(`Invalid env var key: "${key}" (must match [A-Z_][A-Z0-9_]*)`);
+  }
+  const envPath = join(projectPath, ENV_FILE_NAME);
+  // Ensure parent dir exists (project might be brand new without a hosted root).
+  mkdirSync(dirname(envPath), { recursive: true });
+  const current = readProjectEnv(projectPath);
+  current[key] = value;
+  const body = serializeEnvBody(current);
+  // Atomic write: temp file + rename.
+  const tmpPath = `${envPath}.tmp`;
+  writeFileSync(tmpPath, body, { encoding: "utf-8", mode: 0o600 });
+  renameSync(tmpPath, envPath);
+}
+
+export function removeProjectEnvVar(projectPath: string, key: string): void {
+  const envPath = join(projectPath, ENV_FILE_NAME);
+  if (!existsSync(envPath)) return;
+  const current = readProjectEnv(projectPath);
+  if (!(key in current)) return;
+  delete current[key];
+  const body = serializeEnvBody(current);
+  const tmpPath = `${envPath}.tmp`;
+  writeFileSync(tmpPath, body, { encoding: "utf-8", mode: 0o600 });
+  renameSync(tmpPath, envPath);
+}
+
+/**
+ * Resolve `$VAR` references in a string against a key/value map.
+ * Used at MCP server registration time to expand authToken / env values
+ * pulled from the project's .env without putting secrets in project.json.
+ *
+ *   resolveDollarVars("$TYNN_API_KEY", env)  → env.TYNN_API_KEY (or "")
+ *   resolveDollarVars("npx -y @tynn/mcp-server", env)  → unchanged (no $)
+ */
+export function resolveDollarVars(input: string, env: Record<string, string>): string {
+  if (typeof input !== "string" || !input.includes("$")) return input;
+  if (input.startsWith("$") && !input.includes(" ")) {
+    // Whole-string $VAR — direct substitution.
+    return env[input.slice(1)] ?? "";
+  }
+  // Inline $VAR substitutions (uncommon for MCP; reserved for future shapes).
+  return input.replace(/\$([A-Z_][A-Z0-9_]*)/gi, (_, name: string) => env[name] ?? "");
+}
+
+/** Resolve $VAR refs throughout a Record<string,string>. */
+export function resolveDollarVarsObject(
+  input: Record<string, string> | undefined,
+  env: Record<string, string>,
+): Record<string, string> | undefined {
+  if (input === undefined) return undefined;
+  return Object.fromEntries(Object.entries(input).map(([k, v]) => [k, resolveDollarVars(v, env)]));
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -65,6 +65,14 @@ import { projectConfigPath } from "./project-config-path.js";
 import type { IterativeWorkScheduler } from "./iterative-work/scheduler.js";
 import { cadenceToStaggeredCron } from "./iterative-work/cron.js";
 import {
+  listProjectEnvKeys,
+  readProjectEnv,
+  removeProjectEnvVar,
+  resolveDollarVars,
+  resolveDollarVarsObject,
+  setProjectEnvVar,
+} from "./project-env-store.js";
+import {
   ITERATIVE_WORK_ELIGIBLE_CATEGORIES,
   TESTING_UX_ELIGIBLE_CATEGORIES,
   cadenceOptionsFor,
@@ -177,6 +185,9 @@ export interface RuntimeStateDeps {
    *  surface Race-to-DONE counts. Optional: when missing or when the
    *  provider doesn't expose getActiveFocusProgress, the route returns 503. */
   pmProvider?: PmProvider;
+  /** McpClient — used by the per-project MCP tab routes (Wish #7 / s125) to
+   *  register/unregister/test MCP servers + surface listServers state. */
+  mcpClient?: import("@agi/mcp-client").McpClient;
   /** Path to the MApp marketplace directory (for catalog browsing). */
   mappMarketplaceDir?: string;
   /** CommsLog — persistent message log for comms page. */
@@ -1684,6 +1695,219 @@ export async function createGatewayRuntimeState(
     } catch (err) {
       return reply.code(502).send({ error: err instanceof Error ? err.message : String(err) });
     }
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-project MCP routes (Wish #7 / s125 — MCP tab on project detail).
+  //
+  // Surfaces project's MCP servers + .env-backed key storage to the dashboard
+  // MCP tab. Servers are namespaced as `<projectSlug>:<serverId>` when
+  // registered with mcpClient to avoid collision across projects.
+  //
+  // .env values are NEVER returned through these endpoints — only key NAMES.
+  // The project's .env file holds the secrets; dashboard sets values blindly.
+  // -----------------------------------------------------------------------
+
+  // Helper: project namespace prefix for MCP server ids.
+  const mcpServerNs = (projectPath: string, serverId: string): string => {
+    const slug = projectConfigPath(projectPath).split("/").slice(-2, -1)[0] ?? "default";
+    return `${slug}:${serverId}`;
+  };
+
+  // GET /api/projects/mcp/list?path= — list MCP servers + connection state.
+  fastify.get("/api/projects/mcp/list", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    if (!deps.projectConfigManager) return reply.code(503).send({ error: "Project config manager not available" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const pathParam = (request.query as Record<string, string>)["path"];
+    if (!pathParam) return reply.code(400).send({ error: "path query parameter is required" });
+    const targetPath = resolvePath(pathParam);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    const cfg = await deps.projectConfigManager.read(targetPath);
+    const servers = (cfg as { mcp?: { servers?: Array<{ id: string; name?: string; transport: string; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }> } }).mcp?.servers ?? [];
+    // Augment with live connection state from mcpClient.
+    const liveServers = deps.mcpClient?.listServers() ?? [];
+    const liveById = new Map(liveServers.map((s: { id: string; state: string }) => [s.id, s.state]));
+    return reply.send({
+      servers: servers.map((s) => ({
+        id: s.id,
+        name: s.name ?? s.id,
+        transport: s.transport,
+        command: s.command,
+        url: s.url,
+        envKeys: Object.keys(s.env ?? {}),
+        autoConnect: s.autoConnect ?? true,
+        hasAuthToken: typeof s.authToken === "string" && s.authToken.length > 0,
+        state: liveById.get(mcpServerNs(targetPath, s.id)) ?? "not-registered",
+      })),
+    });
+  });
+
+  // PUT /api/projects/mcp/server?path= — add/update a server (writes to project.json).
+  fastify.put("/api/projects/mcp/server", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    if (!deps.projectConfigManager) return reply.code(503).send({ error: "Project config manager not available" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const body = request.body as { path?: string; server?: { id: string; name?: string; transport: "stdio" | "http" | "websocket"; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string } } | undefined;
+    if (!body?.path || !body.server?.id) return reply.code(400).send({ error: "path + server.id are required" });
+    const targetPath = resolvePath(body.path);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    if (!existsSync(projectConfigPath(targetPath))) return reply.code(404).send({ error: "Project has no project.json" });
+    try {
+      const cur = await deps.projectConfigManager.read(targetPath);
+      const servers = ((cur as { mcp?: { servers?: typeof body.server[] } }).mcp?.servers ?? []).filter((s) => s.id !== body.server!.id);
+      servers.push(body.server);
+      const updated = await deps.projectConfigManager.update(targetPath, { mcp: { servers } } as Record<string, unknown>);
+      // Re-register with mcpClient under namespaced id (best-effort; surfaces error in response).
+      let registerError: string | null = null;
+      if (deps.mcpClient && (body.server.autoConnect ?? true)) {
+        try {
+          const env = body.server.env ? resolveDollarVarsObject(body.server.env, readProjectEnv(targetPath)) : undefined;
+          const authToken = body.server.authToken ? resolveDollarVars(body.server.authToken, readProjectEnv(targetPath)) : undefined;
+          await deps.mcpClient.registerServer({
+            id: mcpServerNs(targetPath, body.server.id),
+            name: body.server.name,
+            transport: body.server.transport,
+            command: body.server.command,
+            env,
+            url: body.server.url,
+            autoConnect: true,
+            authToken,
+          });
+        } catch (err) {
+          registerError = err instanceof Error ? err.message : String(err);
+        }
+      }
+      return reply.send({ ok: true, mcp: (updated as { mcp?: unknown }).mcp ?? { servers: [] }, registerError });
+    } catch (err) {
+      return reply.code(400).send({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // DELETE /api/projects/mcp/server?path=&id= — remove server.
+  fastify.delete("/api/projects/mcp/server", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    if (!deps.projectConfigManager) return reply.code(503).send({ error: "Project config manager not available" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const query = request.query as Record<string, string>;
+    const pathParam = query["path"];
+    const idParam = query["id"];
+    if (!pathParam || !idParam) return reply.code(400).send({ error: "path + id query params required" });
+    const targetPath = resolvePath(pathParam);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    try {
+      const cur = await deps.projectConfigManager.read(targetPath);
+      const servers = ((cur as { mcp?: { servers?: Array<{ id: string }> } }).mcp?.servers ?? []).filter((s) => s.id !== idParam);
+      await deps.projectConfigManager.update(targetPath, { mcp: { servers } } as Record<string, unknown>);
+      // Best-effort unregister.
+      try { await deps.mcpClient?.unregisterServer?.(mcpServerNs(targetPath, idParam)); } catch { /* ignore */ }
+      return reply.send({ ok: true });
+    } catch (err) {
+      return reply.code(400).send({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // GET /api/projects/mcp/env?path= — list .env KEY NAMES (never values).
+  fastify.get("/api/projects/mcp/env", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const pathParam = (request.query as Record<string, string>)["path"];
+    if (!pathParam) return reply.code(400).send({ error: "path query parameter is required" });
+    const targetPath = resolvePath(pathParam);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    return reply.send({ keys: listProjectEnvKeys(targetPath) });
+  });
+
+  // POST /api/projects/mcp/env?path= — body: { key, value }; value is write-only.
+  fastify.post("/api/projects/mcp/env", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const body = request.body as { path?: string; key?: string; value?: string } | undefined;
+    if (!body?.path || !body.key) return reply.code(400).send({ error: "path + key required" });
+    const targetPath = resolvePath(body.path);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    try {
+      setProjectEnvVar(targetPath, body.key, body.value ?? "");
+      return reply.send({ ok: true, keys: listProjectEnvKeys(targetPath) });
+    } catch (err) {
+      return reply.code(400).send({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // DELETE /api/projects/mcp/env?path=&key= — remove a key from .env.
+  fastify.delete("/api/projects/mcp/env", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    const projectDirs = deps.workspaceProjects ?? [];
+    const query = request.query as Record<string, string>;
+    const pathParam = query["path"];
+    const keyParam = query["key"];
+    if (!pathParam || !keyParam) return reply.code(400).send({ error: "path + key required" });
+    const targetPath = resolvePath(pathParam);
+    if (!projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)))) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    try {
+      removeProjectEnvVar(targetPath, keyParam);
+      return reply.send({ ok: true, keys: listProjectEnvKeys(targetPath) });
+    } catch (err) {
+      return reply.code(400).send({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // POST /api/projects/mcp/server/test?path=&id= — try connecting + listTools.
+  fastify.post("/api/projects/mcp/server/test", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    if (!deps.mcpClient) return reply.code(503).send({ error: "MCP client not available" });
+    const query = request.query as Record<string, string>;
+    const pathParam = query["path"];
+    const idParam = query["id"];
+    if (!pathParam || !idParam) return reply.code(400).send({ error: "path + id required" });
+    const targetPath = resolvePath(pathParam);
+    const nsId = mcpServerNs(targetPath, idParam);
+    try {
+      const tools = await deps.mcpClient.listTools(nsId);
+      return reply.send({ ok: true, toolCount: tools.length, tools: tools.slice(0, 5).map((t: { name: string }) => t.name) });
+    } catch (err) {
+      return reply.code(502).send({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  // GET /api/projects/mcp/available — list MCP server templates (built-in + plugin-registered).
+  fastify.get("/api/projects/mcp/available", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    // Built-in templates. Future: plugin-registered MCP service definitions (Wish #8 — Tynn plugin).
+    const builtIn: Array<{ id: string; name: string; description: string; transport: "stdio" | "http" | "websocket"; defaultCommand?: string[]; defaultEnv?: Record<string, string>; defaultUrl?: string; authTokenKey?: string; pluginId?: string }> = [
+      {
+        id: "tynn",
+        name: "Tynn",
+        description: "Tynn-the-service via MCP. Provides PM tools (list-tasks, set-status, add-comment, getActiveFocusProgress, etc) for the agent.",
+        transport: "stdio",
+        defaultCommand: ["npx", "-y", "@tynn/mcp-server"],
+        defaultEnv: { TYNN_API_KEY: "$TYNN_API_KEY" },
+        authTokenKey: "TYNN_API_KEY",
+      },
+    ];
+    // Plugin-registered templates — when registered via api.registerMcpServerTemplate (future Wish #8).
+    const pluginTemplates = (deps.pluginRegistry as { getMcpServerTemplates?: () => typeof builtIn } | undefined)?.getMcpServerTemplates?.() ?? [];
+    return reply.send({ templates: [...builtIn, ...pluginTemplates] });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -1971,11 +1971,47 @@ export async function startGatewayServer(
   });
   log.info(`registered ${String(agentToolCount)} agent tools`);
 
-  // s118 t441 cycle 33 — MCP client + `mcp` agent tool. Instantiated empty;
-  // server config wiring (per-project mcp.servers block) ships in s118 t435.
-  // Until then, mcp.list-servers returns [] and call/list-tools/etc. error
-  // with "server X not registered" — Aion has the surface, not yet the data.
+  // s118 t441 cycle 33 — MCP client + `mcp` agent tool.
+  // s118 t446 D5 (cycle 67+) — boot-time wiring: read config.mcp.servers
+  // and registerServer each. TynnPmProvider's callTool("tynn", ...) +
+  // /api/projects/iterative-work/progress + the `mcp` agent tool's
+  // listServers/listTools/callTool now have real data when servers are
+  // configured. Each server block: { id, transport: stdio|http|websocket,
+  // command/env (stdio), url (http/ws), authToken (env-resolvable via
+  // $VAR), autoConnect: bool }.
   const mcpClient = new McpClient();
+  const mcpServersConfig = (config as { mcp?: { servers?: Array<Record<string, unknown>> } }).mcp?.servers ?? [];
+  for (const serverCfg of mcpServersConfig) {
+    try {
+      // Resolve $VAR-prefixed authToken via process.env so secrets stay
+      // out of gateway.json. {"authToken": "$TYNN_API_KEY"} → real token
+      // from process.env.TYNN_API_KEY at registration time.
+      const resolvedAuthToken = typeof serverCfg.authToken === "string" && serverCfg.authToken.startsWith("$")
+        ? process.env[serverCfg.authToken.slice(1)]
+        : (serverCfg.authToken as string | undefined);
+      // Resolve $VAR in env block too — `{"FOO": "$REAL_FOO"}` reads from process.env.
+      const resolvedEnv = typeof serverCfg.env === "object" && serverCfg.env !== null
+        ? Object.fromEntries(
+            Object.entries(serverCfg.env as Record<string, string>).map(([k, v]) =>
+              [k, v.startsWith("$") ? (process.env[v.slice(1)] ?? "") : v],
+            ),
+          )
+        : undefined;
+      await mcpClient.registerServer({
+        id: serverCfg.id as string,
+        name: serverCfg.name as string | undefined,
+        transport: serverCfg.transport as "stdio" | "http" | "websocket",
+        command: serverCfg.command as string[] | undefined,
+        env: resolvedEnv,
+        url: serverCfg.url as string | undefined,
+        autoConnect: (serverCfg.autoConnect as boolean | undefined) ?? true,
+        authToken: resolvedAuthToken,
+      });
+      log.info(`mcp: registered server "${String(serverCfg.id)}" (transport=${String(serverCfg.transport)})`);
+    } catch (err) {
+      log.warn(`mcp: failed to register server "${String(serverCfg.id)}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
 
   // s118 t432 cycle 36 — PM provider resolution + `pm` agent tool.
   // PM provider resolution (s118 t434): config.agent.pm.provider selects

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -2013,6 +2013,51 @@ export async function startGatewayServer(
     }
   }
 
+  // Per-project MCP servers (Wish #7 / s125 t478) — register each project's
+  // mcp.servers block under namespaced ids `<slug>:<id>`. Auth tokens + env
+  // values resolve from the project's .env file via $VAR notation.
+  try {
+    const { readProjectEnv, resolveDollarVars, resolveDollarVarsObject } = await import("./project-env-store.js");
+    const { projectConfigPath: pcp, projectSlug: pslug } = await import("./project-config-path.js");
+    for (const projectDir of projectPaths) {
+      try {
+        const { readdirSync, statSync } = await import("node:fs");
+        for (const entry of readdirSync(projectDir)) {
+          const fullPath = `${projectDir}/${entry}`;
+          if (!statSync(fullPath).isDirectory()) continue;
+          const cfgPath = pcp(fullPath);
+          if (!existsSync(cfgPath)) continue;
+          const raw = JSON.parse(readFileSync(cfgPath, "utf-8")) as { mcp?: { servers?: Array<{ id: string; name?: string; transport: "stdio" | "http" | "websocket"; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }> } };
+          const projectServers = raw.mcp?.servers ?? [];
+          if (projectServers.length === 0) continue;
+          const projectEnv = readProjectEnv(fullPath);
+          for (const s of projectServers) {
+            if (s.autoConnect === false) continue;
+            try {
+              await mcpClient.registerServer({
+                id: `${pslug(fullPath)}:${s.id}`,
+                name: s.name,
+                transport: s.transport,
+                command: s.command,
+                env: resolveDollarVarsObject(s.env, projectEnv),
+                url: s.url ? resolveDollarVars(s.url, projectEnv) : undefined,
+                autoConnect: true,
+                authToken: s.authToken ? resolveDollarVars(s.authToken, projectEnv) : undefined,
+              });
+              log.info(`mcp: registered project-server "${pslug(fullPath)}:${s.id}" (project=${entry})`);
+            } catch (err) {
+              log.warn(`mcp: failed to register project-server "${pslug(fullPath)}:${s.id}": ${err instanceof Error ? err.message : String(err)}`);
+            }
+          }
+        }
+      } catch (err) {
+        log.warn(`mcp: project enumeration failed for ${projectDir}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  } catch (err) {
+    log.warn(`mcp: per-project wiring init failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   // s118 t432 cycle 36 — PM provider resolution + `pm` agent tool.
   // PM provider resolution (s118 t434): config.agent.pm.provider selects
   // which implementation backs the canonical tynn workflow. Built-in ids
@@ -2325,6 +2370,7 @@ export async function startGatewayServer(
       iterativeWorkScheduler,
       projectConfigManager,
       pmProvider,
+      mcpClient,
       commsLog,
       notificationStore,
       chatPersistence,

--- a/ui/dashboard/src/components/MCPTab.tsx
+++ b/ui/dashboard/src/components/MCPTab.tsx
@@ -1,0 +1,314 @@
+/**
+ * MCPTab — per-project MCP server config (Wish #7 / s125 t474).
+ *
+ * Owner adds/configures MCP servers for THIS project. Servers come from a
+ * dropdown of available templates (built-in tynn + plugin-registered later).
+ * Auth tokens reference values in the project's .env file via $VAR notation
+ * — keys are stored in .env (write-only via UI), never in project.json.
+ *
+ * Tab is gated on `project.projectType?.hasCode` (only code-bearing projects
+ * benefit from MCP integration).
+ */
+
+import { useEffect, useState } from "react";
+import type { ProjectInfo } from "../types";
+import { Button } from "./ui/button";
+
+interface McpServerEntry {
+  id: string;
+  name: string;
+  transport: "stdio" | "http" | "websocket";
+  command?: string[];
+  url?: string;
+  envKeys: string[];
+  autoConnect: boolean;
+  hasAuthToken: boolean;
+  state: string;
+}
+
+interface McpTemplate {
+  id: string;
+  name: string;
+  description: string;
+  transport: "stdio" | "http" | "websocket";
+  defaultCommand?: string[];
+  defaultEnv?: Record<string, string>;
+  defaultUrl?: string;
+  authTokenKey?: string;
+  pluginId?: string;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const headers = new Headers(init?.headers);
+  if (init?.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json");
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({ error: res.statusText }))) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${String(res.status)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export function MCPTab({ project }: { project: ProjectInfo }): JSX.Element {
+  const [servers, setServers] = useState<McpServerEntry[]>([]);
+  const [envKeys, setEnvKeys] = useState<string[]>([]);
+  const [templates, setTemplates] = useState<McpTemplate[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Add-server form state
+  const [showAdd, setShowAdd] = useState(false);
+  const [tplId, setTplId] = useState<string>("");
+  const [keyValue, setKeyValue] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Test-connection state
+  const [testing, setTesting] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<Record<string, { ok: boolean; message: string }>>({});
+
+  const refresh = async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [list, envList, tplList] = await Promise.all([
+        fetchJson<{ servers: McpServerEntry[] }>(`/api/projects/mcp/list?path=${encodeURIComponent(project.path)}`),
+        fetchJson<{ keys: string[] }>(`/api/projects/mcp/env?path=${encodeURIComponent(project.path)}`),
+        fetchJson<{ templates: McpTemplate[] }>(`/api/projects/mcp/available`),
+      ]);
+      setServers(list.servers);
+      setEnvKeys(envList.keys);
+      setTemplates(tplList.templates);
+      if (tplList.templates.length > 0 && tplId === "") setTplId(tplList.templates[0]!.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    const id = window.setInterval(() => { void refresh(); }, 30_000);
+    return (): void => { window.clearInterval(id); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [project.path]);
+
+  const addServer = async (): Promise<void> => {
+    const tpl = templates.find((t) => t.id === tplId);
+    if (!tpl) return;
+    setSaving(true);
+    setError(null);
+    try {
+      // 1) Save the key to .env (if template has authTokenKey + user provided value).
+      if (tpl.authTokenKey && keyValue.length > 0) {
+        await fetchJson(`/api/projects/mcp/env`, {
+          method: "POST",
+          body: JSON.stringify({ path: project.path, key: tpl.authTokenKey, value: keyValue }),
+        });
+      }
+      // 2) Save server config to project.json.
+      await fetchJson(`/api/projects/mcp/server`, {
+        method: "PUT",
+        body: JSON.stringify({
+          path: project.path,
+          server: {
+            id: tpl.id,
+            name: tpl.name,
+            transport: tpl.transport,
+            command: tpl.defaultCommand,
+            env: tpl.defaultEnv,
+            url: tpl.defaultUrl,
+            autoConnect: true,
+            authToken: tpl.authTokenKey ? `$${tpl.authTokenKey}` : undefined,
+          },
+        }),
+      });
+      setShowAdd(false);
+      setKeyValue("");
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeServer = async (id: string): Promise<void> => {
+    if (!confirm(`Remove MCP server "${id}"? Its env keys stay in .env (use the env list below to clear them).`)) return;
+    try {
+      await fetch(`/api/projects/mcp/server?path=${encodeURIComponent(project.path)}&id=${encodeURIComponent(id)}`, { method: "DELETE" });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const testServer = async (id: string): Promise<void> => {
+    setTesting(id);
+    try {
+      const res = await fetch(`/api/projects/mcp/server/test?path=${encodeURIComponent(project.path)}&id=${encodeURIComponent(id)}`, { method: "POST" });
+      const body = await res.json() as { ok: boolean; toolCount?: number; tools?: string[]; error?: string };
+      setTestResult((prev) => ({
+        ...prev,
+        [id]: body.ok
+          ? { ok: true, message: `Connected — ${String(body.toolCount ?? 0)} tools (${(body.tools ?? []).slice(0, 3).join(", ")}${body.tools && body.tools.length > 3 ? "…" : ""})` }
+          : { ok: false, message: body.error ?? "Test failed" },
+      }));
+    } catch (err) {
+      setTestResult((prev) => ({ ...prev, [id]: { ok: false, message: err instanceof Error ? err.message : String(err) } }));
+    } finally {
+      setTesting(null);
+    }
+  };
+
+  const removeEnvKey = async (key: string): Promise<void> => {
+    if (!confirm(`Remove env key "${key}" from this project's .env?`)) return;
+    try {
+      await fetch(`/api/projects/mcp/env?path=${encodeURIComponent(project.path)}&key=${encodeURIComponent(key)}`, { method: "DELETE" });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-card border border-border p-4 space-y-6" data-testid="mcp-tab">
+      <div>
+        <h3 className="text-[13px] font-semibold mb-2">MCP Servers</h3>
+        <p className="text-[12px] text-muted-foreground">
+          Model Context Protocol servers expand this project's agent capabilities. Add a server (e.g. Tynn for PM tools), provide its auth key — keys are written to this project's <span className="font-mono">.env</span> file (never to <span className="font-mono">project.json</span>) for per-project isolation.
+        </p>
+      </div>
+
+      {error && <div className="text-[12px] text-red">{error}</div>}
+      {loading && servers.length === 0 && <div className="text-[12px] text-muted-foreground">Loading…</div>}
+
+      <section data-testid="mcp-servers">
+        {servers.length === 0 ? (
+          <div className="text-[12px] text-muted-foreground py-2">No MCP servers configured.</div>
+        ) : (
+          <table className="w-full text-[12px]" data-testid="mcp-servers-table">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left pb-1">Server</th>
+                <th className="text-left pb-1">Transport</th>
+                <th className="text-left pb-1">Auth</th>
+                <th className="text-left pb-1">State</th>
+                <th className="text-left pb-1">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {servers.map((s) => (
+                <tr key={s.id} className="border-b border-border/50 align-top">
+                  <td className="py-2">
+                    <div className="font-mono">{s.name}</div>
+                    <div className="text-[10px] text-muted-foreground">id: {s.id}</div>
+                  </td>
+                  <td className="py-2 font-mono">{s.transport}</td>
+                  <td className="py-2 text-[11px]">
+                    {s.hasAuthToken ? <span className="text-green">configured</span> : <span className="text-muted-foreground">none</span>}
+                  </td>
+                  <td className="py-2">
+                    <span className={
+                      s.state === "connected" ? "text-green" :
+                      s.state === "error" ? "text-red" :
+                      "text-muted-foreground"
+                    }>{s.state}</span>
+                    {testResult[s.id] && (
+                      <div className={"text-[10px] mt-0.5 " + (testResult[s.id]!.ok ? "text-green" : "text-red")}>
+                        {testResult[s.id]!.message}
+                      </div>
+                    )}
+                  </td>
+                  <td className="py-2">
+                    <div className="flex gap-2">
+                      <Button onClick={() => { void testServer(s.id); }} disabled={testing === s.id} data-testid={`mcp-test-${s.id}`}>
+                        {testing === s.id ? "Testing…" : "Test"}
+                      </Button>
+                      <Button onClick={() => { void removeServer(s.id); }} data-testid={`mcp-remove-${s.id}`}>
+                        Remove
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        <div className="mt-3">
+          {!showAdd ? (
+            <Button onClick={() => setShowAdd(true)} data-testid="mcp-add-button">Add MCP Server</Button>
+          ) : (
+            <div className="rounded border border-border p-3 mt-2 space-y-3">
+              <div>
+                <label className="block text-[11px] font-semibold text-muted-foreground mb-1">Service</label>
+                <select
+                  value={tplId}
+                  onChange={(e) => setTplId(e.target.value)}
+                  className="w-full text-[12px] rounded border border-border bg-background px-2 py-1"
+                  data-testid="mcp-add-template"
+                >
+                  {templates.map((t) => (
+                    <option key={t.id} value={t.id}>{t.name}{t.pluginId ? ` (via ${t.pluginId})` : ""}</option>
+                  ))}
+                </select>
+                {(() => {
+                  const tpl = templates.find((t) => t.id === tplId);
+                  return tpl ? <div className="text-[11px] text-muted-foreground mt-1">{tpl.description}</div> : null;
+                })()}
+              </div>
+              {(() => {
+                const tpl = templates.find((t) => t.id === tplId);
+                if (!tpl?.authTokenKey) return null;
+                return (
+                  <div>
+                    <label className="block text-[11px] font-semibold text-muted-foreground mb-1">
+                      {tpl.authTokenKey} <span className="font-normal">(saved to <span className="font-mono">.env</span>; never echoed back)</span>
+                    </label>
+                    <input
+                      type="password"
+                      value={keyValue}
+                      onChange={(e) => setKeyValue(e.target.value)}
+                      placeholder="paste key…"
+                      className="w-full text-[12px] rounded border border-border bg-background px-2 py-1 font-mono"
+                      data-testid="mcp-add-key"
+                    />
+                  </div>
+                );
+              })()}
+              <div className="flex gap-2">
+                <Button onClick={() => { void addServer(); }} disabled={saving} data-testid="mcp-add-save">
+                  {saving ? "Saving…" : "Save + Connect"}
+                </Button>
+                <Button onClick={() => { setShowAdd(false); setKeyValue(""); }}>Cancel</Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="pt-2 border-t border-border" data-testid="mcp-env-keys">
+        <h4 className="text-[12px] font-semibold mb-2">.env keys (this project)</h4>
+        {envKeys.length === 0 ? (
+          <div className="text-[12px] text-muted-foreground">No keys set.</div>
+        ) : (
+          <ul className="text-[12px] space-y-1">
+            {envKeys.map((k) => (
+              <li key={k} className="flex items-center justify-between">
+                <span className="font-mono">{k}</span>
+                <button
+                  onClick={() => { void removeEnvKey(k); }}
+                  className="text-[11px] text-muted-foreground hover:text-red"
+                  data-testid={`mcp-env-remove-${k}`}
+                >
+                  remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -19,6 +19,7 @@ import { HostingPanel } from "./HostingPanel.js";
 import { EnvManager } from "./EnvManager.js";
 import { TaskmasterTab } from "./TaskmasterTab.js";
 import { IterativeWorkTab } from "./IterativeWorkTab.js";
+import { MCPTab } from "./MCPTab.js";
 import { ProjectManagement } from "./ProjectManagement.js";
 import type { HostingStatus } from "../api.js";
 import { TreeNav, ContextMenu, useToast } from "@particle-academy/react-fancy";
@@ -318,6 +319,9 @@ export function ProjectDetail({
           {!isCoreFork && <TabsTrigger value="taskmaster">TaskMaster</TabsTrigger>}
           {!isCoreFork && (project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible) && (
             <TabsTrigger value="iterative-work">Iterative Work</TabsTrigger>
+          )}
+          {!isCoreFork && project.projectType?.hasCode && (
+            <TabsTrigger value="mcp">MCP</TabsTrigger>
           )}
           {!isCoreFork && pluginPanels.map((p) => (
             <TabsTrigger key={p.id} value={`plugin-${p.id}`}>{p.label}</TabsTrigger>
@@ -787,6 +791,12 @@ export function ProjectDetail({
         {(project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible) && (
           <TabsContent value="iterative-work" className="mt-4 flex-1 min-h-0 overflow-y-auto">
             <IterativeWorkTab project={project} />
+          </TabsContent>
+        )}
+
+        {project.projectType?.hasCode && (
+          <TabsContent value="mcp" className="mt-4 flex-1 min-h-0 overflow-y-auto">
+            <MCPTab project={project} />
           </TabsContent>
         )}
 


### PR DESCRIPTION
Whole-feature ship per the new ship-whole-features directive. s125 is from the VIP track.

User-facing: open a project's MCP tab → click 'Add MCP Server' → pick Tynn → paste key (saves to project's .env) → server registers + connects. Aion's mcp + pm tools reach that project's Tynn workspace.

Includes:
- Schema (project.json mcp.servers block)
- Backend (8 endpoints + .env helpers + atomic writes)
- Boot wiring (per-project servers register at gateway start, namespaced \`<slug>:<id>\`)
- Dashboard MCP tab (gated on hasCode; template dropdown; key field; remove/test/list)
- 5 e2e tests (templates endpoint, tab visibility, panel render, form open, full save round-trip with cleanup)

Closes s125 tasks t474-t479.