### PR TITLE
agi v0.4.545 — s150 t642 doc rewrite (closes s150 13/13)

### DIFF
--- a/docs/agents/magic-apps.md
+++ b/docs/agents/magic-apps.md
@@ -62,30 +62,36 @@ MApps are classified into 5 top-level categories:
 | `game` | Interactive games & simulations | (Future) |
 | `custom` | Catch-all | (User-defined) |
 
-### Project Category Compatibility
+### Project Type Compatibility (s150 model)
 
-MApps declare which project categories they serve via `projectCategories`:
+MApps declare which **project types** they serve via `projectTypes`:
 
-`literature`, `app`, `web`, `media`, `administration`, `ops`, `monorepo`
+Code-served: `web-app`, `static-site`, `api-service`, `php-app`, `art`, `writing`
+Desktop-served: `ops`, `media`, `literature`, `documentation`, `backup-aggregator`
 
-Empty `projectCategories` means compatible with all types.
+Empty `projectTypes` means compatible with all. The legacy `projectCategories` field is still recognized for back-compat (s150 t630/t639 dropped `category` from the project schema and from registerProjectType plugin manifests; MApp-side migration to `projectTypes` is the next step). New MApp definitions should set `projectTypes` only.
 
 ## Container Resolution Order
 
 When `HostingManager.startContainer()` runs for a project:
 
-1. **MagicApp** — checked first. If a MagicApp is set as the project's viewer, its container config is used.
-2. **Stack** — if no MagicApp, checks installed stacks for `containerConfig`.
-3. **Legacy** — fallback to hardcoded image constants.
+1. **Desktop-served dispatch** (`isDesktopServed(meta)` via `servesDesktopFor(type)`) — when the project's `type` is in `DESKTOP_SERVED_TYPES`, the gateway runs the unified desktop+tiles container (nginx:alpine + generated MApp Desktop HTML, tiles from `hosting.mapps[]`). This replaces the legacy `containerKind === "mapp"` branch (s150 t634).
+2. **Multi-repo** — if the project has multiple repos with `port` set, build dedicated multi-repo container args.
+3. **Single-MApp viewer** (legacy fallback) — if a registered MApp resolves for the project's type via `resolveMagicAppContainerConfig`, its container config drives dispatch. Wish #14 tracks the collapse of this path into the unified Desktop-served dispatch once owner UX direction is clear.
+4. **Stack** — if no Desktop-served + no single-viewer match, checks installed stacks for `containerConfig`.
+5. **Legacy** — fallback to hardcoded image constants.
 
 ## Dashboard Integration
 
-The MApp desktop (`/magic-apps`) organizes apps into category Cards with icon buttons. Clicking an app opens a Project Picker filtered to compatible projects.
+The MApp Marketplace UI lists every registered MApp; install/uninstall happens there at the system level.
 
