### PR TITLE
fix(caddy): host.containers.internal entry in agi-caddy unit (v0.4.521)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.520",
+  "version": "0.4.521",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/agi-caddy.service
+++ b/scripts/agi-caddy.service
@@ -25,6 +25,7 @@ ExecStart=/usr/bin/podman run \
 	-d \
 	--name agi-caddy \
 	--network=aionima \
+	--add-host=host.containers.internal:host-gateway \
 	-v /etc/caddy/Caddyfile:/etc/caddy/Caddyfile:ro \
 	-v %h/.local/share/agi-caddy/data:/data \
 	-v %h/.local/share/agi-caddy/config:/config \


### PR DESCRIPTION
## Summary
- After host reboot + podman daemon restart, agi-caddy came up with empty ExtraHosts. With podman 4.x + netavark + custom network (`--network=aionima`), `host.containers.internal` is NOT auto-injected — needs `--add-host=host.containers.internal:host-gateway`.
- All Caddy reverse_proxy directives that target `host.containers.internal:3100` returned 502 Bad Gateway, so the dashboard at https://ai.on/ was unreachable.
- One-line fix to scripts/agi-caddy.service.

## Verification
- Owner's running production: copied updated unit to `~/.config/systemd/user/`, daemon-reload + restart agi-caddy → `https://ai.on/` returns 200, `https://id.ai.on/` returns 302 (expected Local-ID redirect).
- ExtraHosts on container now: `[host.containers.internal:host-gateway]`.

## Test plan
- [x] typecheck clean
- [x] route-check clean (326 routes)
- [x] docs-check clean
- [x] Production dashboard reachable after fix applied
- [ ] Future host reboot: agi-caddy comes up with the entry intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)