### PR TITLE
feat(hosting): reset-breaker button (v0.4.530)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.529",
+  "version": "0.4.530",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/HostingPanel.tsx
+++ b/ui/dashboard/src/components/HostingPanel.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Select } from "@/components/ui/select";
 import type { ProjectHostingInfo, ProjectTypeTool, RuntimeInfo, StackInfo, ProjectStackInstance } from "../types.js";
-import { fetchProjectDevCommands, fetchRuntimes, fetchProjectStacks, fetchStacks, fetchEffectiveStartCommand } from "../api.js";
+import { fetchProjectDevCommands, fetchRuntimes, fetchProjectStacks, fetchStacks, fetchEffectiveStartCommand, resetCircuitBreaker } from "../api.js";
 import type { EffectiveStartCommand } from "../api.js";
 import { ProjectToolbar } from "./ProjectToolbar.js";
 import { StackManager } from "./StackManager.js";
@@ -89,6 +89,7 @@ export function HostingPanel({
     hosting.internalPort !== null ? String(hosting.internalPort) : "",
   );
   const [saving, setSaving] = useState(false);
+  const [resettingBreaker, setResettingBreaker] = useState(false);
   const [tunnelLoading, setTunnelLoading] = useState(false);
   const [tunnelCopied, setTunnelCopied] = useState(false);
   const [devCommands, setDevCommands] = useState<Record<string, string>>({});
@@ -249,19 +250,35 @@ export function HostingPanel({
             <span className={cn("inline-block w-2 h-2 rounded-full", statusDot)} />
             <span className={cn("text-[12px] font-semibold capitalize", statusColor)}>{statusLabel}</span>
             {hosting.breaker && hosting.breaker.status !== "closed" && (
-              <span
-                className={cn(
-                  "text-[10px] px-1.5 py-0.5 rounded font-medium",
-                  hosting.breaker.status === "open"
-                    ? "bg-red/15 text-red"
-                    : "bg-amber/15 text-amber",
-                )}
-                title={hosting.breaker.lastError ?? `${String(hosting.breaker.failures)} consecutive failures`}
-              >
-                {hosting.breaker.status === "open"
-                  ? `circuit open · ${String(hosting.breaker.failures)} fails`
-                  : "circuit half-open"}
-              </span>
+              <>
+                <span
+                  className={cn(
+                    "text-[10px] px-1.5 py-0.5 rounded font-medium",
+                    hosting.breaker.status === "open"
+                      ? "bg-red/15 text-red"
+                      : "bg-amber/15 text-amber",
+                  )}
+                  title={hosting.breaker.lastError ?? `${String(hosting.breaker.failures)} consecutive failures`}
+                >
+                  {hosting.breaker.status === "open"
+                    ? `circuit open · ${String(hosting.breaker.failures)} fails`
+                    : "circuit half-open"}
+                </span>
+                <button
+                  onClick={() => {
+                    setResettingBreaker(true);
+                    resetCircuitBreaker(`hosting:${projectPath}`)
+                      .then(() => onRestart(projectPath))
+                      .catch((err: unknown) => setStickyError(err instanceof Error ? err.message : String(err)))
+                      .finally(() => setResettingBreaker(false));
+                  }}
+                  disabled={resettingBreaker || busy}
+                  className="text-[10px] px-1.5 py-0.5 rounded border border-border hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Reset the circuit breaker and re-attempt boot"
+                >
+                  {resettingBreaker ? "resetting…" : "reset"}
+                </button>
+              </>
             )}
             {hosting.url && (
               <a href={hosting.url} target="_blank" rel="noopener noreferrer" className="text-[11px] text-blue underline">{hosting.url}</a>


### PR DESCRIPTION
## Summary
- Companion to v0.4.529. Circuit-open projects had two recovery options: wait 24h for cool-down OR restart the gateway. Now there's a third: click \"reset\" next to the breaker chip in HostingPanel.
- Wiring: HostingPanel imports the existing \`resetCircuitBreaker(serviceId)\` API client. Service id is \`hosting:\${projectPath}\` matching backend convention. On success → \`onRestart(path)\` so the gateway re-attempts boot immediately and the chip clears.

## Hosting durability arc — closed
v0.4.526 / .527 / .528 / .529 / .530 — running / stopped / error / needs-build / circuit-open all have distinct visuals AND in-place recovery actions where applicable.

## Test plan
- [x] typecheck clean
- [x] route-check clean
- [x] docs-check clean
- [ ] Owner: \`agi upgrade\` → projects with circuit-open chip show \"reset\" button → click → chip clears + boot re-attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)