### PR TITLE
agi v0.4.535 — s150 t632 project.json shape sweep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.534",
+  "version": "0.4.535",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/project-config-shape-migration.test.ts
+++ b/packages/gateway-core/src/project-config-shape-migration.test.ts
@@ -1,0 +1,302 @@
+/**
+ * project-config-shape-migration tests — verifies the s150 t632 sweep:
+ *   1. Drops top-level `category`
+ *   2. Drops `hosting.containerKind`
+ *   3. Derives top-level `type` from `hosting.type` / `category`
+ *   4. Removes `.agi/project.json` debris
+ * and is idempotent on re-runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  migrateAllProjectConfigShapes,
+  migrateProjectConfigShape,
+} from "./project-config-shape-migration.js";
+
+describe("migrateProjectConfigShape", () => {
+  let tmpRoot: string;
+  let projectPath: string;
+
+  beforeEach(() => {
+    tmpRoot = join(tmpdir(), `shape-mig-${String(Date.now())}-${String(Math.random()).slice(2)}`);
+    projectPath = join(tmpRoot, "myproject");
+    mkdirSync(projectPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function writeConfig(obj: unknown, dir: string = projectPath, name = "project.json"): string {
+    const p = join(dir, name);
+    writeFileSync(p, `${JSON.stringify(obj, null, 2)}\n`, "utf-8");
+    return p;
+  }
+
+  function readConfig(dir: string = projectPath, name = "project.json"): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(dir, name), "utf-8")) as Record<string, unknown>;
+  }
+
+  it("strips top-level category and rewrites the file", () => {
+    writeConfig({
+      name: "demo",
+      type: "web-app",
+      category: "web",
+      hosting: { enabled: true, type: "web-app", hostname: "demo" },
+    });
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.configRewritten).toBe(true);
+    expect(r.droppedCategory).toBe("web");
+    expect(r.derivedType).toBeUndefined();
+    const after = readConfig();
+    expect(after.category).toBeUndefined();
+    expect(after.type).toBe("web-app");
+  });
+
+  it("strips hosting.containerKind", () => {
+    writeConfig({
+      name: "demo",
+      type: "ops",
+      hosting: { enabled: true, type: "static-site", hostname: "demo", containerKind: "mapp" },
+    });
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.configRewritten).toBe(true);
+    expect(r.droppedContainerKind).toBe("mapp");
+    const after = readConfig();
+    const hosting = after.hosting as Record<string, unknown>;
+    expect("containerKind" in hosting).toBe(false);
+    expect(hosting.type).toBe("static-site");
+  });
+
+  it("derives top-level type from hosting.type when missing", () => {
+    writeConfig({
+      name: "demo",
+      hosting: { enabled: true, type: "web-app", hostname: "demo" },
+    });
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.configRewritten).toBe(true);
+    expect(r.derivedType).toEqual({ value: "web-app", source: "hosting.type" });
+    expect(readConfig().type).toBe("web-app");
+  });
+
+  it("derives top-level type from category when hosting.type is absent", () => {
+    writeConfig({
+      name: "demo",
+      category: "literature",
+    });
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.configRewritten).toBe(true);
+    expect(r.derivedType).toEqual({ value: "writing", source: "category" });
+    expect(r.droppedCategory).toBe("literature");
+    const after = readConfig();
+    expect(after.type).toBe("writing");
+    expect(after.category).toBeUndefined();
+  });
+
+  it("falls back to static-site when neither hosting.type nor a known category is present", () => {
+    writeConfig({ name: "demo" });
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.configRewritten).toBe(true);
+    expect(r.derivedType).toEqual({ value: "static-site", source: "default" });
+    expect(readConfig().type).toBe("static-site");
+  });
+
+  it("removes .agi/project.json debris and rmdirs the empty .agi/", () => {
+    writeConfig({ name: "demo", type: "web-app", hosting: { enabled: false, type: "web-app", hostname: "demo" } });
+    const agiDir = join(projectPath, ".agi");
+    mkdirSync(agiDir, { recursive: true });
+    writeConfig({ name: "demo-stale" }, agiDir);
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.agiDebrisRemoved).toBe(true);
+    expect(existsSync(join(agiDir, "project.json"))).toBe(false);
+    expect(existsSync(agiDir)).toBe(false); // empty dir was rmdir'd
+  });
+
+  it("leaves a non-empty .agi/ directory in place after removing the stale config", () => {
+    writeConfig({ name: "demo", type: "web-app", hosting: { enabled: false, type: "web-app", hostname: "demo" } });
+    const agiDir = join(projectPath, ".agi");
+    mkdirSync(agiDir, { recursive: true });
+    writeConfig({ name: "demo-stale" }, agiDir);
+    writeFileSync(join(agiDir, "other.txt"), "keep me", "utf-8");
+
+    const r = migrateProjectConfigShape(projectPath);
+
+    expect(r.agiDebrisRemoved).toBe(true);
+    expect(existsSync(agiDir)).toBe(true); // sibling file kept the dir alive
+    expect(existsSync(join(agiDir, "other.txt"))).toBe(true);
+    expect(existsSync(join(agiDir, "project.json"))).toBe(false);
+  });
+
+  it("is idempotent — running twice on a clean shape touches nothing the second time", () => {
+    writeConfig({
+      name: "demo",
+      type: "web-app",
+      category: "web",
+      hosting: { enabled: true, type: "web-app", hostname: "demo", containerKind: "code" },
+    });
+
+    const first = migrateProjectConfigShape(projectPath);
+    expect(first.configRewritten).toBe(true);
+
+    const second = migrateProjectConfigShape(projectPath);
+    expect(second.configRewritten).toBe(false);
+    expect(second.agiDebrisRemoved).toBe(false);
+    expect(second.droppedCategory).toBeUndefined();
+    expect(second.droppedContainerKind).toBeUndefined();
+    expect(second.derivedType).toBeUndefined();
+  });
+
+  it("preserves unrelated keys at the root and inside hosting", () => {
+    writeConfig({
+      name: "demo",
+      type: "web-app",
+      category: "web",
+      tynnToken: "rpk_keep",
+      magicApps: ["reader"],
+      hosting: {
+        enabled: true,
+        type: "web-app",
+        hostname: "demo",
+        containerKind: "code",
+        port: 4001,
+        runtimeId: "node-24",
+      },
+    });
+
+    migrateProjectConfigShape(projectPath);
+
+    const after = readConfig();
+    expect(after.tynnToken).toBe("rpk_keep");
+    expect(after.magicApps).toEqual(["reader"]);
+    const hosting = after.hosting as Record<string, unknown>;
+    expect(hosting.port).toBe(4001);
+    expect(hosting.runtimeId).toBe("node-24");
+    expect("containerKind" in hosting).toBe(false);
+  });
+
+  it("reports an error and does not throw on unparseable project.json", () => {
+    writeFileSync(join(projectPath, "project.json"), "{not valid json", "utf-8");
+    const r = migrateProjectConfigShape(projectPath);
+    expect(r.error).toBeDefined();
+    expect(r.configRewritten).toBe(false);
+  });
+
+  it("returns a no-op when project.json is absent and there is no debris", () => {
+    const r = migrateProjectConfigShape(projectPath);
+    expect(r.configRewritten).toBe(false);
+    expect(r.agiDebrisRemoved).toBe(false);
+    expect(r.error).toBeUndefined();
+  });
+
+  it("skips sacred project paths (e.g. _aionima)", () => {
+    const sacred = join(tmpRoot, "_aionima");
+    mkdirSync(sacred, { recursive: true });
+    writeConfig({ name: "AGI", type: "aionima", category: "monorepo" }, sacred);
+
+    const r = migrateProjectConfigShape(sacred);
+
+    expect(r.configRewritten).toBe(false);
+    expect(readConfig(sacred).category).toBe("monorepo"); // untouched
+  });
+});
+
+describe("migrateAllProjectConfigShapes", () => {
+  let tmpRoot: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    tmpRoot = join(tmpdir(), `shape-sweep-${String(Date.now())}-${String(Math.random()).slice(2)}`);
+    workspace = join(tmpRoot, "_projects");
+    mkdirSync(workspace, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function makeProject(name: string, config: unknown, withAgiDebris = false): string {
+    const dir = join(workspace, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "project.json"), `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+    if (withAgiDebris) {
+      const agiDir = join(dir, ".agi");
+      mkdirSync(agiDir, { recursive: true });
+      writeFileSync(join(agiDir, "project.json"), `${JSON.stringify({ name: `${name}-stale` })}\n`, "utf-8");
+    }
+    return dir;
+  }
+
+  it("aggregates per-project results across the workspace", () => {
+    makeProject("alpha", {
+      name: "alpha",
+      category: "web",
+      hosting: { enabled: true, type: "web-app", hostname: "alpha", containerKind: "code" },
+    }, true);
+    makeProject("beta", {
+      name: "beta",
+      type: "writing",
+      hosting: { enabled: false, type: "writing", hostname: "beta" },
+    });
+    makeProject("gamma", {
+      name: "gamma",
+      hosting: { enabled: true, type: "static-site", hostname: "gamma" },
+    });
+    // Sacred-skip path inside the workspace.
+    mkdirSync(join(workspace, "_aionima"), { recursive: true });
+    writeFileSync(
+      join(workspace, "_aionima", "project.json"),
+      `${JSON.stringify({ name: "AGI", category: "monorepo" })}\n`,
+      "utf-8",
+    );
+
+    const summary = migrateAllProjectConfigShapes([workspace]);
+
+    // alpha + beta + gamma scanned; _aionima skipped before scan increment.
+    expect(summary.scanned).toBe(3);
+    expect(summary.rewrote).toBe(2); // alpha (cat+containerKind) + gamma (type derive)
+    expect(summary.debrisRemoved).toBe(1); // alpha had .agi debris
+    expect(summary.errors).toBe(0);
+
+    const alpha = summary.projects.find((p) => p.projectPath.endsWith("alpha"));
+    expect(alpha?.result.droppedCategory).toBe("web");
+    expect(alpha?.result.droppedContainerKind).toBe("code");
+    expect(alpha?.result.agiDebrisRemoved).toBe(true);
+
+    const gamma = summary.projects.find((p) => p.projectPath.endsWith("gamma"));
+    expect(gamma?.result.derivedType).toEqual({ value: "static-site", source: "hosting.type" });
+
+    const beta = summary.projects.find((p) => p.projectPath.endsWith("beta"));
+    expect(beta?.result.configRewritten).toBe(false);
+
+    // Sacred dir untouched.
+    const sacredCfg = JSON.parse(
+      readFileSync(join(workspace, "_aionima", "project.json"), "utf-8"),
+    ) as Record<string, unknown>;
+    expect(sacredCfg.category).toBe("monorepo");
+  });
+
+  it("tolerates missing workspace directories", () => {
+    const summary = migrateAllProjectConfigShapes([
+      join(tmpRoot, "does-not-exist"),
+      workspace,
+    ]);
+    expect(summary.scanned).toBe(0);
+    expect(summary.errors).toBe(0);
+  });
+});

--- a/packages/gateway-core/src/project-config-shape-migration.ts
+++ b/packages/gateway-core/src/project-config-shape-migration.ts
@@ -1,0 +1,220 @@
+/**
+ * project-config-shape-migration — s150 t632.
+ *
+ * One-shot, idempotent sweep that rewrites existing `<projectPath>/project.json`
+ * files into the s150 shape:
+ *
+ *   1. Top-level `type` is the single source of truth for project
+ *      classification. Ensure it is set; derive from `hosting.type` first,
+ *      `category` second, falling back to `"static-site"` only if neither
+ *      is available (no project today reaches that fallback).
+ *   2. Drop top-level `category` (replaced by `type`; the type registry
+ *      derives Desktop-served vs code-served from `type` alone).
+ *   3. Drop `hosting.containerKind` (same reason — type drives container
+ *      shape; the field has been redundant since t631 added `servesDesktop`).
+ *   4. Remove `<projectPath>/.agi/project.json` debris left over from the
+ *      s130 → s140 location migration. Empty `.agi/` dir is rmdir'd.
+ *
+ * Safe to call repeatedly. Disk is only touched when something actually
+ * changes — a fully-migrated project returns `{ configRewritten: false,
+ * agiDebrisRemoved: false }` and short-circuits.
+ *
+ * Sibling to `migrateProjectConfig` (project-config-path.ts), which
+ * handles the s130 → s140 LOCATION migration. Shape vs. location are
+ * separate axes; keeping them in different modules makes it easier to
+ * retire the location migration later without disturbing the shape pass.
+ */
+
+import { existsSync, readFileSync, readdirSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { isSacredProjectPath } from "./project-config-path.js";
+
+// ---------------------------------------------------------------------------
+// Category → default type map. Used only when a project.json has `category`
+// but neither top-level `type` nor `hosting.type`. None of the projects on
+// disk today reach this fallback; it exists to keep the migration safe for
+// any older snapshots that pre-date hosting being configured.
+// ---------------------------------------------------------------------------
+
+const CATEGORY_TO_DEFAULT_TYPE: Readonly<Record<string, string>> = Object.freeze({
+  literature: "writing",
+  app: "web-app",
+  web: "web-app",
+  media: "art",
+  administration: "ops",
+  ops: "ops",
+  monorepo: "monorepo",
+});
+
+export interface ShapeMigrationResult {
+  /** True when project.json contents were rewritten. */
+  configRewritten: boolean;
+  /** True when `<projectPath>/.agi/project.json` was deleted. */
+  agiDebrisRemoved: boolean;
+  /** Populated when the migration had to set top-level `type` itself. */
+  derivedType?: { value: string; source: "hosting.type" | "category" | "default" };
+  /** Populated when a top-level `category` was removed. */
+  droppedCategory?: string;
+  /** Populated when a `hosting.containerKind` was removed. */
+  droppedContainerKind?: string;
+  /** Populated when migration failed for the project (non-fatal). */
+  error?: string;
+}
+
+/**
+ * Migrate one project's project.json into the s150 shape.
+ * Idempotent and side-effect-free when nothing needs changing.
+ */
+export function migrateProjectConfigShape(projectPath: string): ShapeMigrationResult {
+  const result: ShapeMigrationResult = {
+    configRewritten: false,
+    agiDebrisRemoved: false,
+  };
+
+  if (isSacredProjectPath(projectPath)) return result;
+
+  // Step 1 — clean up `.agi/project.json` debris from the s130 → s140 migration.
+  // Done first because if the file is present alongside the s140 project.json,
+  // the legacy file is stale and should never be re-promoted.
+  const agiDir = join(projectPath, ".agi");
+  const agiConfigPath = join(agiDir, "project.json");
+  if (existsSync(agiConfigPath)) {
+    try {
+      unlinkSync(agiConfigPath);
+      result.agiDebrisRemoved = true;
+      // Best-effort rmdir — leave the dir alone if other files live there.
+      try {
+        if (readdirSync(agiDir).length === 0) rmdirSync(agiDir);
+      } catch { /* dir went away or has siblings — fine */ }
+    } catch (e) {
+      result.error = `failed to remove .agi/project.json: ${e instanceof Error ? e.message : String(e)}`;
+      return result;
+    }
+  }
+
+  // Step 2 — rewrite project.json contents (if it exists).
+  const configPath = join(projectPath, "project.json");
+  if (!existsSync(configPath)) return result;
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+  } catch (e) {
+    result.error = `failed to parse project.json: ${e instanceof Error ? e.message : String(e)}`;
+    return result;
+  }
+
+  const next: Record<string, unknown> = { ...raw };
+  let mutated = false;
+
+  // 2a — ensure top-level `type` is set.
+  if (typeof next.type !== "string" || next.type.length === 0) {
+    const hosting = next.hosting as Record<string, unknown> | undefined;
+    const hostingType = typeof hosting?.type === "string" && hosting.type.length > 0 ? hosting.type : undefined;
+    const category = typeof next.category === "string" ? next.category : undefined;
+    let derived: string;
+    let source: "hosting.type" | "category" | "default";
+    if (hostingType !== undefined) {
+      derived = hostingType;
+      source = "hosting.type";
+    } else if (category !== undefined && CATEGORY_TO_DEFAULT_TYPE[category] !== undefined) {
+      derived = CATEGORY_TO_DEFAULT_TYPE[category];
+      source = "category";
+    } else {
+      derived = "static-site";
+      source = "default";
+    }
+    next.type = derived;
+    result.derivedType = { value: derived, source };
+    mutated = true;
+  }
+
+  // 2b — drop top-level `category`.
+  if ("category" in next) {
+    result.droppedCategory = typeof next.category === "string" ? next.category : String(next.category);
+    delete next.category;
+    mutated = true;
+  }
+
+  // 2c — drop `hosting.containerKind`.
+  const hosting = next.hosting as Record<string, unknown> | undefined;
+  if (hosting !== undefined && "containerKind" in hosting) {
+    result.droppedContainerKind = typeof hosting.containerKind === "string"
+      ? hosting.containerKind
+      : String(hosting.containerKind);
+    const { containerKind: _drop, ...hostingNext } = hosting;
+    next.hosting = hostingNext;
+    mutated = true;
+  }
+
+  if (mutated) {
+    try {
+      writeFileSync(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+      result.configRewritten = true;
+    } catch (e) {
+      result.error = `failed to write project.json: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  }
+
+  return result;
+}
+
+export interface ShapeSweepResult {
+  /** Total project directories scanned (after sacred-skip). */
+  scanned: number;
+  /** How many had their project.json rewritten. */
+  rewrote: number;
+  /** How many had a `.agi/project.json` debris file removed. */
+  debrisRemoved: number;
+  /** How many failed the migration (non-fatal). */
+  errors: number;
+  /** Per-project results for the boot log / dashboard. */
+  projects: Array<{ projectPath: string; result: ShapeMigrationResult }>;
+}
+
+/**
+ * Run the shape migration across every project directory under each entry
+ * of `workspaceProjects`. Mirrors hosting-manager's
+ * `migrateAllProjectsToFolderLayout` shape so the boot-time wiring reads
+ * symmetrically.
+ */
+export function migrateAllProjectConfigShapes(workspaceProjects: readonly string[]): ShapeSweepResult {
+  const out: ShapeSweepResult = { scanned: 0, rewrote: 0, debrisRemoved: 0, errors: 0, projects: [] };
+
+  for (const dir of workspaceProjects) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+        .map((d) => d.name);
+    } catch {
+      continue;
+    }
+
+    for (const slug of entries) {
+      const projectPath = join(dir, slug);
+      if (isSacredProjectPath(projectPath)) continue;
+      out.scanned++;
+      try {
+        const result = migrateProjectConfigShape(projectPath);
+        out.projects.push({ projectPath, result });
+        if (result.configRewritten) out.rewrote++;
+        if (result.agiDebrisRemoved) out.debrisRemoved++;
+        if (result.error !== undefined) out.errors++;
+      } catch (e) {
+        out.errors++;
+        out.projects.push({
+          projectPath,
+          result: {
+            configRewritten: false,
+            agiDebrisRemoved: false,
+            error: e instanceof Error ? e.message : String(e),
+          },
+        });
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -128,6 +128,7 @@ import { buildTynnSyncPrompt } from "./plan-tynn-mapper.js";
 import { projectConfigPath } from "./project-config-path.js";
 import { HostingManager } from "./hosting-manager.js";
 import { ProjectConfigManager } from "./project-config-manager.js";
+import { migrateAllProjectConfigShapes } from "./project-config-shape-migration.js";
 import { IterativeWorkScheduler } from "./iterative-work/scheduler.js";
 import { listProjectsWithConfig } from "./iterative-work/list-projects.js";
 import { projectSlug } from "./project-config-path.js";
@@ -1807,6 +1808,26 @@ export async function startGatewayServer(
     logger.warn(
       "migrate",
       `boot-time s130 sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // s150 t632 — boot-time JSON-shape sweep. Drops legacy `category` +
+  // `hosting.containerKind` and ensures top-level `type` is set on every
+  // project.json across the workspace. Idempotent; only logs when something
+  // actually changed. Sibling to the s130 sweep above, which handles file-
+  // location migration; this one handles shape inside the file.
+  try {
+    const result = migrateAllProjectConfigShapes(projectPaths);
+    if (result.rewrote > 0 || result.debrisRemoved > 0 || result.errors > 0) {
+      logger.info(
+        "migrate",
+        `boot-time s150 shape sweep: ${String(result.scanned)} scanned, ${String(result.rewrote)} rewritten, ${String(result.debrisRemoved)} .agi/project.json removed, ${String(result.errors)} error(s)`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      "migrate",
+      `boot-time s150 shape sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- Boot-time idempotent migration that drops legacy \`category\` + \`hosting.containerKind\`, ensures top-level \`type\`, and clears \`.agi/project.json\` debris.
- New module \`project-config-shape-migration.ts\` (sibling to \`project-config-path.ts\`); wired into server.ts after the existing s130 sweep.
- Sacred-skip honored. 14 unit tests pass (host-run via \`AIONIMA_TEST_VM=1\` — pure-logic, fs+tmpdir, no DB/service).

Closes s150 t632 (PM/Hosting model alignment, sequencing layer 1).

## Test plan
- [x] Unit tests (14/14 + 8 chat-mig + 12 project-types regression check)
- [x] \`tsc --noEmit\` on @agi/gateway-core
- [ ] Live-boot verification on test VM after merge — boot log should show \`boot-time s150 shape sweep: N scanned, M rewritten, K .agi/project.json removed\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)