### PR TITLE
fix(resources): EChart style + CPU grid aspect (v0.4.525)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.524",
+  "version": "0.4.525",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/routes/resources.tsx
+++ b/ui/dashboard/src/routes/resources.tsx
@@ -409,9 +409,7 @@ function GpuLiveSection() {
                   <span className="text-[10px] text-muted-foreground uppercase tracking-wider">Core activity</span>
                   <span className="text-[18px] font-bold text-foreground tabular-nums">{Math.round(corePct)}%</span>
                 </div>
-                <div style={{ width: "100%", height: 130 }}>
-                  <EChart option={activityHeatmapOption(corePct, "Core")} />
-                </div>
+                <EChart option={activityHeatmapOption(corePct, "Core")} style={{ height: 140 }} />
               </div>
               <div>
                 <div className="flex items-center justify-between mb-2">
@@ -420,9 +418,7 @@ function GpuLiveSection() {
                     {memUsedGB}<span className="text-muted-foreground text-[12px]"> / {memTotalGB} GB ({Math.round(memPct)}%)</span>
                   </span>
                 </div>
-                <div style={{ width: "100%", height: 130 }}>
-                  <EChart option={activityHeatmapOption(memPct, "VRAM")} />
-                </div>
+                <EChart option={activityHeatmapOption(memPct, "VRAM")} style={{ height: 140 }} />
               </div>
             </div>
             <div className="mt-2 text-[9px] text-muted-foreground">
@@ -461,8 +457,12 @@ function GpuLiveSection() {
 // ---------------------------------------------------------------------------
 
 function cpuPerCoreHeatmapOption(perCore: number[]): Record<string, unknown> {
-  const cols = Math.ceil(Math.sqrt(perCore.length));
-  const rows = Math.ceil(perCore.length / cols);
+  // Wider-than-tall grid suits a full-width card better than a square grid.
+  // Target 2-3 rows for typical core counts; fall back to sqrt for ≤6 cores.
+  const N = perCore.length;
+  const targetRows = N > 16 ? 3 : N > 6 ? 2 : 1;
+  const cols = Math.ceil(N / targetRows);
+  const rows = Math.ceil(N / cols);
   const data: [number, number, number, number][] = perCore.map((pct, i) => [
     i % cols,
     Math.floor(i / cols),
@@ -542,9 +542,7 @@ function CpuPerCoreSection() {
         </div>
         <div className="text-[9px] text-muted-foreground">blue = idle · green = active · yellow/red = saturated</div>
       </div>
-      <div style={{ width: "100%", height: 200 }}>
-        <EChart option={option} />
-      </div>
+      <EChart option={option} style={{ height: 180 }} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Heatmaps were rendering massively oversized — cells overflowed their cards into adjacent sections.
- Root cause: EChart ignores parent div height; \`style\` must be passed as a prop on the EChart component itself, matching the existing pattern in ResourceUsage.tsx.
- Also improved CPU grid layout: \`targetRows=3\` for >16 cores yields 8×3 for 24-core boxes (perfect fit, no empty slot) instead of stretched-rectangle 5×5.

## Test plan
- [x] typecheck clean
- [x] route-check clean
- [x] docs-check clean
- [ ] Owner: \`agi upgrade\` → /resources heatmaps fit cleanly within their cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)