### PR TITLE
feat(resources): live per-GPU stats (v0.4.523)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.522",
+  "version": "0.4.523",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hardware-probe.ts
+++ b/packages/gateway-core/src/hardware-probe.ts
@@ -166,3 +166,56 @@ export function probeThunderbolt(): ThunderboltInfo {
   }
   return { available: true, devices };
 }
+
+// ---------------------------------------------------------------------------
+// Live per-GPU stats — utilization, VRAM, temp, power. Sampled every poll.
+// NVIDIA path uses nvidia-smi --query-gpu (single shell-out covers all
+// fields). AMD path is a future addition (rocm-smi --showuse --showmemuse
+// --showtemp --showpower) once the iGPU vs dGPU enrichment matters more.
+// ---------------------------------------------------------------------------
+
+export interface GpuLiveStats {
+  busId: string;
+  name: string;
+  gpuUtilPct: number | null;
+  memUtilPct: number | null;
+  memUsedMB: number | null;
+  memTotalMB: number | null;
+  tempC: number | null;
+  powerW: number | null;
+  powerLimitW: number | null;
+}
+
+export function probeGpuStats(): GpuLiveStats[] {
+  const out = safeRun(
+    "nvidia-smi",
+    [
+      "--query-gpu=pci.bus_id,name,utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu,power.draw,power.limit",
+      "--format=csv,noheader,nounits",
+    ],
+    3_000,
+  );
+  if (!out) return [];
+  const rows: GpuLiveStats[] = [];
+  for (const row of out.split("\n")) {
+    const cols = row.split(",").map((s) => s.trim());
+    if (cols.length < 9 || !cols[0]) continue;
+    const num = (s: string | undefined): number | null => {
+      if (s === undefined || s === "" || s === "[N/A]" || s === "[Not Supported]") return null;
+      const n = Number(s);
+      return Number.isFinite(n) ? n : null;
+    };
+    rows.push({
+      busId: cols[0]!.toLowerCase(),
+      name: cols[1] ?? "",
+      gpuUtilPct: num(cols[2]),
+      memUtilPct: num(cols[3]),
+      memUsedMB: num(cols[4]),
+      memTotalMB: num(cols[5]),
+      tempC: num(cols[6]),
+      powerW: num(cols[7]),
+      powerLimitW: num(cols[8]),
+    });
+  }
+  return rows;
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -33,6 +33,8 @@ import type { EntityStore, CommsLog, NotificationStore } from "@agi/entity-model
 import { fetchOwnerToken, injectTokenIntoCloneUrl } from "./dev-mode-auth.js";
 import { createComponentLogger } from "./logger.js";
 import type { Logger } from "./logger.js";
+import { probeGpuStats } from "./hardware-probe.js";
+import type { GpuLiveStats } from "./hardware-probe.js";
 import { CpuPowerSampler, GpuPowerSampler } from "./system-power.js";
 import { appRouter, type AppContext } from "@agi/trpc-api";
 import type { HostingManager } from "./hosting-manager.js";
@@ -3924,6 +3926,10 @@ export async function createGatewayRuntimeState(
     // socket CPU aggregate), multi-GPU aggregation.
     const cpuWatts = cpuPowerSampler.sample();
     const gpuWatts = gpuPowerSampler.sample();
+    // Per-GPU live stats (utilization, VRAM, temp, power). NVIDIA only via
+    // nvidia-smi today; AMD ROCm enrichment planned. Empty array on hosts
+    // without nvidia-smi installed.
+    const gpuStats: GpuLiveStats[] = probeGpuStats();
 
     return reply.send({
       cpu: { loadAvg, cores, usage: cpuUsage },
@@ -3931,6 +3937,7 @@ export async function createGatewayRuntimeState(
       disk: { total: diskTotal, used: diskUsed, free: diskFree, percent: diskPercent },
       diskIO,
       power: { cpuWatts, gpuWatts },
+      gpus: gpuStats,
       uptime: os.uptime(),
       hostname: os.hostname(),
     });

--- a/ui/dashboard/src/routes/resources.tsx
+++ b/ui/dashboard/src/routes/resources.tsx
@@ -249,6 +249,119 @@ function PowerGaugeSection() {
 }
 
 // ---------------------------------------------------------------------------
+// GPU live stats — per-GPU utilization, VRAM, temperature, power. Polls
+// /api/system/stats every 5s. Hidden when no GPUs report stats (no
+// nvidia-smi installed or no NVIDIA hardware). AMD ROCm enrichment is a
+// follow-up; today only NVIDIA fills these fields.
+// ---------------------------------------------------------------------------
+
+interface GpuLiveRow {
+  busId: string;
+  name: string;
+  gpuUtilPct: number | null;
+  memUtilPct: number | null;
+  memUsedMB: number | null;
+  memTotalMB: number | null;
+  tempC: number | null;
+  powerW: number | null;
+  powerLimitW: number | null;
+}
+
+function GpuLiveSection() {
+  const [gpus, setGpus] = useState<GpuLiveRow[]>([]);
+  const hw = useMachineHardware();
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async (): Promise<void> => {
+      try {
+        const r = await fetch("/api/system/stats");
+        if (!r.ok) return;
+        const j = await r.json() as { gpus?: GpuLiveRow[] };
+        if (!cancelled) setGpus(j.gpus ?? []);
+      } catch { /* ignore */ }
+    };
+    void refresh();
+    const id = window.setInterval(() => { void refresh(); }, 5_000);
+    return (): void => { cancelled = true; window.clearInterval(id); };
+  }, []);
+
+  // Surface non-NVIDIA GPUs the static hardware probe found, even when we
+  // have no live stats for them — owner can see they exist + which driver.
+  const detected = hw.data?.gpus ?? [];
+  const nonNvidiaDetected = detected.filter((g) => g.driver !== null && g.driver !== "nvidia");
+
+  if (gpus.length === 0 && nonNvidiaDetected.length === 0) {
+    return (
+      <div className="text-[11px] text-muted-foreground">
+        No GPU stats available. Install nvidia-smi or rocm-smi to surface live utilization, VRAM, and temperature.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {gpus.map((g) => {
+        const memPct = g.memTotalMB && g.memUsedMB !== null
+          ? Math.round((g.memUsedMB / g.memTotalMB) * 100) : null;
+        const memUsedGB = g.memUsedMB !== null  ? (g.memUsedMB  / 1024).toFixed(1) : "—";
+        const memTotalGB = g.memTotalMB !== null ? (g.memTotalMB / 1024).toFixed(1) : "—";
+        return (
+          <div key={g.busId} className="border border-border rounded p-3">
+            <div className="flex items-center justify-between mb-2">
+              <div>
+                <div className="text-[12px] font-medium text-foreground">{g.name}</div>
+                <code className="text-[10px] text-muted-foreground">{g.busId}</code>
+              </div>
+              <div className="text-right text-[10px] text-muted-foreground">
+                {g.tempC !== null ? <span className="mr-3">{g.tempC}°C</span> : null}
+                {g.powerW !== null
+                  ? <span>{g.powerW.toFixed(1)} W{g.powerLimitW !== null ? <span className="text-muted-foreground"> / {g.powerLimitW.toFixed(0)} W</span> : null}</span>
+                  : null}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+                  <span>Core utilization</span>
+                  <span className="tabular-nums text-foreground">{g.gpuUtilPct !== null ? `${g.gpuUtilPct}%` : "—"}</span>
+                </div>
+                <BarGauge pct={g.gpuUtilPct ?? 0} />
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+                  <span>VRAM</span>
+                  <span className="tabular-nums text-foreground">{memUsedGB} / {memTotalGB} GB{memPct !== null ? ` (${String(memPct)}%)` : ""}</span>
+                </div>
+                <BarGauge pct={memPct ?? 0} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      {nonNvidiaDetected.map((g) => (
+        <div key={g.busId} className="border border-border rounded p-3 opacity-70">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-[12px] font-medium text-foreground">
+                {g.vendor.replace(/, Inc\.\s*\[AMD\/ATI\]$/, " (AMD)").replace(/ Corporation$/, "").replace(/, Inc\.$/, "")} — {g.model.replace(/\s*\(rev.*$/, "")}
+              </div>
+              <code className="text-[10px] text-muted-foreground">{g.busId}</code>
+            </div>
+            <div className="text-[10px] text-muted-foreground">
+              driver: <span className="text-foreground">{g.driver}</span>
+            </div>
+          </div>
+          <div className="text-[10px] text-muted-foreground mt-1">
+            Live stats not yet sampled for this driver — utilization/VRAM/temp/power need rocm-smi or i915-perf integration (planned).
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 
 export default function ResourcesPage() {
   return (
@@ -258,6 +371,12 @@ export default function ResourcesPage() {
         <Card className="p-4">
           <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">Power</h3>
           <PowerGaugeSection />
+        </Card>
+      </div>
+      <div className="mt-4">
+        <Card className="p-4">
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">GPUs</h3>
+          <GpuLiveSection />
         </Card>
       </div>
       <div className="mt-4">


### PR DESCRIPTION
## Summary
- Owner asked for per-GPU core utilization and VRAM (only Power was shown).
- Added \`probeGpuStats()\` in hardware-probe.ts — single nvidia-smi query for pci.bus_id, name, utilization.gpu, utilization.memory, memory.used, memory.total, temperature.gpu, power.draw, power.limit.
- Wired into \`/api/system/stats\` response under \`gpus[]\`.
- New \`GpuLiveSection\` Card on Resources page polls every 5s, renders one bordered card per GPU with: name + bus, temp + power/limit, core util bar, VRAM used/total bar with pct.
- Non-NVIDIA GPUs from the static probe (AMD iGPU on owner's box) are surfaced too with a 'live stats not yet sampled for this driver' note — visible but flagged as needing rocm-smi integration.

## Verified on owner's machine
\`\`\`
[
  {
    \"busId\": \"00000000:c5:00.0\",
    \"name\": \"NVIDIA GeForce RTX 3050\",
    \"gpuUtilPct\": 8,
    \"memUtilPct\": 1,
    \"memUsedMB\": 392,
    \"memTotalMB\": 6144,
    \"tempC\": 56,
    \"powerW\": 18.24,
    \"powerLimitW\": 70
  }
]
\`\`\`

## Test plan
- [x] typecheck clean
- [x] route-check clean (326 routes)
- [x] docs-check clean
- [x] live probe sanity-check on owner's machine (RTX 3050 stats above)
- [ ] Owner: \`agi upgrade\` → /resources shows new GPUs card with live bars

🤖 Generated with [Claude Code](https://claude.com/claude-code)