### PR TITLE
fix(boot): postgres readiness wait + hard exit on boot failure (v0.4.520)

### DIFF
--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -39,8 +39,7 @@ export function registerRunCommand(program: Command): void {
         console.error(
           `Error: ${err instanceof Error ? err.message : String(err)}`,
         );
-        process.exitCode = 1;
-        return;
+        process.exit(1);
       }
 
       const gw = config.gateway ?? { host: "127.0.0.1", port: 3100, state: "OFFLINE" as const };
@@ -64,8 +63,11 @@ export function registerRunCommand(program: Command): void {
         console.error(
           `Error starting gateway: ${err instanceof Error ? err.message : String(err)}`,
         );
-        process.exitCode = 1;
-        return;
+        // Hard exit — `process.exitCode = 1; return;` left the process alive
+        // when DB pools / file watchers / half-initialized Fastify held open
+        // handles, causing systemd self-heal to never fire. Force exit so
+        // systemd restarts the unit cleanly.
+        process.exit(1);
       }
 
       // Graceful shutdown on SIGINT / SIGTERM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.519",
+  "version": "0.4.520",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/db-schema/src/client.ts
+++ b/packages/db-schema/src/client.ts
@@ -55,3 +55,55 @@ export function createDbClient(options: CreateDbClientOptions = {}): DbClient {
   const db = drizzle(pool, { schema });
   return { pool, db };
 }
+
+export interface WaitForDbOptions {
+  /** Total budget in ms before giving up. Default 20_000. */
+  timeoutMs?: number;
+  /** Initial backoff in ms; doubles up to 2_000ms. Default 250. */
+  initialDelayMs?: number;
+  /** Optional logger for retry attempts. */
+  onAttempt?: (attempt: number, lastError: Error | null) => void;
+}
+
+/**
+ * Block until the pool can accept a query, or throw after the timeout.
+ *
+ * Boot order race: when the host reboots, systemd starts the gateway at the
+ * same time the postgres container is coming up. The first DB query can
+ * reject with ECONNREFUSED / "the database system is starting up" before
+ * postgres is ready. Without this wait, the rejection lands in the global
+ * unhandled-rejection safety net and the gateway zombies — process alive,
+ * Fastify never bound. With this wait, the failure becomes a fatal boot
+ * error and systemd restarts cleanly.
+ */
+export async function waitForDb(pool: Pool, options: WaitForDbOptions = {}): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 20_000;
+  const initialDelayMs = options.initialDelayMs ?? 250;
+  const deadline = Date.now() + timeoutMs;
+  let delay = initialDelayMs;
+  let attempt = 0;
+  let lastError: Error | null = null;
+  while (Date.now() < deadline) {
+    attempt += 1;
+    try {
+      const client = await pool.connect();
+      try {
+        await client.query("select 1");
+      } finally {
+        client.release();
+      }
+      return;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (options.onAttempt !== undefined) options.onAttempt(attempt, lastError);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((r) => setTimeout(r, Math.min(delay, remaining)));
+      delay = Math.min(delay * 2, 2_000);
+    }
+  }
+  throw new Error(
+    `Database not ready after ${String(timeoutMs)}ms (${String(attempt)} attempts). ` +
+      `Last error: ${lastError?.message ?? "unknown"}`,
+  );
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -45,7 +45,7 @@ function resolveAgiVersion(selfRepoPath: string | undefined): string {
 }
 import { EntityStore, MessageQueue, CommsLog, NotificationStore, IncidentStore, VendorStore, SessionStore as ComplianceSessionStore, ConsentStore, UsageStore } from "@agi/entity-model";
 import type { Entity } from "@agi/entity-model";
-import { createDbClient } from "@agi/db-schema/client";
+import { createDbClient, waitForDb } from "@agi/db-schema/client";
 import { BackupManager } from "./backup-manager.js";
 import { registerComplianceRoutes } from "./compliance-api.js";
 import { registerSecurityRoutes } from "./security-api.js";
@@ -428,6 +428,21 @@ export async function startGatewayServer(
   // -------------------------------------------------------------------------
 
   const { db, pool: dbPool } = createDbClient();
+
+  // Wait for postgres to accept queries before any store touches it.
+  // After a host reboot, systemd starts the gateway at the same time as the
+  // postgres container; the first query can race ahead of postgres readiness
+  // and reject with ECONNREFUSED. Without this wait, that rejection lands in
+  // the global safety net and the gateway zombies — process alive, Fastify
+  // never bound. The throw here is fatal: it propagates to run.ts and exits
+  // the process so systemd can restart cleanly.
+  await waitForDb(dbPool, {
+    onAttempt: (attempt, err) => {
+      if (attempt === 1) return;
+      log.warn(`waiting for postgres (attempt ${String(attempt)}): ${err?.message ?? "unknown"}`);
+    },
+  });
+
   const entityStore = new EntityStore(db);
   const messageQueue = new MessageQueue(db);
   const coaLogger = new COAChainLogger(db);


### PR DESCRIPTION
## Summary
- After host reboot, gateway raced ahead of postgres container and zombied (process alive, Fastify never bound). Two-part fix.
- `waitForDb(pool)` helper: `SELECT 1` with exponential backoff up to 20s budget; throws on timeout.
- `server.ts`: await readiness right after `createDbClient` before any store query touches the pool.
- `run.ts`: replace soft `process.exitCode = 1; return;` with hard `process.exit(1)` in both boot catches so systemd self-heal actually fires (open DB pool / file watcher handles were keeping the half-dead process alive).

## Why
Owner hit this exact zombie state tonight after a driver-update reboot. Self-heal didn't trigger because the process never exited; the safety net swallowed the boot rejection. v0.4.520 closes both halves: ready before query, exit hard if anything in boot still throws.

## Test plan
- [x] typecheck clean
- [x] route-check clean (326 routes)
- [x] docs-check clean
- [x] staged-check clean
- [ ] Owner: `agi upgrade` → reboot host → confirm gateway comes up clean without manual restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)