### PR TITLE
chore(plugins): add provider to PluginCategory enum (v0.4.531, s111 t376)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.530",
+  "version": "0.4.531",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -25,7 +25,12 @@ export type AionimaPermission =
 // Plugin categories
 // ---------------------------------------------------------------------------
 
-export type PluginCategory = "runtime" | "service" | "tool" | "editor" | "integration" | "project" | "knowledge" | "theme" | "workflow" | "system" | "stack";
+// "provider" — added per s111 t376. Anthropic / OpenAI / Ollama / Lemonade /
+// HF / aion-micro all qualify. Runtime is a Provider attribute (per
+// `feedback_provider_definition` memory), not a sibling category, so the
+// pre-existing "runtime" value is now reserved for non-Provider runtime
+// plugins (none today; back-compat for future cases).
+export type PluginCategory = "provider" | "runtime" | "service" | "tool" | "editor" | "integration" | "project" | "knowledge" | "theme" | "workflow" | "system" | "stack";
 
 // ---------------------------------------------------------------------------
 // Provides labels — capability-based taxonomy


### PR DESCRIPTION
## Summary
PluginCategory enum was missing \"provider\" as a valid value, forcing Provider plugin manifests to declare misleading categories (\"runtime\" for lemonade, \"integration\" for the API providers). Adding it unblocks the matching marketplace ship that fixes the 4 manifests.

## Companion ship
agi-marketplace dev/HEAD: 4 plugin manifests updated to category:\"provider\" (Anthropic, OpenAI, Ollama, Lemonade).

## Test plan
- [x] typecheck clean
- [x] route-check clean
- [x] docs-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)