### PR TITLE
feat(resources): calendar-style heatmaps (v0.4.524)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.523",
+  "version": "0.4.524",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -3817,6 +3817,25 @@ export async function createGatewayRuntimeState(
     return usage;
   }
 
+  // Per-core CPU utilization — same delta-based sampling but reported as
+  // one value per logical CPU. Powers the per-core heatmap on the
+  // Resources page.
+  async function getCpuPerCore(): Promise<number[]> {
+    const os = await import("node:os");
+    const cpus1 = os.cpus();
+    await new Promise((r) => setTimeout(r, 100));
+    const cpus2 = os.cpus();
+    const result: number[] = [];
+    for (let i = 0; i < cpus1.length; i++) {
+      const c1 = cpus1[i]!.times;
+      const c2 = cpus2[i]!.times;
+      const idle = c2.idle - c1.idle;
+      const total = (c2.user - c1.user) + (c2.nice - c1.nice) + (c2.sys - c1.sys) + (c2.irq - c1.irq) + idle;
+      result.push(total > 0 ? Math.round(((total - idle) / total) * 100) : 0);
+    }
+    return result;
+  }
+
   // Disk I/O tracking — reads /proc/diskstats for the root volume device
   let rootDiskDevice = "";
   try {
@@ -3930,9 +3949,11 @@ export async function createGatewayRuntimeState(
     // nvidia-smi today; AMD ROCm enrichment planned. Empty array on hosts
     // without nvidia-smi installed.
     const gpuStats: GpuLiveStats[] = probeGpuStats();
+    // Per-core CPU utilization for the per-core heatmap.
+    const cpuPerCore = await getCpuPerCore();
 
     return reply.send({
-      cpu: { loadAvg, cores, usage: cpuUsage },
+      cpu: { loadAvg, cores, usage: cpuUsage, perCore: cpuPerCore },
       memory: { total: totalMem, free: freeMem, used: usedMem, percent: memPercent },
       disk: { total: diskTotal, used: diskUsed, free: diskFree, percent: diskPercent },
       diskIO,

--- a/ui/dashboard/src/routes/resources.tsx
+++ b/ui/dashboard/src/routes/resources.tsx
@@ -4,13 +4,16 @@
  * and a Running Model Containers section with per-container CPU/RAM stats.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ResourceUsage } from "@/components/ResourceUsage.js";
 import { PageScroll } from "@/components/PageScroll.js";
 import { Card } from "@/components/ui/card.js";
 import { fetchDatabaseStorage } from "@/api.js";
 import { useHFContainerStats, useMachineHardware } from "@/hooks.js";
 import type { HFContainerStats } from "@/api.js";
+// fancy-echarts (npm published as @particle-academy/react-echarts pending
+// rename per CLAUDE.md § 1.5 — package is the canonical PAx EChart wrapper).
+import { EChart } from "@particle-academy/react-echarts";
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -253,6 +256,12 @@ function PowerGaugeSection() {
 // /api/system/stats every 5s. Hidden when no GPUs report stats (no
 // nvidia-smi installed or no NVIDIA hardware). AMD ROCm enrichment is a
 // follow-up; today only NVIDIA fills these fields.
+//
+// Visualization: ECharts heatmap that renders one cell per "activity unit"
+// (10×10 = 100 cells = percentage points of GPU compute). Cells <= util
+// are green (active), cells > util are blue (idle). Mirrors the calendar-
+// simple aesthetic from echarts.apache.org. NVML doesn't expose per-SM
+// utilization; this is an approximate visualization of aggregate util.
 // ---------------------------------------------------------------------------
 
 interface GpuLiveRow {
@@ -265,6 +274,69 @@ interface GpuLiveRow {
   tempC: number | null;
   powerW: number | null;
   powerLimitW: number | null;
+}
+
+const HEATMAP_COLS = 10;
+const HEATMAP_ROWS = 10;
+const COLOR_ACTIVE = "#10b981"; // emerald-500
+const COLOR_IDLE   = "#1e3a8a"; // blue-900
+
+// Build a 10×10 grid of cells where cells <= pct are 1 ("active") and the
+// rest are 0 ("idle"). Returns ECharts heatmap data shape: [x, y, value].
+function buildActivityHeatmap(pct: number): [number, number, number][] {
+  const filled = Math.round(Math.max(0, Math.min(100, pct)));
+  const data: [number, number, number][] = [];
+  for (let i = 0; i < HEATMAP_COLS * HEATMAP_ROWS; i++) {
+    const x = i % HEATMAP_COLS;
+    const y = Math.floor(i / HEATMAP_COLS);
+    data.push([x, y, i < filled ? 1 : 0]);
+  }
+  return data;
+}
+
+function activityHeatmapOption(pct: number, tooltipLabel: string): Record<string, unknown> {
+  return {
+    grid: { left: 4, right: 4, top: 4, bottom: 4, containLabel: false },
+    tooltip: {
+      formatter: (): string => `${tooltipLabel}: ${String(Math.round(pct))}%`,
+    },
+    xAxis: {
+      type: "category",
+      data: Array.from({ length: HEATMAP_COLS }, (_, i) => String(i)),
+      show: false,
+      splitArea: { show: false },
+    },
+    yAxis: {
+      type: "category",
+      data: Array.from({ length: HEATMAP_ROWS }, (_, i) => String(i)),
+      show: false,
+      splitArea: { show: false },
+      inverse: true,
+    },
+    visualMap: {
+      show: false,
+      min: 0,
+      max: 1,
+      calculable: false,
+      pieces: [
+        { value: 0, color: COLOR_IDLE },
+        { value: 1, color: COLOR_ACTIVE },
+      ],
+    },
+    series: [
+      {
+        type: "heatmap",
+        data: buildActivityHeatmap(pct),
+        itemStyle: {
+          borderColor: "rgba(0,0,0,0.4)",
+          borderWidth: 2,
+          borderRadius: 2,
+        },
+        progressive: 0,
+        animationDuration: 600,
+      },
+    ],
+  };
 }
 
 function GpuLiveSection() {
@@ -300,50 +372,70 @@ function GpuLiveSection() {
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {gpus.map((g) => {
         const memPct = g.memTotalMB && g.memUsedMB !== null
-          ? Math.round((g.memUsedMB / g.memTotalMB) * 100) : null;
+          ? (g.memUsedMB / g.memTotalMB) * 100 : 0;
         const memUsedGB = g.memUsedMB !== null  ? (g.memUsedMB  / 1024).toFixed(1) : "—";
         const memTotalGB = g.memTotalMB !== null ? (g.memTotalMB / 1024).toFixed(1) : "—";
+        const corePct = g.gpuUtilPct ?? 0;
         return (
-          <div key={g.busId} className="border border-border rounded p-3">
-            <div className="flex items-center justify-between mb-2">
+          <div key={g.busId} className="border border-border rounded-md p-4">
+            <div className="flex items-start justify-between mb-3">
               <div>
-                <div className="text-[12px] font-medium text-foreground">{g.name}</div>
+                <div className="text-[13px] font-semibold text-foreground">{g.name}</div>
                 <code className="text-[10px] text-muted-foreground">{g.busId}</code>
               </div>
-              <div className="text-right text-[10px] text-muted-foreground">
-                {g.tempC !== null ? <span className="mr-3">{g.tempC}°C</span> : null}
-                {g.powerW !== null
-                  ? <span>{g.powerW.toFixed(1)} W{g.powerLimitW !== null ? <span className="text-muted-foreground"> / {g.powerLimitW.toFixed(0)} W</span> : null}</span>
-                  : null}
+              <div className="flex items-center gap-4 text-[11px]">
+                {g.tempC !== null && (
+                  <div className="text-right">
+                    <div className="text-[9px] text-muted-foreground uppercase tracking-wider">temp</div>
+                    <div className="font-bold text-foreground tabular-nums">{g.tempC}°C</div>
+                  </div>
+                )}
+                {g.powerW !== null && (
+                  <div className="text-right">
+                    <div className="text-[9px] text-muted-foreground uppercase tracking-wider">power</div>
+                    <div className="font-bold text-foreground tabular-nums">
+                      {g.powerW.toFixed(1)}<span className="text-muted-foreground text-[10px]"> / {g.powerLimitW !== null ? g.powerLimitW.toFixed(0) : "—"} W</span>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-2 gap-4">
               <div>
-                <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
-                  <span>Core utilization</span>
-                  <span className="tabular-nums text-foreground">{g.gpuUtilPct !== null ? `${g.gpuUtilPct}%` : "—"}</span>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider">Core activity</span>
+                  <span className="text-[18px] font-bold text-foreground tabular-nums">{Math.round(corePct)}%</span>
                 </div>
-                <BarGauge pct={g.gpuUtilPct ?? 0} />
+                <div style={{ width: "100%", height: 130 }}>
+                  <EChart option={activityHeatmapOption(corePct, "Core")} />
+                </div>
               </div>
               <div>
-                <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
-                  <span>VRAM</span>
-                  <span className="tabular-nums text-foreground">{memUsedGB} / {memTotalGB} GB{memPct !== null ? ` (${String(memPct)}%)` : ""}</span>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-[10px] text-muted-foreground uppercase tracking-wider">VRAM</span>
+                  <span className="text-[18px] font-bold text-foreground tabular-nums">
+                    {memUsedGB}<span className="text-muted-foreground text-[12px]"> / {memTotalGB} GB ({Math.round(memPct)}%)</span>
+                  </span>
                 </div>
-                <BarGauge pct={memPct ?? 0} />
+                <div style={{ width: "100%", height: 130 }}>
+                  <EChart option={activityHeatmapOption(memPct, "VRAM")} />
+                </div>
               </div>
+            </div>
+            <div className="mt-2 text-[9px] text-muted-foreground">
+              Heatmap = aggregate utilization rendered as 100 cells (each = 1%). NVML doesn't expose per-SM utilization, so per-core breakdown is approximate.
             </div>
           </div>
         );
       })}
       {nonNvidiaDetected.map((g) => (
-        <div key={g.busId} className="border border-border rounded p-3 opacity-70">
+        <div key={g.busId} className="border border-border rounded-md p-4 opacity-70">
           <div className="flex items-center justify-between">
             <div>
-              <div className="text-[12px] font-medium text-foreground">
+              <div className="text-[13px] font-semibold text-foreground">
                 {g.vendor.replace(/, Inc\.\s*\[AMD\/ATI\]$/, " (AMD)").replace(/ Corporation$/, "").replace(/, Inc\.$/, "")} — {g.model.replace(/\s*\(rev.*$/, "")}
               </div>
               <code className="text-[10px] text-muted-foreground">{g.busId}</code>
@@ -362,6 +454,102 @@ function GpuLiveSection() {
 }
 
 // ---------------------------------------------------------------------------
+// CPU per-core heatmap — one cell per logical CPU, colored by per-core
+// utilization. Real data from /proc/stat sampling, not approximated.
+// Layout: ceil(sqrt(N)) × ceil(N/cols) so 24 cores fit a 5×5 grid with
+// one empty slot. Updates every 5s in step with /api/system/stats.
+// ---------------------------------------------------------------------------
+
+function cpuPerCoreHeatmapOption(perCore: number[]): Record<string, unknown> {
+  const cols = Math.ceil(Math.sqrt(perCore.length));
+  const rows = Math.ceil(perCore.length / cols);
+  const data: [number, number, number, number][] = perCore.map((pct, i) => [
+    i % cols,
+    Math.floor(i / cols),
+    pct,
+    i, // 4th element carries the original core index for the tooltip
+  ]);
+  return {
+    grid: { left: 4, right: 4, top: 4, bottom: 4, containLabel: false },
+    tooltip: {
+      formatter: (params: { value: [number, number, number, number] }): string =>
+        `core ${String(params.value[3])}: ${String(params.value[2])}%`,
+    },
+    xAxis: { type: "category", data: Array.from({ length: cols }, (_, i) => String(i)), show: false },
+    yAxis: { type: "category", data: Array.from({ length: rows }, (_, i) => String(i)), show: false, inverse: true },
+    visualMap: {
+      show: false,
+      min: 0,
+      max: 100,
+      calculable: false,
+      inRange: { color: [COLOR_IDLE, "#3b82f6", "#0ea5a0", COLOR_ACTIVE, "#fbbf24", "#ef4444"] },
+    },
+    series: [
+      {
+        type: "heatmap",
+        data,
+        label: { show: false },
+        itemStyle: { borderColor: "rgba(0,0,0,0.4)", borderWidth: 2, borderRadius: 4 },
+        progressive: 0,
+        animationDuration: 400,
+      },
+    ],
+  };
+}
+
+function CpuPerCoreSection() {
+  const [perCore, setPerCore] = useState<number[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async (): Promise<void> => {
+      try {
+        const r = await fetch("/api/system/stats");
+        if (!r.ok) return;
+        const j = await r.json() as { cpu?: { perCore?: number[] } };
+        if (!cancelled && Array.isArray(j.cpu?.perCore)) setPerCore(j.cpu.perCore);
+      } catch { /* ignore */ }
+    };
+    void refresh();
+    const id = window.setInterval(() => { void refresh(); }, 5_000);
+    return (): void => { cancelled = true; window.clearInterval(id); };
+  }, []);
+
+  const option = useMemo(() => cpuPerCoreHeatmapOption(perCore), [perCore]);
+  const avg = perCore.length > 0 ? Math.round(perCore.reduce((a, b) => a + b, 0) / perCore.length) : 0;
+  const peak = perCore.length > 0 ? Math.max(...perCore) : 0;
+
+  if (perCore.length === 0) {
+    return <div className="text-[11px] text-muted-foreground">Loading per-core stats...</div>;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-4 text-[11px]">
+          <div>
+            <div className="text-[9px] text-muted-foreground uppercase tracking-wider">cores</div>
+            <div className="font-bold text-foreground tabular-nums">{perCore.length}</div>
+          </div>
+          <div>
+            <div className="text-[9px] text-muted-foreground uppercase tracking-wider">avg</div>
+            <div className="font-bold text-foreground tabular-nums">{avg}%</div>
+          </div>
+          <div>
+            <div className="text-[9px] text-muted-foreground uppercase tracking-wider">peak</div>
+            <div className="font-bold text-foreground tabular-nums">{peak}%</div>
+          </div>
+        </div>
+        <div className="text-[9px] text-muted-foreground">blue = idle · green = active · yellow/red = saturated</div>
+      </div>
+      <div style={{ width: "100%", height: 200 }}>
+        <EChart option={option} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 
 export default function ResourcesPage() {
   return (
@@ -371,6 +559,12 @@ export default function ResourcesPage() {
         <Card className="p-4">
           <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">Power</h3>
           <PowerGaugeSection />
+        </Card>
+      </div>
+      <div className="mt-4">
+        <Card className="p-4">
+          <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">CPU per-core activity</h3>
+          <CpuPerCoreSection />
         </Card>
       </div>
       <div className="mt-4">


### PR DESCRIPTION
## Summary
- Owner: \"GPU stats are ugly as hell, can we use a calendar-style heatmap that shows each core activity?\" — referencing https://echarts.apache.org/examples/en/editor.html?c=calendar-simple
- Two new EChart heatmaps on the Resources page using \`@particle-academy/react-echarts\` (the fancy-echarts package, npm rename pending per CLAUDE.md § 1.5).

## Backend
- \`getCpuPerCore()\` in server-runtime-state.ts — delta-based per-core sampling of \`os.cpus()\` times. Real data, no approximation.
- \`/api/system/stats\` response gains \`cpu.perCore: number[]\`.

## Frontend
- **CpuPerCoreSection** (NEW): one EChart heatmap, \`ceil(sqrt(N))×ceil(N/cols)\` grid where N = logical core count (24 on owner's box → 5×5 with one empty slot). Color ramp blue → green → yellow → red. Header shows cores / avg / peak.
- **GpuLiveSection** (REWRITTEN): two side-by-side heatmaps per GPU — Core activity + VRAM. 10×10 = 100 cells, cells <= util% are green, > util% are blue. Footer note: NVML doesn't expose per-SM utilization, so this is an approximate visualization of aggregate util.
- Both update every 5s in step with existing power-gauge polling.

## Visual notes
- The CPU heatmap is the genuinely-per-core one (real data per logical CPU).
- The GPU heatmap is an approximation — until rocm-smi/NVML per-SM integration lands, it visually conveys aggregate util as a 'fill the grid' pattern matching the calendar-simple aesthetic.

## Test plan
- [x] typecheck clean
- [x] route-check clean (326 routes)
- [x] docs-check clean
- [x] backend per-core sampler logic verified (delta math same as existing aggregate sampler)
- [ ] Owner: \`agi upgrade\` → /resources shows new heatmaps; CPU heatmap reacts under load (e.g., \`stress-ng --cpu 4 --timeout 10\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)