### PR TITLE
agi v0.4.539 — s150 t636 dashboard single-type model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.538",
+  "version": "0.4.539",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -1312,6 +1312,8 @@ export async function createGatewayRuntimeState(
       tynnToken?: string | null;
       category?: string;
       type?: string;
+      /** s150 t636 — free-form Purpose textarea content. Empty string clears. */
+      description?: string;
     };
 
     if (!body.path || typeof body.path !== "string") {
@@ -1361,6 +1363,16 @@ export async function createGatewayRuntimeState(
       const hosting = projectMeta.hosting as Record<string, unknown> | undefined;
       if (hosting) {
         hosting.type = body.type.trim();
+      }
+    }
+    // s150 t636 — free-form description (Purpose textarea). Empty string is
+    // the canonical "cleared" value: delete the key so JSON stays clean.
+    if (body.description !== undefined && typeof body.description === "string") {
+      const trimmed = body.description.trim();
+      if (trimmed.length > 0) {
+        projectMeta.description = trimmed;
+      } else {
+        delete projectMeta.description;
       }
     }
 

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -174,7 +174,12 @@ export async function updateProject(params: {
   path: string;
   name?: string;
   tynnToken?: string | null;
+  /** @deprecated s150 — use `type`. Backend still accepts for back-compat. */
   category?: string;
+  /** s150 — single classifier replacing `category`. */
+  type?: string;
+  /** s150 t636 — free-form purpose textarea. */
+  description?: string;
 }): Promise<{ ok: boolean }> {
   const res = await fetch("/api/projects", {
     method: "PUT",

--- a/ui/dashboard/src/components/HostingPanel.tsx
+++ b/ui/dashboard/src/components/HostingPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Select } from "@/components/ui/select";
+import { isDesktopServedType } from "@/lib/project-type-classifier";
 import type { ProjectHostingInfo, ProjectTypeTool, RuntimeInfo, StackInfo, ProjectStackInstance } from "../types.js";
 import { fetchProjectDevCommands, fetchRuntimes, fetchProjectStacks, fetchStacks, fetchEffectiveStartCommand, resetCircuitBreaker } from "../api.js";
 import type { EffectiveStartCommand } from "../api.js";
@@ -38,9 +39,12 @@ export interface HostingPanelProps {
     mode?: "production" | "development";
     internalPort?: number;
     runtimeId?: string;
-    /** s145 t585 — flip container kind from the dashboard. */
+    /**
+     * @deprecated s150 t636 — UI no longer emits this; backend computes it
+     * from `type`. Kept on the prop type for any caller still passing it.
+     */
     containerKind?: "static" | "code" | "mapp";
-    /** s145 t585 — list of MApp IDs installed when containerKind=mapp. */
+    /** s145 t585 / s150 t636 — list of MApp IDs installed when type is Desktop-served. */
     mapps?: string[];
   }) => Promise<unknown>;
   onRestart: (path: string) => Promise<unknown>;
@@ -77,11 +81,11 @@ export function HostingPanel({
   const [type, setType] = useState<string>(hosting.type ?? detectedHosting?.projectType ?? "static-site");
   const [hostname, setHostname] = useState(hosting.hostname);
   const [docRoot, setDocRoot] = useState(hosting.docRoot ?? detectedHosting?.docRoot ?? "");
-  // s145 t585 — container-kind selector + mapps[] entries. Default reads
-  // from server; user toggle persists via configureHosting.
-  const [containerKind, setContainerKind] = useState<"static" | "code" | "mapp" | "">(
-    hosting.containerKind ?? "",
-  );
+  // s150 t636 — Desktop-served vs code-served is derived from `type`.
+  // Replaces the old `containerKind` selector. The mapps input renders only
+  // when the project is Desktop-served; docRoot/startCommand render only
+  // when it's code-served.
+  const desktopServed = isDesktopServedType(type);
   const [mappsInput, setMappsInput] = useState<string>((hosting.mapps ?? []).join(", "));
   const [startCommand, setStartCommand] = useState(hosting.startCommand ?? detectedHosting?.startCommand ?? "");
   const [mode, setMode] = useState<"production" | "development">(hosting.mode ?? "production");
@@ -102,13 +106,13 @@ export function HostingPanel({
 
   // Sync state when hosting prop changes
   useEffect(() => {
+    // s150 t636 — track only the rerender values that survive the migration.
     setType(hosting.type ?? detectedHosting?.projectType ?? "static-site");
     setHostname(hosting.hostname);
     setDocRoot(hosting.docRoot ?? detectedHosting?.docRoot ?? "");
     setStartCommand(hosting.startCommand ?? detectedHosting?.startCommand ?? "");
     setMode(hosting.mode ?? "production");
     setInternalPort(hosting.internalPort !== null ? String(hosting.internalPort) : "");
-    setContainerKind(hosting.containerKind ?? "");
     setMappsInput((hosting.mapps ?? []).join(", "));
   }, [hosting, detectedHosting]);
 
@@ -147,33 +151,35 @@ export function HostingPanel({
     setSaving(true);
     try {
       const portNum = internalPort ? Number(internalPort) : undefined;
-      // s145 t585 — split the comma-separated MApps input into a deduped
-      // array. Empty input + non-mapp kinds → undefined (clears mapps[]).
-      const parsedMapps = containerKind === "mapp"
+      // s150 t636 — Desktop-served projects emit mapps[]; code-served emit
+      // docRoot/startCommand. Empty input on Desktop-served clears mapps[].
+      const parsedMapps = desktopServed
         ? Array.from(new Set(mappsInput.split(",").map((s) => s.trim()).filter((s) => s.length > 0)))
         : undefined;
       await onConfigure({
         path: projectPath,
         type,
         hostname: hostname || undefined,
-        docRoot: docRoot || undefined,
-        // Intentionally send empty string when the user has cleared the field — the
-        // server treats empty/whitespace as "clear the override". Previously
-        // `startCommand || undefined` collapsed an empty string to undefined,
-        // and the server treated undefined as "don't update", so clearing the
-        // field silently did nothing and the stored override persisted.
-        startCommand: startCommand,
+        // s150 t636 — only emit code-served fields for code-served projects.
+        // Desktop-served projects ignore docRoot/startCommand at dispatch
+        // (post-t634); sending stale values would just clutter project.json.
+        ...(desktopServed
+          ? {}
+          : {
+              docRoot: docRoot || undefined,
+              // Intentionally send empty string when the user clears the field —
+              // server treats empty as "clear the override". `startCommand || undefined`
+              // would collapse it to "don't update".
+              startCommand,
+            }),
         mode,
         internalPort: portNum && !isNaN(portNum) ? portNum : undefined,
-        // Only emit containerKind when set — undefined means "leave unchanged",
-        // so existing back-compat projects keep their type-driven kind.
-        containerKind: containerKind === "" ? undefined : containerKind,
         mapps: parsedMapps,
       });
     } catch { /* error handled by caller */ } finally {
       setSaving(false);
     }
-  }, [projectPath, type, hostname, docRoot, startCommand, mode, internalPort, containerKind, mappsInput, onConfigure]);
+  }, [projectPath, type, hostname, docRoot, startCommand, mode, internalPort, desktopServed, mappsInput, onConfigure]);
 
   // Derive the set of compatible languages from installed stacks.
   // If any installed stack declares compatibleLanguages, restrict the runtime
@@ -350,28 +356,13 @@ export function HostingPanel({
             <span className="text-[10px] text-muted-foreground whitespace-nowrap">.{baseDomain}</span>
           </div>
         </div>
-        {/* s145 t585 — Container kind selector. Default ('Auto') leaves the
-            field undefined so HostingManager dispatches based on type +
-            stacks (existing behavior). 'MApp' flips dispatch to the MApp
-            host container branch (currently a stub via t584; t586 will
-            replace it with the real bundle). */}
-        <div data-testid="hosting-container-kind-row">
-          <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
-            Container Kind
-          </label>
-          <Select
-            className="text-[12px]"
-            list={[
-              { value: "", label: "Auto (type-driven)" },
-              { value: "static", label: "Static" },
-              { value: "code", label: "Code" },
-              { value: "mapp", label: "MApp Container" },
-            ]}
-            value={containerKind}
-            onValueChange={(v) => setContainerKind(v as "" | "static" | "code" | "mapp")}
-          />
-        </div>
-        {containerKind === "mapp" && (
+        {/*
+          s150 t636 — Container Kind select REMOVED. The container shape is
+          now derived from `type` via the type registry (DESKTOP_SERVED_TYPES
+          vs CODE_SERVED_TYPES). The MApps input below renders only for
+          Desktop-served types.
+        */}
+        {desktopServed && (
           <div className="col-span-2" data-testid="hosting-mapps-row">
             <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
               MApps <span className="font-normal italic opacity-70">(comma-separated IDs from MApp Marketplace)</span>
@@ -386,72 +377,77 @@ export function HostingPanel({
               data-testid="hosting-mapps-input"
             />
             <p className="mt-0.5 text-[10px] text-muted-foreground leading-tight">
-              s145 t586 implementation pending — for now, flagging this kind sets project status to <code>stopped</code> with a clear reason; the gateway logs the configured MApps.
+              Desktop-served project — listed MApps render as tiles on the project's Desktop.
             </p>
           </div>
         )}
       </div>
 
-      <div className="grid grid-cols-2 gap-2 mb-2">
-        <div>
-          <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
-            Doc Root
-          </label>
-          <Input
-            type="text"
-            value={docRoot}
-            onChange={(e) => setDocRoot(e.target.value)}
-            disabled={busy}
-            placeholder="dist"
-            className="text-[12px] h-8"
-          />
-        </div>
-        <div>
-          <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
-            Start Command <span className="font-normal italic opacity-70">(override)</span>
-          </label>
-          <Input
-            type="text"
-            value={startCommand}
-            onChange={(e) => setStartCommand(e.target.value)}
-            disabled={busy}
-            placeholder={effectiveStart?.stackDefault ?? "npm start"}
-            className="text-[12px] h-8"
-            data-testid="hosting-start-command-input"
-          />
-          <div className="mt-0.5 text-[10px] text-muted-foreground leading-tight">
-            {effectiveStart !== null && (
-              <>
-                <span data-testid="hosting-start-command-source" className={cn(
-                  effectiveStart.source === "override" && "text-blue font-semibold",
-                )}>
-                  {effectiveStart.source === "override" && "Using your override."}
-                  {effectiveStart.source === "stack" && "Using stack default."}
-                  {effectiveStart.source === "devCommands" && "Using stack devCommands fallback."}
-                  {effectiveStart.source === "image-default" && "No command \u2014 image default CMD runs."}
-                </span>
-                {effectiveStart.source !== "override" && effectiveStart.stackDefault && (
-                  <>
-                    {" "}
-                    <span className="opacity-70">Leave empty to keep default: </span>
-                    <code className="text-[10px]">{effectiveStart.stackDefault}</code>
-                  </>
-                )}
-                {effectiveStart.source === "override" && effectiveStart.stackDefault && (
-                  <>
-                    {" "}
-                    <span className="opacity-70">Stack default (cleared by override): </span>
-                    <code className="text-[10px]">{effectiveStart.stackDefault}</code>
-                  </>
-                )}
-              </>
-            )}
-            {effectiveStart === null && (
-              <span className="opacity-70">Leave empty to use your installed stack&apos;s default; when set, this replaces the stack command and runs via sh -c.</span>
-            )}
+      {/* s150 t636 \u2014 docRoot + startCommand only render for code-served projects.
+          Desktop-served projects ignore both fields at dispatch (post-t634);
+          rendering them just wastes attention and invites stale config. */}
+      {!desktopServed && (
+        <div className="grid grid-cols-2 gap-2 mb-2" data-testid="hosting-code-served-fields">
+          <div>
+            <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
+              Doc Root
+            </label>
+            <Input
+              type="text"
+              value={docRoot}
+              onChange={(e) => setDocRoot(e.target.value)}
+              disabled={busy}
+              placeholder="dist"
+              className="text-[12px] h-8"
+            />
+          </div>
+          <div>
+            <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
+              Start Command <span className="font-normal italic opacity-70">(override)</span>
+            </label>
+            <Input
+              type="text"
+              value={startCommand}
+              onChange={(e) => setStartCommand(e.target.value)}
+              disabled={busy}
+              placeholder={effectiveStart?.stackDefault ?? "npm start"}
+              className="text-[12px] h-8"
+              data-testid="hosting-start-command-input"
+            />
+            <div className="mt-0.5 text-[10px] text-muted-foreground leading-tight">
+              {effectiveStart !== null && (
+                <>
+                  <span data-testid="hosting-start-command-source" className={cn(
+                    effectiveStart.source === "override" && "text-blue font-semibold",
+                  )}>
+                    {effectiveStart.source === "override" && "Using your override."}
+                    {effectiveStart.source === "stack" && "Using stack default."}
+                    {effectiveStart.source === "devCommands" && "Using stack devCommands fallback."}
+                    {effectiveStart.source === "image-default" && "No command \u2014 image default CMD runs."}
+                  </span>
+                  {effectiveStart.source !== "override" && effectiveStart.stackDefault && (
+                    <>
+                      {" "}
+                      <span className="opacity-70">Leave empty to keep default: </span>
+                      <code className="text-[10px]">{effectiveStart.stackDefault}</code>
+                    </>
+                  )}
+                  {effectiveStart.source === "override" && effectiveStart.stackDefault && (
+                    <>
+                      {" "}
+                      <span className="opacity-70">Stack default (cleared by override): </span>
+                      <code className="text-[10px]">{effectiveStart.stackDefault}</code>
+                    </>
+                  )}
+                </>
+              )}
+              {effectiveStart === null && (
+                <span className="opacity-70">Leave empty to use your installed stack&apos;s default; when set, this replaces the stack command and runs via sh -c.</span>
+              )}
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div className="grid grid-cols-2 gap-2 mb-2">
         <div>

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -39,7 +39,7 @@ import { MagicAppPicker } from "./MagicAppPicker.js";
 
 export interface ProjectDetailProps {
   projects: ProjectInfo[];
-  onUpdate: (params: { path: string; name?: string; tynnToken?: string | null; category?: string; type?: string }) => Promise<void>;
+  onUpdate: (params: { path: string; name?: string; tynnToken?: string | null; category?: string; type?: string; description?: string }) => Promise<void>;
   updating: boolean;
   onDelete: (params: { path: string; confirm: boolean }) => Promise<void>;
   deleting: boolean;
@@ -114,8 +114,10 @@ export function ProjectDetail({
   const [editName, setEditName] = useState<string | null>(null);
   // s140 cycle-169 t591 — Tynn token state removed; token now lives in
   // the Tynn MCP plugin settings UX, not on the project Details tab.
-  const [editCategory, setEditCategory] = useState<string | null>(null);
   const [editProjectType, setEditProjectType] = useState<string | null>(null);
+  // s150 t636 — free-form purpose textarea replaces the legacy Purpose select.
+  // Bound to project.description (a top-level optional field already in the schema).
+  const [editDescription, setEditDescription] = useState<string | null>(null);
   const [projectTypes, setProjectTypes] = useState<Array<{ id: string; label: string }>>([]);
   const [saving, setSaving] = useState(false);
   const [cloneUrl, setCloneUrl] = useState("");
@@ -266,7 +268,7 @@ export function ProjectDetail({
 
   // Initialize edit fields when project loads
   const name = editName ?? project?.name ?? "";
-  const category = editCategory ?? project?.category ?? project?.projectType?.category ?? "";
+  const description = editDescription ?? project?.description ?? "";
 
   const handleSave = useCallback(async () => {
     if (!project) return;
@@ -276,11 +278,15 @@ export function ProjectDetail({
       // owned by the Tynn MCP plugin settings UX. The PUT route still
       // accepts a tynnToken body for back-compat callers, but the Details
       // tab no longer exposes it.
-      const params: { path: string; name?: string; category?: string; type?: string } = { path: project.path };
+      const params: { path: string; name?: string; type?: string; description?: string } = { path: project.path };
       const trimmedName = name.trim();
       if (trimmedName && trimmedName !== project.name) params.name = trimmedName;
-      if (category && category !== (project.category ?? project.projectType?.category ?? "")) {
-        params.category = category;
+      // s150 t636 — free-form purpose textarea (Description). Empty string is
+      // the canonical "cleared" value, so include it when it differs from the
+      // currently-saved description.
+      const trimmedDescription = description.trim();
+      if (trimmedDescription !== (project.description ?? "")) {
+        params.description = trimmedDescription;
       }
       // Include project type change — also trigger hosting reconfigure
       const selectedType = editProjectType;
@@ -295,7 +301,7 @@ export function ProjectDetail({
     } catch { /* error shown via hook */ } finally {
       setSaving(false);
     }
-  }, [project, name, category, editProjectType, onUpdate]);
+  }, [project, name, description, editProjectType, onUpdate, onHostingConfigure]);
 
   const handleFileSave = useCallback(async () => {
     if (!openFilePath || !fileDirty) return;
@@ -757,43 +763,42 @@ export function ProjectDetail({
                 These settings control how Aion treats the project. Hosting, MCP servers, and
                 environment vars live in their own tabs.
               </p>
-              <div className="grid grid-cols-2 gap-3 mb-3">
-                <div>
-                  <label className="block text-[11px] font-semibold text-muted-foreground mb-1">Purpose</label>
-                  <Select
-                    className="text-[13px]"
-                    list={[
-                      { value: "", label: "Auto-detect" },
-                      { value: "literature", label: "Literature" },
-                      { value: "app", label: "App" },
-                      { value: "web", label: "Web" },
-                      { value: "media", label: "Media" },
-                      { value: "administration", label: "Administration" },
-                    ]}
-                    value={category}
-                    onValueChange={setEditCategory}
-                    disabled={isSacred}
-                  />
-                </div>
-                <div>
-                  <label className="block text-[11px] font-semibold text-muted-foreground mb-1">Project Type</label>
-                  <Select
-                    className="text-[13px]"
-                    list={(() => {
-                      const items = [];
-                      if (project.projectType && !projectTypes.some((t) => t.id === project.projectType?.id)) {
-                        items.push({ value: project.projectType.id, label: `${project.projectType.label} (detected)` });
-                      }
-                      for (const pt of projectTypes) {
-                        items.push({ value: pt.id, label: `${pt.label}${pt.id === project.projectType?.id ? " (detected)" : ""}` });
-                      }
-                      return items;
-                    })()}
-                    value={editProjectType ?? project.projectType?.id ?? ""}
-                    onValueChange={(v) => setEditProjectType(v || null)}
-                    disabled={isSacred}
-                  />
-                </div>
+              {/* s150 t636 — Project Type is the single classifier. The legacy
+                  "Purpose" select (bound to category) is replaced by a free-form
+                  Purpose textarea below (bound to project.description). category
+                  itself is dropped from the data model in s150 t630/t632. */}
+              <div className="mb-3">
+                <label className="block text-[11px] font-semibold text-muted-foreground mb-1">Project Type</label>
+                <Select
+                  className="text-[13px]"
+                  list={(() => {
+                    const items = [];
+                    if (project.projectType && !projectTypes.some((t) => t.id === project.projectType?.id)) {
+                      items.push({ value: project.projectType.id, label: `${project.projectType.label} (detected)` });
+                    }
+                    for (const pt of projectTypes) {
+                      items.push({ value: pt.id, label: `${pt.label}${pt.id === project.projectType?.id ? " (detected)" : ""}` });
+                    }
+                    return items;
+                  })()}
+                  value={editProjectType ?? project.projectType?.id ?? ""}
+                  onValueChange={(v) => setEditProjectType(v || null)}
+                  disabled={isSacred}
+                />
+              </div>
+              <div className="mb-3">
+                <label className="block text-[11px] font-semibold text-muted-foreground mb-1">
+                  Purpose <span className="font-normal italic opacity-70">(free-form — what this project is for)</span>
+                </label>
+                <textarea
+                  className="w-full rounded border border-input bg-background px-2 py-1.5 text-[13px] resize-y min-h-[60px] disabled:opacity-50"
+                  value={description}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  placeholder="One or two lines describing what this project is for. Visible to Aion as project context."
+                  disabled={isSacred}
+                  rows={3}
+                  data-testid="project-purpose-textarea"
+                />
               </div>
 
               {/*

--- a/ui/dashboard/src/lib/project-type-classifier.test.ts
+++ b/ui/dashboard/src/lib/project-type-classifier.test.ts
@@ -1,0 +1,53 @@
+/**
+ * project-type-classifier tests — verifies the dashboard mirror of
+ * gateway-core's DESKTOP_SERVED_TYPES / CODE_SERVED_TYPES classification.
+ *
+ * The real source of truth is gateway-core/src/project-types.ts. The
+ * dashboard duplicates the constants because it can't import gateway-core.
+ * These tests pin the dashboard's view; the gateway-core suite pins the
+ * backend's view; together they enforce the shared contract.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CODE_SERVED_TYPES,
+  DESKTOP_SERVED_TYPES,
+  isDesktopServedType,
+} from "./project-type-classifier";
+
+describe("isDesktopServedType", () => {
+  it("classifies all DESKTOP_SERVED_TYPES as Desktop-served", () => {
+    for (const t of DESKTOP_SERVED_TYPES) {
+      expect(isDesktopServedType(t)).toBe(true);
+    }
+  });
+
+  it("classifies all CODE_SERVED_TYPES as code-served", () => {
+    for (const t of CODE_SERVED_TYPES) {
+      expect(isDesktopServedType(t)).toBe(false);
+    }
+  });
+
+  it("returns false for unknown / null / undefined / empty", () => {
+    expect(isDesktopServedType(null)).toBe(false);
+    expect(isDesktopServedType(undefined)).toBe(false);
+    expect(isDesktopServedType("")).toBe(false);
+    expect(isDesktopServedType("never-registered-type")).toBe(false);
+  });
+
+  it("includes the canonical s150 set on the Desktop side", () => {
+    expect(isDesktopServedType("ops")).toBe(true);
+    expect(isDesktopServedType("media")).toBe(true);
+    expect(isDesktopServedType("literature")).toBe(true);
+    expect(isDesktopServedType("documentation")).toBe(true);
+    expect(isDesktopServedType("backup-aggregator")).toBe(true);
+  });
+
+  it("includes the canonical s150 set on the code side", () => {
+    expect(isDesktopServedType("web-app")).toBe(false);
+    expect(isDesktopServedType("static-site")).toBe(false);
+    expect(isDesktopServedType("api-service")).toBe(false);
+    expect(isDesktopServedType("php-app")).toBe(false);
+    expect(isDesktopServedType("monorepo")).toBe(false);
+  });
+});

--- a/ui/dashboard/src/lib/project-type-classifier.ts
+++ b/ui/dashboard/src/lib/project-type-classifier.ts
@@ -1,0 +1,43 @@
+/**
+ * Dashboard-side mirror of `DESKTOP_SERVED_TYPES` / `CODE_SERVED_TYPES` /
+ * `servesDesktopFor` from gateway-core's project-types.ts.
+ *
+ * Why duplicate: the dashboard runs in the browser and can't import directly
+ * from gateway-core. The lists are small, change rarely (when a new built-in
+ * project type is added on either side of the binary), and are explicitly
+ * cross-checked by the s150 t636 component-contract tests.
+ *
+ * Keep this in sync with `agi/packages/gateway-core/src/project-types.ts`.
+ */
+
+/** Project type IDs whose network face is served by the Aion Desktop bundle. */
+export const DESKTOP_SERVED_TYPES: ReadonlySet<string> = new Set([
+  "ops",
+  "media",
+  "literature",
+  "documentation",
+  "backup-aggregator",
+]);
+
+/** Project type IDs whose network face is produced by the project's own code. */
+export const CODE_SERVED_TYPES: ReadonlySet<string> = new Set([
+  "web-app",
+  "static-site",
+  "api-service",
+  "php-app",
+  "monorepo",
+  "art",
+  "writing",
+]);
+
+/**
+ * Returns whether a project type is Desktop-served (true) vs code-served
+ * (false). Defaults to false for unknown / unset / empty types — code-served
+ * has more conditional UI fields, and a stranger surface is the safer
+ * default to render than the Desktop-served one.
+ */
+export function isDesktopServedType(typeId: string | null | undefined): boolean {
+  if (!typeId) return false;
+  if (DESKTOP_SERVED_TYPES.has(typeId)) return true;
+  return false;
+}


### PR DESCRIPTION
HostingPanel: Container Kind select dropped; mapps + docRoot+startCommand gate on isDesktopServedType. ProjectDetail: Purpose select replaced with free-form Purpose textarea bound to project.description. Backend PUT /api/projects accepts description. New project-type-classifier mirror + 5 unit tests. Closes s150 t636.