### PR TITLE
feat(hosting): surface circuit-breaker state in HostingPanel (v0.4.529)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.528",
+  "version": "0.4.529",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -3223,6 +3223,15 @@ export class HostingManager {
     /** s145 t585 — surface containerKind + mapps to dashboard. */
     containerKind?: "static" | "code" | "mapp";
     mapps?: string[];
+    /** Circuit-breaker state for this project's hosting service id, when not closed.
+     * Surfaces "open" / "half-open" so the dashboard can render a distinct chip
+     * instead of leaving the project looking simply "stopped" with no context. */
+    breaker?: {
+      status: "closed" | "half-open" | "open";
+      failures: number;
+      lastError?: string;
+      lastFailureAt?: string;
+    };
   } {
     const resolved = resolvePath(projectPath);
     const hosted = this.projects.get(resolved);
@@ -3237,6 +3246,18 @@ export class HostingManager {
       const resolvedImage = runtimeDef?.containerImage
         ?? stackConfig?.image
         ?? CONTAINER_IMAGES[knownType];
+      // Surface circuit-breaker state when not "closed" — dashboard renders a
+      // distinct chip so owners can see why a project keeps failing or
+      // is being skipped on boot.
+      const breakerState = this.circuitBreaker?.getState(`hosting:${resolved}`);
+      const breaker = breakerState && breakerState.status !== "closed"
+        ? {
+            status: breakerState.status,
+            failures: breakerState.failures,
+            ...(breakerState.lastError ? { lastError: breakerState.lastError } : {}),
+            ...(breakerState.lastFailureAt ? { lastFailureAt: breakerState.lastFailureAt } : {}),
+          }
+        : undefined;
       return {
         enabled: hosted.meta.enabled,
         type: hosted.meta.type,
@@ -3255,6 +3276,7 @@ export class HostingManager {
         ...(hosted.meta.viewer ? { viewer: hosted.meta.viewer } : {}),
         ...(hosted.meta.containerKind !== undefined ? { containerKind: hosted.meta.containerKind } : {}),
         ...(hosted.meta.mapps !== undefined ? { mapps: hosted.meta.mapps } : {}),
+        ...(breaker ? { breaker } : {}),
         url: hosted.status === "running"
           ? `https://${hosted.meta.hostname}.${this.config.baseDomain}`
           : null,

--- a/ui/dashboard/src/components/HostingPanel.tsx
+++ b/ui/dashboard/src/components/HostingPanel.tsx
@@ -248,6 +248,21 @@ export function HostingPanel({
           <div className="flex items-center gap-2">
             <span className={cn("inline-block w-2 h-2 rounded-full", statusDot)} />
             <span className={cn("text-[12px] font-semibold capitalize", statusColor)}>{statusLabel}</span>
+            {hosting.breaker && hosting.breaker.status !== "closed" && (
+              <span
+                className={cn(
+                  "text-[10px] px-1.5 py-0.5 rounded font-medium",
+                  hosting.breaker.status === "open"
+                    ? "bg-red/15 text-red"
+                    : "bg-amber/15 text-amber",
+                )}
+                title={hosting.breaker.lastError ?? `${String(hosting.breaker.failures)} consecutive failures`}
+              >
+                {hosting.breaker.status === "open"
+                  ? `circuit open · ${String(hosting.breaker.failures)} fails`
+                  : "circuit half-open"}
+              </span>
+            )}
             {hosting.url && (
               <a href={hosting.url} target="_blank" rel="noopener noreferrer" className="text-[11px] text-blue underline">{hosting.url}</a>
             )}

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -333,6 +333,14 @@ export interface ProjectHostingInfo {
   containerKind?: "static" | "code" | "mapp";
   /** s145 t585 — installed MApp IDs for the MApp container kind. */
   mapps?: string[];
+  /** Circuit-breaker state for this project's hosting service id, when not closed.
+   *  Surfaces "open" / "half-open" so the dashboard can render a distinct chip. */
+  breaker?: {
+    status: "closed" | "half-open" | "open";
+    failures: number;
+    lastError?: string;
+    lastFailureAt?: string;
+  };
 }
 
 /** Tool definition from project type registry. */


### PR DESCRIPTION
## Summary
- Breaker state was invisible to the dashboard — owners had to read gateway logs to learn that a project's circuit had tripped after 3 consecutive failures.
- Backend: \`getProjectHostingInfo\` now includes optional \`breaker\` field (status, failures, lastError, lastFailureAt) populated from the persistent CircuitBreakerTracker. Only emits when status !== \"closed\".
- Frontend: HostingPanel renders a chip next to the status dot:
  - red \"circuit open · N fails\" when fully open
  - amber \"circuit half-open\" when allowing one retry after cool-down
- Hover tooltip shows lastError for in-place diagnosis.

## Hosting status vocabulary now complete
running / stopped / error / needs-build / circuit-open — together with v0.4.527 (pre-flight) + v0.4.528 (needs-build UI), every owner-relevant hosting state has a distinct surface.

## Test plan
- [x] typecheck clean
- [x] route-check clean
- [x] docs-check clean
- [ ] Owner: \`agi upgrade\` → projects with circuit-open state (e.g. blackorchid_web, civicognita_website, my-art) show red \"circuit open · N fails\" chip in /projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)