### PR TITLE
feat(machine): dynamic GPU + Thunderbolt detection (v0.4.522)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.521",
+  "version": "0.4.522",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hardware-probe.ts
+++ b/packages/gateway-core/src/hardware-probe.ts
@@ -1,0 +1,168 @@
+/**
+ * Hardware probes — GPU enumeration + Thunderbolt/USB4 enumeration.
+ *
+ * These run shell tools (lspci, nvidia-smi, boltctl) via execFileSync with
+ * short timeouts and degrade gracefully when the tool is missing. Used by
+ * the Machine page's complete-snapshot view; detection-driven so the page
+ * dynamically reflects whatever is actually plugged in.
+ */
+
+import { execFileSync } from "node:child_process";
+
+function safeRun(file: string, args: string[], timeoutMs = 5_000): string {
+  try {
+    return execFileSync(file, args, { timeout: timeoutMs, stdio: "pipe" }).toString().trim();
+  } catch {
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GPU probe — enumerate every PCIe display device (VGA / 3D / Display
+// controller class) via `lspci -D -k`, then overlay nvidia-smi data when
+// available. Returns one row per device regardless of vendor; the frontend
+// renders all of them. Detection-driven, no hardcoded NVIDIA assumption.
+// ---------------------------------------------------------------------------
+
+export interface GpuDevice {
+  /** PCI address — "0000:c5:00.0" (domain:bus:device.function). */
+  busId: string;
+  /** lspci device class — VGA / 3D / Display. */
+  classDesc: string;
+  /** Vendor name, normalized to short form when known. */
+  vendor: string;
+  /** Device name + revision. */
+  model: string;
+  /** Kernel module currently bound (`nvidia`, `amdgpu`, `i915`, …) or null. */
+  driver: string | null;
+  /** Total VRAM in MiB. NVIDIA-only — populated from nvidia-smi when present. */
+  memoryMB: number | null;
+  /** Userspace driver version. NVIDIA-only — populated from nvidia-smi when present. */
+  driverVersion: string | null;
+}
+
+const VENDOR_PREFIXES = [
+  "NVIDIA Corporation",
+  "Advanced Micro Devices, Inc. [AMD/ATI]",
+  "Advanced Micro Devices, Inc.",
+  "Intel Corporation",
+  "Matrox Electronics Systems Ltd.",
+  "ASPEED Technology, Inc.",
+  "VMware",
+  "Red Hat, Inc.",
+];
+
+export function probeGpus(): GpuDevice[] {
+  const out = safeRun("lspci", ["-D", "-k"], 5_000);
+  if (!out) return [];
+  const devices: GpuDevice[] = [];
+  // Each device occupies one line at column 0 plus indented continuation
+  // lines. Split before any line that starts with a hex digit.
+  const blocks = out.split(/\n(?=[0-9a-f])/i);
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    const head = lines[0] ?? "";
+    const m = /^([\w:.]+)\s+(VGA compatible controller|3D controller|Display controller):\s+(.+)$/.exec(head);
+    if (!m?.[1] || !m[2] || !m[3]) continue;
+    const busId = m[1];
+    const classDesc = m[2];
+    const rest = m[3];
+    let vendor = "Unknown";
+    let model = rest;
+    for (const v of VENDOR_PREFIXES) {
+      if (rest.startsWith(`${v} `)) {
+        vendor = v;
+        model = rest.slice(v.length + 1);
+        break;
+      }
+    }
+    let driver: string | null = null;
+    for (const line of lines) {
+      const dm = /^\s+Kernel driver in use:\s*(\S+)/.exec(line);
+      if (dm?.[1]) {
+        driver = dm[1];
+        break;
+      }
+    }
+    devices.push({ busId, classDesc, vendor, model, driver, memoryMB: null, driverVersion: null });
+  }
+  // Overlay NVIDIA-specific fields when nvidia-smi is installed.
+  const smi = safeRun(
+    "nvidia-smi",
+    ["--query-gpu=pci.bus_id,memory.total,driver_version", "--format=csv,noheader,nounits"],
+    3_000,
+  );
+  if (smi) {
+    for (const row of smi.split("\n")) {
+      const cols = row.split(",").map((s) => s.trim());
+      if (cols.length < 3 || !cols[0]) continue;
+      const smiBus = cols[0].toLowerCase();
+      const memMb = Number(cols[1]);
+      const driverVersion = cols[2] ?? "";
+      // nvidia-smi reports 8-hex-digit PCI domain ("00000000:C5:00.0"); lspci
+      // uses 4-digit ("0000:c5:00.0"). Match on the trailing :BB:DD.F portion.
+      const tail = smiBus.slice(-9);
+      for (const dev of devices) {
+        if (dev.busId.toLowerCase().endsWith(tail)) {
+          dev.memoryMB = Number.isFinite(memMb) ? memMb : null;
+          dev.driverVersion = driverVersion || null;
+          break;
+        }
+      }
+    }
+  }
+  return devices;
+}
+
+// ---------------------------------------------------------------------------
+// Thunderbolt / USB4 probe — surfaces every Thunderbolt domain and connected
+// device known to bolt(8). Reads `boltctl list -a` (the userspace daemon's
+// view; matches what the kernel exposes via /sys/bus/thunderbolt/devices/).
+// Fully degrades to { available: false } when boltctl is not installed or
+// the system has no Thunderbolt controllers.
+// ---------------------------------------------------------------------------
+
+export interface ThunderboltDevice {
+  name: string;
+  /** "host" (a system port) or "peripheral" (a connected enclosure). */
+  type: string;
+  vendor: string;
+  /** "USB4" | "Thunderbolt 4" | "Thunderbolt 3" | etc. */
+  generation: string;
+  /** "authorized" | "auth-error" | "pending" | etc. */
+  status: string;
+  uuid: string;
+}
+
+export interface ThunderboltInfo {
+  available: boolean;
+  devices: ThunderboltDevice[];
+}
+
+export function probeThunderbolt(): ThunderboltInfo {
+  const out = safeRun("boltctl", ["list", "-a"], 3_000);
+  if (!out) return { available: false, devices: [] };
+  const devices: ThunderboltDevice[] = [];
+  // Each device starts with a line beginning with " * "; attribute lines
+  // start with "   |- key: value" or "   `- key: value".
+  const blocks = out.split(/\n(?=\s*\*\s)/);
+  for (const block of blocks) {
+    const headMatch = /^\s*\*\s+(.+)/.exec(block);
+    if (!headMatch?.[1]) continue;
+    const name = headMatch[1].trim();
+    const get = (key: string): string => {
+      const re = new RegExp(`[|\`]-\\s+${key}:\\s+(.+)`);
+      const m = re.exec(block);
+      return m?.[1]?.trim() ?? "";
+    };
+    devices.push({
+      name,
+      type: get("type"),
+      vendor: get("vendor"),
+      generation: get("generation"),
+      status: get("status"),
+      uuid: get("uuid"),
+    });
+  }
+  return { available: true, devices };
+}

--- a/packages/gateway-core/src/machine-admin-api.ts
+++ b/packages/gateway-core/src/machine-admin-api.ts
@@ -14,6 +14,8 @@ import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { hostname, arch, cpus, totalmem } from "node:os";
 import { promisify } from "node:util";
 import { createComponentLogger } from "./logger.js";
+import { probeGpus, probeThunderbolt } from "./hardware-probe.js";
+import type { GpuDevice, ThunderboltInfo } from "./hardware-probe.js";
 import type { Logger } from "./logger.js";
 import type { DashboardUserStore, DashboardRole } from "./dashboard-user-store.js";
 import { hasRole } from "./dashboard-user-store.js";
@@ -266,6 +268,8 @@ export function registerMachineAdminRoutes(
       const cpu = probeCpuDetail();
       const storage = probeStorage();
       const networkInterfaces = probeNetworkInterfaces();
+      const gpus: GpuDevice[] = probeGpus();
+      const thunderbolt: ThunderboltInfo = probeThunderbolt();
 
       // OS / kernel
       let distro = "Unknown";
@@ -315,6 +319,8 @@ export function registerMachineAdminRoutes(
         },
         storage,
         network: networkInterfaces,
+        gpus,
+        thunderbolt,
       });
     } catch (e) {
       log.error(`Failed to get machine hardware snapshot: ${e instanceof Error ? e.message : String(e)}`);

--- a/ui/dashboard/src/components/MachineAdmin.tsx
+++ b/ui/dashboard/src/components/MachineAdmin.tsx
@@ -194,6 +194,54 @@ function HardwareSnapshotCard() {
         <Field label="Total Bytes" value={bytesToHuman(d.memory.totalBytes)} />
       </div>
 
+      {/* Graphics — GPUs detected via lspci, with NVIDIA enrichment when available. */}
+      {d.gpus.length > 0 && (
+        <>
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground mb-2 mt-4">Graphics</div>
+          <div className="flex flex-col gap-1.5 mb-4">
+            {d.gpus.map((g) => (
+              <div key={g.busId} className="flex items-start gap-3 text-[12px] py-1 border-b border-border last:border-b-0">
+                <code className="text-foreground w-28">{g.busId}</code>
+                <span className="text-muted-foreground w-24 truncate" title={g.classDesc}>{g.classDesc.replace(/ controller$/i, "").replace(/ compatible$/i, "")}</span>
+                <span className="text-foreground w-32 truncate" title={g.vendor}>{g.vendor.replace(/ Corporation$/, "").replace(/ Inc\.\s*\[AMD\/ATI\]$/, " (AMD)").replace(/, Inc\.$/, "")}</span>
+                <span className="text-foreground flex-1 truncate" title={g.model}>{g.model}</span>
+                <span className="text-muted-foreground text-[11px] w-20 truncate">
+                  {g.memoryMB !== null ? `${(g.memoryMB / 1024).toFixed(g.memoryMB >= 8192 ? 0 : 1)} GB` : ""}
+                </span>
+                <span className={cn(
+                  "px-1.5 rounded text-[10px]",
+                  g.driver ? "bg-green/15 text-green" : "bg-muted text-muted-foreground",
+                )}>{g.driver ?? "no driver"}</span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Thunderbolt / USB4 — detected via boltctl. Hidden when no controllers. */}
+      {d.thunderbolt.available && d.thunderbolt.devices.length > 0 && (
+        <>
+          <div className="text-[11px] uppercase tracking-wide text-muted-foreground mb-2 mt-4">Thunderbolt / USB4</div>
+          <div className="flex flex-col gap-1.5 mb-4">
+            {d.thunderbolt.devices.map((tb) => (
+              <div key={tb.uuid || tb.name} className="flex items-start gap-3 text-[12px] py-1 border-b border-border last:border-b-0">
+                <span className="text-foreground w-32 truncate" title={tb.name}>{tb.name}</span>
+                <span className={cn(
+                  "px-1.5 rounded text-[10px]",
+                  tb.type === "host" ? "bg-blue/15 text-blue" : "bg-purple/15 text-purple",
+                )}>{tb.type || "—"}</span>
+                <span className="text-muted-foreground w-20 truncate">{tb.generation}</span>
+                <span className={cn(
+                  "px-1.5 rounded text-[10px]",
+                  tb.status === "authorized" ? "bg-green/15 text-green" : "bg-amber/15 text-amber",
+                )}>{tb.status || "—"}</span>
+                <code className="text-muted-foreground text-[10px] flex-1 truncate" title={tb.uuid}>{tb.uuid}</code>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
       {/* Storage */}
       {d.storage.length > 0 && (
         <>

--- a/ui/dashboard/src/routes/resources.tsx
+++ b/ui/dashboard/src/routes/resources.tsx
@@ -9,7 +9,7 @@ import { ResourceUsage } from "@/components/ResourceUsage.js";
 import { PageScroll } from "@/components/PageScroll.js";
 import { Card } from "@/components/ui/card.js";
 import { fetchDatabaseStorage } from "@/api.js";
-import { useHFContainerStats } from "@/hooks.js";
+import { useHFContainerStats, useMachineHardware } from "@/hooks.js";
 import type { HFContainerStats } from "@/api.js";
 
 function formatBytes(bytes: number): string {
@@ -178,6 +178,24 @@ function ModelContainerStatsSection() {
 function PowerGaugeSection() {
   const [power, setPower] = useState<{ cpuWatts: number | null; gpuWatts: number | null } | null>(null);
   const [energyToday, setEnergyToday] = useState<number | null>(null);
+  const hw = useMachineHardware();
+
+  // Detect-driven sub-labels: replace the previous hardcoded "RAPL / intel-rapl"
+  // and "NVML / nvidia-smi" strings with what's actually present on this box.
+  const cpuVendor = hw.data?.cpu.vendorId.toLowerCase() ?? "";
+  const cpuSubLabel =
+    cpuVendor.includes("intel") ? "RAPL / intel-rapl" :
+    cpuVendor.includes("amd")   ? "RAPL / amd-rapl" :
+    cpuVendor !== ""            ? "RAPL" :
+                                  "—";
+  const gpus = hw.data?.gpus ?? [];
+  const nvidiaGpu = gpus.find((g) => g.driver === "nvidia");
+  const otherGpu  = gpus.find((g) => g.driver !== null && g.driver !== "nvidia");
+  const gpuSubLabel =
+    nvidiaGpu ? `NVML — ${nvidiaGpu.model.replace(/^[A-Z0-9]+\s+\[/, "").replace(/\]\s*\(rev.*$/, "").replace(/\s*\(rev.*$/, "")}` :
+    otherGpu  ? `${otherGpu.driver} — power not sampled` :
+    gpus.length > 0 ? "no power sampler for detected GPU" :
+                      "no GPU detected";
 
   useEffect(() => {
     let cancelled = false;
@@ -209,12 +227,12 @@ function PowerGaugeSection() {
       <div>
         <span className="text-[9px] text-muted-foreground uppercase tracking-wider">CPU power</span>
         <div className="text-[22px] font-bold text-foreground mt-0.5 tabular-nums">{cpuStr}</div>
-        <div className="text-[10px] text-muted-foreground mt-0.5">RAPL / intel-rapl</div>
+        <div className="text-[10px] text-muted-foreground mt-0.5">{cpuSubLabel}</div>
       </div>
       <div>
         <span className="text-[9px] text-muted-foreground uppercase tracking-wider">GPU power</span>
         <div className="text-[22px] font-bold text-foreground mt-0.5 tabular-nums">{gpuStr}</div>
-        <div className="text-[10px] text-muted-foreground mt-0.5">NVML / nvidia-smi</div>
+        <div className="text-[10px] text-muted-foreground mt-0.5">{gpuSubLabel}</div>
       </div>
       <div>
         <span className="text-[9px] text-muted-foreground uppercase tracking-wider">Energy today</span>

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -882,6 +882,26 @@ export interface MachineHardware {
     addresses: string[];
     state: string;
   }>;
+  gpus: Array<{
+    busId: string;
+    classDesc: string;
+    vendor: string;
+    model: string;
+    driver: string | null;
+    memoryMB: number | null;
+    driverVersion: string | null;
+  }>;
+  thunderbolt: {
+    available: boolean;
+    devices: Array<{
+      name: string;
+      type: string;
+      vendor: string;
+      generation: string;
+      status: string;
+      uuid: string;
+    }>;
+  };
 }
 
 export interface LinuxUser {


### PR DESCRIPTION
## Summary
- Machine page + Resources page were missing GPU information entirely (no probe in `/api/machine/hardware`) and had hardcoded RAPL/NVML sub-labels that lied about non-Intel/non-NVIDIA hardware.
- New `packages/gateway-core/src/hardware-probe.ts`: `probeGpus()` (lspci -D -k + nvidia-smi overlay) and `probeThunderbolt()` (boltctl list -a). Both degrade gracefully when their tool is missing.
- Wired into `/api/machine/hardware` as `gpus[]` and `thunderbolt`.
- UI: new Graphics section + Thunderbolt/USB4 section in `HardwareSnapshotCard`. Resources `PowerGaugeSection` sub-labels now reflect detected CPU vendor + GPU vendor/driver/model.
- When hardware changes (eGPU plugged in, GPU swapped), the next page load reflects new state — all probes run at request time, no caching.

## Verified on owner's machine
```
GPUs:
  0000:c5:00.0  VGA compatible controller  NVIDIA Corporation  GA107 [GeForce RTX 3050 6GB] (rev a1)  driver=nvidia  6144 MB  v595.58.03
  0000:c6:00.0  Display controller         AMD/ATI             Device 150e (rev e4)                   driver=amdgpu

Thunderbolt:
  Micro Computer (HK) Tech Limited AI Series  host  USB4  authorized  c0b63804-e0b6-c44e-...
  Micro Computer (HK) Tech Limited AI Series  host  USB4  authorized  c0b63804-e1b6-c44e-...
```

Note: the eGPU dock owner mentioned does NOT appear as a Thunderbolt peripheral — boltctl only sees the two USB4 host controllers, not a connected enclosure. If the dock is connected via USB-A or via a PCIe-passthrough that doesn't go through bolt(8), the Machine page will show that honestly. Surfacing the absence is itself useful — owner can now see what AGI sees.

## Test plan
- [x] typecheck clean
- [x] route-check clean (326 routes)
- [x] docs-check clean
- [x] live probe sanity-check on owner's machine (output above)
- [ ] Owner: `agi upgrade` → /admin (Machine page) shows Graphics + Thunderbolt sections
- [ ] Owner: /resources shows real CPU/GPU sub-labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)