### PR TITLE
v0.4.517: db-schema connections.dtoken column (s149 t626 prereq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.516",
+  "version": "0.4.517",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/db-schema/src/auth.ts
+++ b/packages/db-schema/src/auth.ts
@@ -122,6 +122,17 @@ export const connections = pgTable(
     refreshToken: text("refresh_token"),
     tokenExpiresAt: timestamp("token_expires_at", { withTimezone: true }),
     scopes: text("scopes"),
+    /**
+     * For proxied providers (Plaid, Google, Discord per s149 cycle 215):
+     * encrypted DToken (delegation token) instead of holding the raw
+     * provider access_token. The DToken is bound to a connection at
+     * Hive-ID; Local-ID forwards it as a Bearer credential to Hive-ID's
+     * proxy gateway. Public-client providers (GitHub device flow) still
+     * use accessToken for the raw token.
+     *
+     * NULL for public-client providers (GitHub) and pre-s149 connections.
+     */
+    dtoken: text("dtoken"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },


### PR DESCRIPTION
Canonical schema source extension for s149 t626 — adds connections.dtoken nullable column. Propagates to Local-ID via sync-schema.sh prebuild hook. Local-ID PR ships in parallel with the route changes that consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)