### PR TITLE
v0.4.516: fix(upgrade) stash dirty Local-ID tree before pull-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.515",
+  "version": "0.4.516",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -309,6 +309,17 @@ fi
 id_version_before="$(cd "$ID_DIR" 2>/dev/null && node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")"
 if [ -d "$ID_DIR/.git" ]; then
   emit "pull-id" "start"
+  # The build runs scripts/sync-schema.sh as a prebuild hook which copies
+  # @agi/db-schema files into src/db/schema/ — that dirties the working
+  # tree. Subsequent git checkout would fail with "local changes would be
+  # overwritten". Discard the sync-schema modifications first; the prebuild
+  # hook will regenerate them. Mirrors the /opt/agi dirty-tree handler at
+  # the top of this script.
+  if [ -n "$(cd "$ID_DIR" && git diff --name-only 2>/dev/null)" ]; then
+    ID_DIRTY="$(cd "$ID_DIR" && git diff --name-only | tr '\n' ', ')"
+    emit "pull-id" "error" "ID tree dirty (auto-regenerated schema files): ${ID_DIRTY}— stashing"
+    (cd "$ID_DIR" && git stash --quiet) || true
+  fi
   if (cd "$ID_DIR" && git fetch origin 2>&1 && git checkout -B "$BRANCH" "origin/$BRANCH" 2>&1); then
     emit "pull-id" "done" "ID service repo updated ($BRANCH)"
   else


### PR DESCRIPTION
Single-commit hotfix: prevents the Local-ID upgrade block discovered cycle 213 when owner's agi upgrade after the Plaid feature merge left Local-ID at v0.1.10 because of dirty working tree from sync-schema.sh's regeneration.

Mirrors the existing /opt/agi dirty-tree handler at line 188-192: detect dirty working tree before fetch+checkout, stash it. The prebuild hook regenerates the schema files on next build cycle.

Closes part of t617 (the deploy-recovery half; services-align + services-status fixes in test-vm.sh remain as separate scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)