-In project detail, the **MagicApps tab** allows:
-- Setting a **Content Viewer** (non-dev projects) via `PUT /api/projects/viewer`
-- **Attaching/detaching** MApps via `PUT/DELETE /api/projects/magic-apps`
-- **Opening** MApps in floating/docked modals
+After s150 t637, **per-project MApp configuration lives inside the Hosting tab**, not a standalone MagicApps tab:
+
+- Desktop-served projects render the MagicAppPicker inline beneath the Hosting card.
+- The `mapps` input on the Hosting panel takes a comma-separated list of MApp IDs that become tiles.
+- The `viewer` field still sets a single MApp viewer (legacy path; see Container Resolution Order #3).
+
+The standalone `/magic-apps` route is still the system-wide marketplace surface. It's the project-tab merge that changed in t637.
 
 ## MAppDefinition Fields
 
@@ -132,18 +138,20 @@ MApp lifecycle events are tracked via the Impactinomics COA<>COI chain:
 
 ## Default MApps (Marketplace)
 
-| App | Category | Project Categories |
+> **Note:** the s150 model classifies projects by `type`, not `category`. The "Project Categories" column below reflects the legacy field that MApp definitions still set; new MApps should declare `projectTypes` instead. The `monorepo` category is retired (s150 t640) — entries that listed it now imply `web-app`.
+
+| App | Category | Project Categories (legacy) |
 |-----|----------|--------------------|
 | Reader | viewer | literature |
 | Gallery | viewer | media |
-| Code Browser | viewer | app, web, monorepo |
+| Code Browser | viewer | app, web |
 | Dashboard Viewer | viewer | administration, ops |
 | Mind Mapper | production | literature |
-| Dev Workbench | production | app, web, monorepo |
+| Dev Workbench | production | app, web |
 | Media Studio | production | media |
 | Admin Editor | production | administration |
 | Runbook Editor | production | ops |
-| Project Analyzer | tool | app, web, monorepo |
+| Project Analyzer | tool | app, web |
 | Ops Monitor | tool | ops |
 
 ## Key Files

--- a/docs/agents/project-config-schema.md
+++ b/docs/agents/project-config-schema.md
@@ -1,12 +1,38 @@
 # Project Config Schema
 
-Per-project configuration files at `~/.agi/{slug}/project.json`.
+Per-project configuration files at `<projectPath>/project.json` (s140 + s150 model).
+
+> **Reconciliation reference:** the rationale for every shape decision below — including why `category` and `hosting.containerKind` were dropped, why every project has `repos/`, and how `type` drives container shape — lives in `_discovery/pm-hosting-reconciliation.md`. That doc is canonical for the s150 PM/Hosting alignment work.
 
 ## Overview
 
-Every managed project has a config file at `~/.agi/{slug}/project.json` where `{slug}` is derived from the project path (e.g., `/home/user/projects/my-app` becomes `home-user-projects-my_app`).
+Every managed project has a config file at `<projectPath>/project.json` (the s140 root location; pre-s130 `~/.agi/{slug}/project.json` and intermediate `<projectPath>/.agi/project.json` are migrated transparently and the legacy locations are no longer authoritative). `<projectPath>` is `<workspaceRoot>/<slug>/` — typically `~/_projects/<slug>/`.
 
 **All reads and writes go through `ProjectConfigManager`** — never read or write project.json directly. The service validates via Zod, emits change events for live WS updates, and handles per-path locking for concurrent access.
+
+The s150 architecture enforces a **single classifier**: `type` is the source of truth for what a project is. The legacy `category` field has been retired (s150 t630/t632), and `hosting.containerKind` has been retired (s150 t630/t634). The container shape — code-served vs Desktop-served — is derived from `type` via `servesDesktopFor(type, registry)`.
+
+## On-disk layout
+
+Every project — regardless of type — has the same skeleton:
+
+```
+<projectPath>/
+├── project.json            # canonical config (the ONLY one — no .agi/project.json)
+├── repos/                  # UNIVERSAL — every project has a repos/ directory
+│   └── <repo_name>/        # one or more sub-repos (clones, project-owned scratch)
+├── k/
+│   ├── plans/              # per-project plans
+│   ├── knowledge/          # markdown notes, design docs, references
+│   ├── pm/                 # PM-Lite kanban data
+│   ├── memory/             # per-project Aion memory
+│   └── chat/               # per-project chat sessions
+├── sandbox/                # agent scratch space — keeps chat-tool cage
+│                           #   primitive from writing into repos/ or k/
+└── .trash/                 # soft-delete buffer
+```
+
+The `<workspaceRoot>/.new/` skeleton (s150 t633) is the source of truth for new-project scaffolding. Boot seeds it from agi-shipped templates the first time and prefers the workspace copy thereafter, so owners can customize the skeleton without forking agi.
 
 ## Schema Reference
 
@@ -17,39 +43,40 @@ Every managed project has a config file at `~/.agi/{slug}/project.json` where `{
 | `name` | `string` | Yes | — | Display name |
 | `createdAt` | `string` | No | — | ISO 8601 creation timestamp |
 | `tynnToken` | `string` | No | — | Tynn project token (external integration) |
-| `type` | `string` | No | — | Project type ID (e.g., `"web-app"`, `"api-service"`, `"static-site"`) |
-| `category` | `enum` | No | — | One of: `literature`, `app`, `web`, `media`, `administration`, `ops`, `monorepo` |
-| `description` | `string` | No | — | Human-readable description |
+| `type` | `string` | No | — | **The single classifier.** A registered project type id (e.g., `"web-app"`, `"api-service"`, `"static-site"`, `"ops"`, `"writing"`). |
+| `description` | `string` | No | — | Free-form Purpose textarea — what this project is for. Visible to Aion as project context. |
 | `hosting` | `object` | No | — | Hosting config (present when project has been configured for hosting) |
-| `magicApps` | `string[]` | No | — | Attached MagicApp IDs |
+| `magicApps` | `string[]` | No | — | Attached MagicApp IDs (Desktop-served projects render these as tiles) |
+| `repos` | `array` | No | — | Sub-repo entries served from this project (multi-repo case) |
 | `aiModels` | `array` | No | — | AI model dependencies (HuggingFace bindings) |
 | `aiDatasets` | `array` | No | — | AI dataset dependencies |
-| `iterativeWork` | `object` | No | — | Iterative-work mode toggle — when `enabled: true`, the prompt assembler injects `agi/prompts/iterative-work.md` so Aion participates in the tynn workflow on this project's behalf |
+| `iterativeWork` | `object` | No | — | Iterative-work mode toggle |
+| `mcp` | `object` | No | — | Per-project MCP servers (s118 / Wish #7) |
 
-The root uses `.passthrough()` — plugins can store custom keys at the root level and they will survive read/write cycles.
+The root uses `.passthrough()` — plugins can store custom keys at the root level and they will survive read/write cycles. Boot-time s150 sweep (`migrateAllProjectConfigShapes`) cleans legacy keys (`category`, retired `type` ids) idempotently.
 
-### Iterative Work Object (`.strict()`)
+> **Removed (s150):** `category` is no longer surfaced from this schema. `ProjectCategorySchema` export remains for back-compat with `magic-app-schema.ts` until that schema migrates to `projectTypes`. Boot sweep strips on-disk values.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | `boolean` | `undefined` (treated as off) | When `true`, the system prompt assembler injects `agi/prompts/iterative-work.md` for project-typed requests on this project. Hot-reloads — no restart needed. |
-| `cron` | `string` | — | Cron expression consumed by the cron-nudge scheduler (story s118 / t436). When omitted while `enabled: true`, manual fire only (e.g. via `/next`). |
-
-### Hosting Object (`.strict()`)
+### Hosting Object (`.passthrough()`)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `boolean` | `false` | Whether hosting is active |
-| `type` | `string` | `"static-site"` | Project type ID |
+| `type` | `string` | `"static-site"` | Project type ID (mirrors top-level `type`) |
 | `hostname` | `string` | — | Subdomain (e.g., `"my-project"` → `my-project.ai.on`) |
-| `docRoot` | `string \| null` | `null` | Document root relative to project dir |
-| `startCommand` | `string \| null` | `null` | Shell command to start the project |
+| `docRoot` | `string \| null` | `null` | Document root relative to project dir (code-served only) |
+| `startCommand` | `string \| null` | `null` | Shell command to start the project (code-served only) |
 | `port` | `number \| null` | `null` | Allocated host port for container mapping |
 | `mode` | `"production" \| "development"` | `"production"` | Runtime mode |
 | `internalPort` | `number \| null` | `null` | Container internal port override |
 | `runtimeId` | `string \| null` | — | Runtime definition ID (from plugin registry) |
 | `tunnelUrl` | `string \| null` | — | Active Cloudflare tunnel URL |
-| `stacks` | `array` | `[]` | Installed stack instances |
+| `tunnelId` | `string \| null` | — | Named tunnel ID (persists across restarts) |
+| `viewer` | `string` | — | MagicApp ID used as the content viewer for the project's `*.ai.on` URL |
+| `mapps` | `string[]` | — | List of MApp IDs installed in this project's Desktop tile bundle (Desktop-served only) |
+| `stacks` | `array` | `[]` | Installed stack instances (code-served only after s150 t635) |
+
+> **Removed (s150):** `containerKind` is no longer schema-enforced. Dispatch reads `type` via `isDesktopServedType` instead. The dashboard payload still surfaces a computed `containerKind` for back-compat consumers; that surface lands gone in a follow-up SDK rev.
 
 ### Stack Instance Object (`.strict()`)
 
@@ -61,28 +88,37 @@ The root uses `.passthrough()` — plugins can store custom keys at the root lev
 | `databasePassword` | `string` | No | Per-project database password |
 | `addedAt` | `string` | Yes | ISO 8601 timestamp |
 
-## Auto-Detection vs User-Set
+### Repo Entry Object (`.strict()`)
 
-| Field | Source |
-|-------|--------|
-| `type` | Auto-detected from project files by `detectProjectDefaults()`, but user can override via UI dropdown or agent tool |
-| `category` | Auto-detected from type, user can override |
-| `hostname` | Generated from project directory name, user can change in hosting panel |
-| `docRoot`, `startCommand` | Auto-detected, user can override |
-| `stacks` | Suggested by detection, added/removed by user |
+For multi-repo projects, each entry under `repos[]` describes a clone bind-mounted into `<projectPath>/repos/<name>/`. See `config/src/project-schema.ts` `ProjectRepoSchema` for the full field list (`name`, `url`, `branch`, `port`, `startCommand`, `isDefault`, `externalPath`, `attachedStacks`, etc.).
 
-## Plugin Extension
+### Iterative Work Object (`.strict()`)
 
-Plugins can store arbitrary keys at the root of `project.json`:
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `boolean` | `undefined` | When `true`, the system prompt assembler injects `agi/prompts/iterative-work.md` for project-typed requests on this project. Hot-reloads — no restart needed. |
+| `cadence` | `enum` | — | User-picked cadence (`30m`, `1h`, `5h`, `12h`, `1d`, `5d`, `1w`). Auto-staggered to a cron expression at save time. |
+| `cron` | `string` | — | Cron expression. When `cadence` is set, this is auto-computed; when only `cron` is set (legacy), it remains the source of truth. |
 
-```json
-{
-  "name": "my-project",
-  "myPluginConfig": { "setting": true }
-}
-```
+## Project type → container shape
 
-The `.passthrough()` on the root schema preserves unknown keys during read/write cycles. The hosting sub-object uses `.strict()` and does NOT allow plugin keys.
+The `type` field discriminates two container-shape paths:
+
+- **Desktop-served** (`servesDesktopFor(type)` returns `true`): types `ops`, `media`, `literature`, `documentation`, `backup-aggregator`. The container is the Aion Desktop bundle (light Caddy + nginx:alpine + per-project `hosting.mapps[]`). Code in `repos/` is metadata or content; the Desktop renders MApp tiles and serves them.
+- **Code-served** (default): types `web-app`, `static-site`, `api-service`, `php-app`, `art`, `writing`. The container image + mounts come from the type registry + installed stacks; the project's `repos/` produces the served output (`npm start`, `nginx`-on-`dist`, `apache`-on-`php`, etc.).
+
+When ambiguous, `servesDesktopFor` consults the type registry's explicit `servesDesktop` flag first, then the `DESKTOP_SERVED_TYPES` / `CODE_SERVED_TYPES` sets, then a category-set fallback for legacy plugins. See `agi/packages/gateway-core/src/project-types.ts`.
+
+> **Retired (s150 t640):** `monorepo` was removed from the type registry. Every project IS a monorepo per the universal-monorepo directive; a sibling "monorepo" type contradicts the model. The boot sweep remaps existing `type: "monorepo"` to `"web-app"` idempotently.
+
+## Migration paths
+
+Two boot-time sweeps converge the workspace on the s150 model on every gateway start:
+
+1. **Folder-layout sweep** (`migrateAllProjectsToFolderLayout`, s130 t523): ensures every project has the canonical skeleton (`k/`, `repos/`, `sandbox/`, `.trash/`).
+2. **Shape sweep** (`migrateAllProjectConfigShapes`, s150 t632/t635/t640): drops legacy `category`, drops `hosting.containerKind`, ensures top-level `type` is set, removes `.agi/project.json` debris, strips stacks from Desktop-served projects, remaps retired type ids.
+
+Both are idempotent. Already-migrated projects are silent no-ops; only changes log to the boot output.
 
 ## Service API
 
@@ -141,9 +177,9 @@ The `manage_project` agent tool handles all project operations through the servi
 
 | Action | Description |
 |--------|-------------|
-| `update` | Update name, tynnToken, type, category |
+| `update` | Update name, tynnToken, type, description |
 | `hosting_configure` | Update hosting fields |
-| `stack_add` / `stack_remove` | Manage stacks |
+| `stack_add` / `stack_remove` | Manage stacks (code-served projects only) |
 
 All actions go through `ProjectConfigManager` — no direct file I/O.
 
@@ -154,47 +190,20 @@ Defined in `config/src/project-schema.ts`:
 - `ProjectConfigSchema` — root
 - `ProjectHostingSchema` — hosting sub-object
 - `ProjectStackInstanceSchema` — stack instance
-- `ProjectCategorySchema` — category enum
+- `ProjectRepoSchema` — sub-repo entry
+- `ProjectMcpServerSchema` / `ProjectMcpSchema` — per-project MCP servers
+- `ProjectCategorySchema` — legacy enum (kept for back-compat consumers)
 
 Types exported from `@agi/config`:
-- `ProjectConfig`, `ProjectHosting`, `ProjectStackInstance`, `ProjectCategory`
+- `ProjectConfig`, `ProjectHosting`, `ProjectStackInstance`, `ProjectRepo`, `ProjectMcpServer`, `ProjectMcp`
 
-## Dashboard Tab Architecture
+## Dashboard surface
 
-The dashboard project detail page uses **different tabs for different project categories**:
+After s150 t636/t637/t638 the project detail page is type-driven, not category-driven:
 
-### Code projects (`hasCode: true`)
-Categories: `web`, `app`, `monorepo`, `ops`
-
-Show the **Development** tab with the built-in `HostingPanel` component — full container management, stack selection, environment variables, terminal, restart/configure controls.
-
-### Non-code projects (`hasCode: false`)
-Categories: `literature`, `media`, `administration`
-
-Do **NOT** show the Development tab. Instead, the project type's plugin provides its own tab via `registerProjectPanel()`:
-
-- **Literature** → "Reader" tab (provided by `plugin-reader-literature`)
-- **Media** → "Gallery" tab (provided by `plugin-reader-media`)
-
-These plugin-provided tabs use the declarative widget system (`WidgetRenderer`) with:
-- `status-display` — shows container status from plugin HTTP route
-- `iframe` — embeds the reader/gallery SPA at the project's `*.ai.on` URL
-- `action-bar` — restart/manage actions
-
-### Widget templates
-
-Widget endpoints support `{projectPath}` template substitution:
-```json
-{ "type": "status-display", "statusEndpoint": "/status?path={projectPath}" }
-{ "type": "iframe", "src": "/reader-frame?path={projectPath}", "height": "600px" }
-```
-
-The `{projectPath}` is replaced with the current project's path at render time.
-
-### Adding a reader for a new project type
-
-1. Create a marketplace plugin
-2. Register a stack with `containerConfig` (nginx + your reader SPA assets)
-3. Register a project panel with `registerProjectPanel()` targeting your project type
-4. Register HTTP routes for status and iframe redirect
-5. The plugin handles hosting transparently — no user interaction needed
+- **Hosting tab** is universal (every project has a network face). Inside, the panel adapts to `isDesktopServedType(type)`:
+  - Desktop-served → MApps list input visible; `docRoot` / `startCommand` hidden.
+  - Code-served → `docRoot` / `startCommand` visible; MApps list hidden.
+- **MagicApps tab** was retired; the picker now renders inline below the Hosting card when type is Desktop-served.
+- **Purpose** is a free-form textarea bound to `description` (was a `category` Select).
+- **Tab clutter trim:** primary tabs are Details / Editor / Hosting / Activity; secondary tabs (Repository / Environment / TaskMaster / Iterative Work / MCP / plugin-* / Security) collapse into a "More…" overflow Select.

--- a/docs/human/project-hosting.md
+++ b/docs/human/project-hosting.md
@@ -1,6 +1,8 @@
 # Project Hosting
 
-Aionima can host local web projects and services on your LAN using Caddy as a reverse proxy, dnsmasq for local DNS, and Podman for container isolation. Projects are accessible via human-readable hostnames on your local network (e.g. `myapp.ai.on`).
+Aionima can host local projects and services on your LAN using Caddy as a reverse proxy, dnsmasq for local DNS, and Podman for container isolation. Projects are accessible via human-readable hostnames on your local network (e.g. `myapp.ai.on`).
+
+> **Universal monorepo model (s150).** Every project — code-served or Desktop-served — has a `repos/` directory and a network face. The `type` field in `<projectPath>/project.json` is the single classifier; it discriminates between projects that serve code (web-app, static-site, api-service, php-app, art, writing) and projects that serve a Desktop bundle of MApp tiles (ops, media, literature, documentation, backup-aggregator). The legacy `category` and `hosting.containerKind` fields have been retired (see `_discovery/pm-hosting-reconciliation.md` for the full reconciliation).
 
 ---
 
@@ -98,15 +100,32 @@ bash scripts/hosting-setup.sh
 
 ## Project Types
 
-Each project has a type that determines how it is run and hosted.
+The `type` field in `<projectPath>/project.json` discriminates two container shapes — code-served vs Desktop-served. The dispatch helper `servesDesktopFor(type, registry)` reads the type registry's explicit `servesDesktop` flag first, then falls back to the canonical id sets below.
 
-| Type | Runtime | Container Image | Notes |
-|------|---------|----------------|-------|
-| `node` | Node.js | Plugin-configured | Runs `npm start` or configured start command |
-| `php` | PHP-FPM | Plugin-configured | Requires `plugin-php-runtime` |
-| `static` | Caddy (static files) | None | Serves files directly from disk |
+### Code-served (the project's own code produces the network face)
 
-Additional project types can be added by runtime plugins (see the [Plugins](./plugins.md) document).
+| Type id | Typical project | Container shape |
+|---------|-----------------|----------------|
+| `web-app` | React/Vue/Next/Nuxt apps | Stack-driven (`stack-nextjs`, `stack-react-vite`, `stack-nuxt`, etc.) |
+| `static-site` | Static HTML/Vite-only output | Caddy static, `dist/` served from `repos/<name>/dist` |
+| `api-service` | Node/Go/Rust/FastAPI services | Stack-driven (`stack-node-app`, `stack-fastapi`, `stack-go-app`, …) |
+| `php-app` | Laravel / WordPress / loose `.php` | `aionima-php-runtime` Apache image |
+| `art` | Code that produces media art | Stack-driven (mostly static) |
+| `writing` | Markdown content with a code-driven SSG | Stack-driven |
+
+### Desktop-served (Aion Desktop bundle serves the network face)
+
+| Type id | Typical project | Container shape |
+|---------|-----------------|----------------|
+| `ops` | Operations dashboards, monitoring | nginx:alpine + generated MApp Desktop, tiles from `hosting.mapps[]` |
+| `media` | Image / video / asset libraries | nginx:alpine + MApp tiles |
+| `literature` | Book-style content, chronicles | nginx:alpine + MApp tiles |
+| `documentation` | Project family docs aggregator | nginx:alpine + MApp tiles |
+| `backup-aggregator` | Cross-repo backup index | nginx:alpine + MApp tiles |
+
+Additional project types can be added by runtime plugins (see [Plugins](./plugins.md)). Plugin manifests should NOT set a `category` — `id` alone identifies the type, and the gateway derives Desktop-served vs code-served from the canonical sets in `agi/packages/gateway-core/src/project-types.ts`.
+
+> **Retired (s150 t640):** the `monorepo` project type was removed. Every project IS a monorepo per the universal-monorepo directive; a sibling "monorepo" type contradicted the model. Boot sweep remaps existing `type: "monorepo"` to `"web-app"`.
 
 ---
 
@@ -114,26 +133,44 @@ Additional project types can be added by runtime plugins (see the [Plugins](./pl
 
 ### Adding a Project
 
-Projects are added via the dashboard (Projects section). The AGI stores all project configuration in `~/.agi/{projectSlug}/project.json` — nothing is written inside the project directory itself.
+Projects are added via the dashboard (Projects section). Configuration lives at the project root: `<projectPath>/project.json`. Pre-s130 location (`~/.agi/{slug}/project.json`) and the intermediate `<projectPath>/.agi/project.json` are migrated transparently.
 
-For example, a project at `/home/user/myproject` stores its config at `~/.agi/home-user-myproject/project.json`:
+For example, a code-served project at `/home/user/_projects/myapp/`:
 
 ```json
 {
   "name": "My App",
-  "type": "node",
+  "type": "web-app",
+  "description": "Customer-facing storefront.",
   "hosting": {
     "enabled": true,
     "hostname": "myapp",
     "mode": "production",
     "startCommand": "node dist/server.js",
     "docRoot": null,
-    "internalPort": 3000
+    "internalPort": 3000,
+    "stacks": [{ "stackId": "stack-nextjs", "addedAt": "2026-04-01T00:00:00Z" }]
   }
 }
 ```
 
-The project is then accessible at `http://myapp.ai.on` on your LAN.
+A Desktop-served project (e.g. operations dashboards) looks like:
+
+```json
+{
+  "name": "Civicognita Ops",
+  "type": "ops",
+  "description": "Operations dashboards for Civicognita.",
+  "hosting": {
+    "enabled": true,
+    "hostname": "civicognita-ops",
+    "mode": "production",
+    "mapps": ["ops-monitor", "incident-board"]
+  }
+}
+```
+
+Both projects are then accessible at `https://<hostname>.ai.on` on your LAN.
 
 ### Project Hosting Fields
 
@@ -141,21 +178,22 @@ The project is then accessible at `http://myapp.ai.on` on your LAN.
 |-------|-------------|
 | `enabled` | Whether hosting is active for this project |
 | `hostname` | Subdomain under the base domain (e.g. `myapp` → `myapp.ai.on`) |
+| `type` | Project type id (mirrors top-level `type`; drives container shape) |
 | `mode` | `production` or `development` |
-| `startCommand` | Command to run the project (for non-static types) |
-| `docRoot` | Document root for static file serving |
+| `startCommand` | Command to run the project (code-served only) |
+| `docRoot` | Document root for static file serving (code-served only) |
 | `internalPort` | Port the app listens on inside the container |
-| `runtimeId` | Plugin runtime ID (e.g. `node-22`, `php-8.5`) |
-| `containerKind` | Override dispatch — `"static"`, `"code"`, or `"mapp"`. Leave unset for the project-type default. |
-| `mapps` | List of MApp IDs to render on the MApp Desktop when `containerKind = "mapp"` |
+| `runtimeId` | Plugin runtime ID (e.g. `node-24`, `php-8.4`) |
+| `mapps` | List of MApp IDs to render as Desktop tiles (Desktop-served only) |
+| `stacks` | Installed stacks (code-served only — boot sweep strips for Desktop-served) |
+| `tunnelUrl` / `tunnelId` | Cloudflare named-tunnel state |
+| `viewer` | Single MApp viewer (legacy single-viewer path; superseded by `mapps[]` for new projects) |
 
-### MApp Container Kind
+> **Removed (s150 t634):** the `containerKind` field on `hosting` is no longer schema-enforced. The dashboard payload still computes a `containerKind` value from `type` for back-compat consumers; that surface lands gone in a follow-up SDK rev.
 
-Operations / media / literature projects often have no codebase to run and no
-custom UI to host — what they need is a curated set of MApps (a Budget MApp,
-a Whitepaper Brainstorming MApp, a Model Training MApp, etc.). For those
-projects, set `hosting.containerKind = "mapp"` and list the MApp IDs in
-`hosting.mapps[]`.
+### Desktop-served container shape
+
+Projects with a Desktop-served type (`ops`, `media`, `literature`, `documentation`, `backup-aggregator`) often have no codebase to "run" and no custom UI to host — what they need is a curated set of MApps (a Budget MApp, a Whitepaper Brainstorming MApp, a Model Training MApp, etc.). For those projects, set `type` to one of the Desktop-served ids and list the MApp IDs in `hosting.mapps[]`.
 
 When the gateway boots the container, it:
 
@@ -297,9 +335,10 @@ The gateway dashboard itself is served at the base domain (`ai.on`) and any conf
 
 ### Project Container Does Not Start
 
-- Check the container logs: `podman logs aionima-{project-name}`.
+- Check the container logs: `podman logs agi-{hostname}`.
 - Verify the container image is available: `podman images`.
-- Ensure the `startCommand` in `~/.agi/{projectSlug}/project.json` is correct.
+- Ensure the `startCommand` in `<projectPath>/project.json` is correct (code-served projects only).
+- Run `agi doctor` — the s150 t641 project-shape diagnostic flags drift in `<projectPath>/project.json` against the canonical s150 model.
 
 ### Hostname Not Resolving
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.544",
+  "version": "0.4.545",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
Three canonical docs rewritten to the s150 single-type model: project-config-schema.md, project-hosting.md, magic-apps.md. Cross-reference _discovery/pm-hosting-reconciliation.md. Closes s150 t642 and the entire PM/Hosting alignment story.