### PR TITLE
agi v0.4.542 — s150 t639 category optional + type-id inference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.541",
+  "version": "0.4.542",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/aion-sdk/src/define-panel.ts
+++ b/packages/aion-sdk/src/define-panel.ts
@@ -1,5 +1,12 @@
 /**
  * definePanel — chainable builder for ProjectPanelDefinition.
+ *
+ * @deprecated s150 t639 (2026-05-07) — `registerProjectPanel` has zero
+ * production callers and conflicts with the trimmed primary/secondary tab
+ * model from t638 (plugin panels are part of the secondary overflow, but
+ * none have shipped). Plan: delete in the next major SDK rev. Plugins
+ * needing per-project surfaces should land their own MApp instead — that
+ * surface has clear ownership + UX patterns.
  */
 
 import type { ProjectPanelDefinition, PanelWidget } from "@agi/plugins";

--- a/packages/gateway-core/src/project-types.ts
+++ b/packages/gateway-core/src/project-types.ts
@@ -53,7 +53,14 @@ export interface ContainerConfig {
 export interface ProjectTypeDefinition {
   id: string;
   label: string;
-  category: ProjectCategory;
+  /**
+   * @deprecated s150 t639 (2026-05-07) — `category` is being phased out.
+   * `id` is now the single classifier; `servesDesktop` derives the container
+   * binary; iterative-work / testing-UX eligibility are inferred from
+   * type-id sets instead. Kept optional for back-compat with plugin
+   * manifests that still set it; new manifests should omit it.
+   */
+  category?: ProjectCategory;
   hostable: boolean;
   /**
    * @deprecated s150 (2026-05-07) — use `servesDesktop` (inverted polarity).
@@ -154,7 +161,7 @@ export function servesDesktopFor(
   if (DESKTOP_SERVED_TYPES.has(typeId)) return true;
   if (CODE_SERVED_TYPES.has(typeId)) return false;
   // Final fallback: derive from category if registered, else assume code-served.
-  if (def && CODE_CATEGORIES.has(def.category)) return false;
+  if (def && def.category !== undefined && CODE_CATEGORIES.has(def.category)) return false;
   return def !== undefined; // unknown type with non-code category → Desktop-served
 }
 
@@ -165,6 +172,28 @@ export function servesDesktopFor(
  * don't expose testing tabs/buttons. Mirrors the iterative-work eligibility
  * pattern but with a narrower set.
  */
+/**
+ * s150 t639 — type-id sets for inference paths that previously routed
+ * through `category`. Plugins now express eligibility by registering with
+ * a known id; falling back to the category set keeps legacy paths working.
+ */
+export const ITERATIVE_WORK_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
+  "web-app",
+  "api-service",
+  "static-site",
+  "php-app",
+  "monorepo",
+  "ops",
+]);
+
+export const TESTING_UX_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
+  "web-app",
+  "static-site",
+  "api-service",
+  "php-app",
+  "monorepo",
+]);
+
 export const TESTING_UX_ELIGIBLE_CATEGORIES: ReadonlySet<ProjectCategory> = new Set([
   "app",
   "web",
@@ -219,17 +248,22 @@ export class ProjectTypeRegistry {
   private readonly types = new Map<string, ProjectTypeDefinition>();
 
   register(def: ProjectTypeDefinition): void {
-    // Infer hasCode from category if not explicitly provided
+    // s150 t639 — defaults derive from `id` first, then category fallback for
+    // legacy plugins that still pass it. The id-based maps (DESKTOP_SERVED_TYPES
+    // / CODE_SERVED_TYPES / ITERATIVE_WORK_ELIGIBLE_TYPE_IDS / TESTING_UX_ELIGIBLE_TYPE_IDS)
+    // are the single source of truth.
     let resolved = def.hasCode !== undefined
       ? def
-      : { ...def, hasCode: CODE_CATEGORIES.has(def.category) };
-    // Infer iterativeWorkEligible from category if not explicitly provided
+      : { ...def, hasCode: !servesDesktopFor(def.id) };
     if (resolved.iterativeWorkEligible === undefined) {
-      resolved = { ...resolved, iterativeWorkEligible: ITERATIVE_WORK_ELIGIBLE_CATEGORIES.has(resolved.category) };
+      const idEligible = ITERATIVE_WORK_ELIGIBLE_TYPE_IDS.has(resolved.id);
+      const catEligible = resolved.category !== undefined && ITERATIVE_WORK_ELIGIBLE_CATEGORIES.has(resolved.category);
+      resolved = { ...resolved, iterativeWorkEligible: idEligible || catEligible };
     }
-    // Infer testingUxEligible from category if not explicitly provided (s121)
     if (resolved.testingUxEligible === undefined) {
-      resolved = { ...resolved, testingUxEligible: TESTING_UX_ELIGIBLE_CATEGORIES.has(resolved.category) };
+      const idEligible = TESTING_UX_ELIGIBLE_TYPE_IDS.has(resolved.id);
+      const catEligible = resolved.category !== undefined && TESTING_UX_ELIGIBLE_CATEGORIES.has(resolved.category);
+      resolved = { ...resolved, testingUxEligible: idEligible || catEligible };
     }
     this.types.set(resolved.id, resolved);
   }

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -1134,7 +1134,7 @@ export async function createGatewayRuntimeState(
         const projectTypeId = metaType ?? detectedHosting?.projectType ?? "static";
         const registry = deps.hostingManager?.getProjectTypeRegistry();
         const typeDef = registry?.get(projectTypeId);
-        const projectType = typeDef ? { id: typeDef.id, label: typeDef.label, category: typeDef.category, hostable: typeDef.hostable, hasCode: typeDef.hasCode, iterativeWorkEligible: typeDef.iterativeWorkEligible ?? false, testingUxEligible: typeDef.testingUxEligible ?? false, tools: typeDef.tools } : undefined;
+        const projectType = typeDef ? { id: typeDef.id, label: typeDef.label, category: typeDef.category ?? "", hostable: typeDef.hostable, hasCode: typeDef.hasCode, iterativeWorkEligible: typeDef.iterativeWorkEligible ?? false, testingUxEligible: typeDef.testingUxEligible ?? false, tools: typeDef.tools } : undefined;
         const category = metaCategory ?? projectType?.category ?? null;
         // Effective iterativeWorkEligible — true when the EFFECTIVE category
         // (project.json override or projectType default) is in the eligible

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -802,6 +802,11 @@ export interface AionimaPluginAPI {
   registerStack(def: StackDefinition): void;
   registerChannel(channelPlugin: AionimaChannelPlugin): void;
   registerAction(def: ActionDefinition): void;
+  /**
+   * @deprecated s150 t639 (2026-05-07) — zero production callers; slated for
+   * removal in the next major SDK rev. Plugins needing per-project surfaces
+   * should ship a MApp instead. See define-panel.ts for the SDK-side note.
+   */
   registerProjectPanel(def: ProjectPanelDefinition): void;
   registerSettingsSection(def: SettingsSectionDefinition): void;
   registerSkill(def: SkillRegistration): void;


### PR DESCRIPTION
ProjectTypeDefinition.category becomes optional; register() infers hasCode/iterativeWorkEligible/testingUxEligible from new type-id sets first then category fallback. registerProjectPanel SDK contract marked @deprecated (zero callers). 47/47 regression. Pairs with agi-marketplace v1.0.2. Closes s150 t639.