### PR TITLE
agi v0.4.543 — s150 t640 retire 'monorepo' project type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.542",
+  "version": "0.4.543",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/project-config-shape-migration.test.ts
+++ b/packages/gateway-core/src/project-config-shape-migration.test.ts
@@ -284,6 +284,50 @@ describe("migrateProjectConfigShape", () => {
       expect(hosting.stacks).toHaveLength(1);
     });
 
+    it("remaps retired type='monorepo' to 'web-app' (s150 t640)", () => {
+      writeConfig({
+        name: "demo",
+        type: "monorepo",
+        hosting: {
+          enabled: true,
+          type: "monorepo",
+          hostname: "demo",
+        },
+      });
+
+      const r = migrateProjectConfigShape(projectPath);
+
+      expect(r.configRewritten).toBe(true);
+      expect(r.remappedType).toEqual({ from: "monorepo", to: "web-app" });
+      const after = readConfig();
+      expect(after.type).toBe("web-app");
+      const hosting = after.hosting as Record<string, unknown>;
+      expect(hosting.type).toBe("web-app");
+    });
+
+    it("preserves hosting.type when it differs from a retired top-level type", () => {
+      // If hosting.type is already "web-app" but top-level is the retired
+      // "monorepo", we still remap top-level. The hosting.type stays since
+      // it doesn't match the retired value.
+      writeConfig({
+        name: "demo",
+        type: "monorepo",
+        hosting: {
+          enabled: true,
+          type: "web-app",
+          hostname: "demo",
+        },
+      });
+
+      const r = migrateProjectConfigShape(projectPath);
+
+      expect(r.remappedType).toEqual({ from: "monorepo", to: "web-app" });
+      const after = readConfig();
+      expect(after.type).toBe("web-app");
+      const hosting = after.hosting as Record<string, unknown>;
+      expect(hosting.type).toBe("web-app"); // unchanged
+    });
+
     it("handles hosting.stacks[] absent gracefully", () => {
       writeConfig({
         name: "demo",

--- a/packages/gateway-core/src/project-config-shape-migration.ts
+++ b/packages/gateway-core/src/project-config-shape-migration.ts
@@ -44,7 +44,9 @@ const CATEGORY_TO_DEFAULT_TYPE: Readonly<Record<string, string>> = Object.freeze
   media: "art",
   administration: "ops",
   ops: "ops",
-  monorepo: "monorepo",
+  // s150 t640 — `category: monorepo` maps to `web-app` (every project is a
+  // monorepo; the sibling "monorepo" type was retired).
+  monorepo: "web-app",
 });
 
 export interface ShapeMigrationResult {
@@ -61,9 +63,23 @@ export interface ShapeMigrationResult {
   /** s150 t635 — populated when `hosting.stacks[]` entries were stripped
    * because the project is Desktop-served (stacks don't apply). */
   strippedStacks?: string[];
+  /** s150 t640 — populated when type was remapped from a retired id (e.g.
+   * "monorepo" → "web-app"). */
+  remappedType?: { from: string; to: string };
   /** Populated when migration failed for the project (non-fatal). */
   error?: string;
 }
+
+/**
+ * s150 t640 — types that have been retired from the registry. Existing
+ * project.json files carrying these values are remapped on read so they
+ * route to a sensible live type instead of falling through to "unknown".
+ */
+const RETIRED_TYPE_REMAP: Readonly<Record<string, string>> = Object.freeze({
+  // "Every project IS a monorepo" — a peer "monorepo" project type
+  // contradicts the model; web-app is the most-common concrete shape.
+  monorepo: "web-app",
+});
 
 export interface ShapeMigrationOptions {
   /**
@@ -126,6 +142,22 @@ export function migrateProjectConfigShape(
 
   const next: Record<string, unknown> = { ...raw };
   let mutated = false;
+
+  // 2a-pre — s150 t640 — remap retired type ids to their live successor.
+  // Run BEFORE the type-derivation step so derivation logic doesn't see the
+  // stale value. The hosting.type sub-field is also remapped so dispatch
+  // and dashboard payload agree.
+  const currentType = typeof next.type === "string" ? next.type : undefined;
+  if (currentType !== undefined && RETIRED_TYPE_REMAP[currentType] !== undefined) {
+    const replacement = RETIRED_TYPE_REMAP[currentType]!;
+    next.type = replacement;
+    result.remappedType = { from: currentType, to: replacement };
+    const hostingForRemap = next.hosting as Record<string, unknown> | undefined;
+    if (hostingForRemap !== undefined && hostingForRemap.type === currentType) {
+      next.hosting = { ...hostingForRemap, type: replacement };
+    }
+    mutated = true;
+  }
 
   // 2a — ensure top-level `type` is set.
   if (typeof next.type !== "string" || next.type.length === 0) {
@@ -213,6 +245,8 @@ export interface ShapeSweepResult {
   debrisRemoved: number;
   /** s150 t635 — how many had stacks stripped (Desktop-served cleanup). */
   stacksStripped: number;
+  /** s150 t640 — how many had their type remapped from a retired id. */
+  typesRemapped: number;
   /** How many failed the migration (non-fatal). */
   errors: number;
   /** Per-project results for the boot log / dashboard. */
@@ -229,7 +263,7 @@ export function migrateAllProjectConfigShapes(
   workspaceProjects: readonly string[],
   options: ShapeMigrationOptions = {},
 ): ShapeSweepResult {
-  const out: ShapeSweepResult = { scanned: 0, rewrote: 0, debrisRemoved: 0, stacksStripped: 0, errors: 0, projects: [] };
+  const out: ShapeSweepResult = { scanned: 0, rewrote: 0, debrisRemoved: 0, stacksStripped: 0, typesRemapped: 0, errors: 0, projects: [] };
 
   for (const dir of workspaceProjects) {
     let entries: string[];
@@ -251,6 +285,7 @@ export function migrateAllProjectConfigShapes(
         if (result.configRewritten) out.rewrote++;
         if (result.agiDebrisRemoved) out.debrisRemoved++;
         if (result.strippedStacks !== undefined && result.strippedStacks.length > 0) out.stacksStripped++;
+        if (result.remappedType !== undefined) out.typesRemapped++;
         if (result.error !== undefined) out.errors++;
       } catch (e) {
         out.errors++;

--- a/packages/gateway-core/src/project-types.ts
+++ b/packages/gateway-core/src/project-types.ts
@@ -133,7 +133,10 @@ export const CODE_SERVED_TYPES: ReadonlySet<string> = new Set([
   "static-site",
   "api-service",
   "php-app",
-  "monorepo",
+  // s150 t640 (2026-05-07) — "monorepo" REMOVED. Every project is a monorepo
+  // per the universal-monorepo directive; a sibling "monorepo" type as a
+  // peer of web-app/static-site/etc. contradicts the model. The s150 t632
+  // shape sweep remaps existing type="monorepo" projects to "web-app".
   "art",
   "writing",
 ]);
@@ -182,7 +185,6 @@ export const ITERATIVE_WORK_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
   "api-service",
   "static-site",
   "php-app",
-  "monorepo",
   "ops",
 ]);
 
@@ -191,7 +193,6 @@ export const TESTING_UX_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
   "static-site",
   "api-service",
   "php-app",
-  "monorepo",
 ]);
 
 export const TESTING_UX_ELIGIBLE_CATEGORIES: ReadonlySet<ProjectCategory> = new Set([

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -1845,10 +1845,13 @@ export async function startGatewayServer(
       // sweep. Cleanup of pre-t634 over-attached state on disk.
       isDesktopServedType: (type) => servesDesktopFor(type, projectTypeRegistry),
     });
-    if (result.rewrote > 0 || result.debrisRemoved > 0 || result.stacksStripped > 0 || result.errors > 0) {
+    if (
+      result.rewrote > 0 || result.debrisRemoved > 0 || result.stacksStripped > 0
+      || result.typesRemapped > 0 || result.errors > 0
+    ) {
       logger.info(
         "migrate",
-        `boot-time s150 shape sweep: ${String(result.scanned)} scanned, ${String(result.rewrote)} rewritten, ${String(result.debrisRemoved)} .agi/project.json removed, ${String(result.stacksStripped)} stack-set(s) stripped, ${String(result.errors)} error(s)`,
+        `boot-time s150 shape sweep: ${String(result.scanned)} scanned, ${String(result.rewrote)} rewritten, ${String(result.debrisRemoved)} .agi/project.json removed, ${String(result.stacksStripped)} stack-set(s) stripped, ${String(result.typesRemapped)} type(s) remapped, ${String(result.errors)} error(s)`,
       );
     }
   } catch (err) {


### PR DESCRIPTION
Per universal-monorepo directive: every project IS a monorepo. Drop 'monorepo' from CODE_SERVED_TYPES + iterative/testing eligibility sets. Extend t632 sweep with RETIRED_TYPE_REMAP (monorepo → web-app); remaps both top-level type and hosting.type idempotently. Pairs with agi-marketplace v1.0.3 which removes the plugin-project-monorepo source. Closes s150 t640.