### PR TITLE
chore(schema): drop category + containerKind from project-schema (v0.4.533, s150 t630)

### DIFF
--- a/config/src/project-schema.ts
+++ b/config/src/project-schema.ts
@@ -78,24 +78,20 @@ export const ProjectHostingSchema = z
     /** MagicApp ID used as the viewer for this project's *.ai.on URL. */
     viewer: z.string().optional(),
     /**
-     * s145 t584 — Container kind. Default undefined preserves existing
-     * behavior: HostingManager dispatches based on project type + stacks.
-     * When set to "mapp", HostingManager routes to the MApp host container
-     * branch (light Caddy + static MApp host bundle, no nginx + no app
-     * server). Used by ops/media/literature projects whose primary surface
-     * is one or more MApps from the marketplace, not custom UI/API code.
-     */
-    containerKind: z.enum(["static", "code", "mapp"]).optional(),
-    /**
-     * s145 t584 — list of MApp IDs installed in this project's container.
-     * Only meaningful when containerKind === "mapp". Each id resolves to a
-     * MApp definition from the MApp Marketplace. The first id (or the one
-     * marked default in MApp config) is what loads at the project root URL;
-     * each MApp is also addressable at <project>.ai.on/<mappId>/.
+     * List of MApp IDs installed in this project's container. Only
+     * meaningful when the project's `type` is registered as Desktop-served
+     * (see Type Registry's `servesDesktop` flag — s150). Each id resolves to
+     * a MApp definition from the MApp Marketplace. Surfaced as launcher
+     * tiles on the Aion Desktop at the project root URL; each MApp is also
+     * addressable at <project>.ai.on/<mappId>/.
      */
     mapps: z.array(z.string()).optional(),
+    // s150 (2026-05-07): `containerKind` was removed. Type registry now
+    // derives the code-served-vs-Desktop-served binary from `type`. Legacy
+    // values in existing project.json files are tolerated by .passthrough()
+    // and stripped by the s150 migration script (s150 t632).
   })
-  .strict();
+  .passthrough();
 
 // ---------------------------------------------------------------------------
 // AI model binding — declared per-project in project.json
@@ -329,8 +325,11 @@ export const ProjectConfigSchema = z
     tynnToken: z.string().optional(),
     /** Project type ID (mirrors hosting.type when hosting is configured). */
     type: z.string().optional(),
-    /** Project category (literature, app, web, etc.). */
-    category: ProjectCategorySchema.optional(),
+    // s150 (2026-05-07): `category` was removed. `type` is now the single
+    // source of truth for project classification. Legacy values tolerated
+    // by the root-level .passthrough() and stripped by the s150 migration
+    // script (s150 t632). ProjectCategorySchema export is preserved for
+    // back-compat consumers (magic-app-schema.ts) until they migrate.
     /** Human-readable project description. */
     description: z.string().optional(),
     /** Hosting configuration (present when project has been configured for hosting). */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.532",
+  "version": "0.4.533",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -1372,7 +1372,12 @@ export class HostingManager {
         tunnelId: hosting.tunnelId ?? null,
         viewer: hosting.viewer ?? null,
         // s145 t584 — propagate the new MApp container fields.
-        ...(hosting.containerKind !== undefined ? { containerKind: hosting.containerKind } : {}),
+        // s150 (2026-05-07): `containerKind` was dropped from the schema. Legacy values survive
+        // via .passthrough(); read them through an unknown-cast for the migration period until
+        // hosting-manager refactor (t634) removes the field from ProjectHostingMeta entirely.
+        ...((hosting as unknown as { containerKind?: "static" | "code" | "mapp" }).containerKind !== undefined
+          ? { containerKind: (hosting as unknown as { containerKind?: "static" | "code" | "mapp" }).containerKind }
+          : {}),
         ...(hosting.mapps !== undefined ? { mapps: hosting.mapps } : {}),
       };
     }

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -1843,10 +1843,13 @@ export async function createGatewayRuntimeState(
     }
 
     // Read current config to access category for eligibility + cadence validation.
+    // s150 (2026-05-07): `category` was dropped from the schema. Legacy values
+    // survive via .passthrough(); read through an unknown-cast for the migration
+    // period until consumers move to deriving from `type` (s150 doc-update task t642).
     let projectCategory: ProjectCategory | undefined;
     try {
       const cur = await deps.projectConfigManager.read(targetPath);
-      projectCategory = cur?.category;
+      projectCategory = (cur as unknown as { category?: ProjectCategory })?.category;
     } catch {
       /* fall through — read errors get caught by update() below */
     }


### PR DESCRIPTION
## Summary
Foundation slice for s150 (PM/Hosting model alignment to single-\`type\` source of truth). Per owner directive 2026-05-07.

- Removes \`category\` from ProjectConfigSchema (replaced by \`type\`)
- Removes \`hosting.containerKind\` from ProjectHostingSchema (derived from type at registry level — added in t631)
- Switches ProjectHostingSchema from .strict() to .passthrough() so legacy values don't cause Zod parse failures
- Two consumer sites updated with unknown-casts for the migration period (hosting-manager.ts, server-runtime-state.ts) — proper cleanup happens in t634/t636/t642

## Reference
- Reconciliation doc: \`_discovery/pm-hosting-reconciliation.md\`
- Tynn story: s150 (PM/Hosting model alignment)

## Test plan
- [x] typecheck clean
- [x] route-check clean
- [x] docs-check clean
- [ ] Owner: \`agi upgrade\` — existing project.json files with legacy category/containerKind values continue to parse without errors (migration tolerance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)