### PR TITLE
agi v0.4.546 — Wish #15 latest-stack-wins + clear startCommand on addStack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.545",
+  "version": "0.4.546",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/hosting-manager-stack-order.test.ts
+++ b/packages/gateway-core/src/hosting-manager-stack-order.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Wish #15 (s150 follow-up) — `orderStacksLatestFirst` correctness.
+ *
+ * The prior FIRST-wins ordering in `resolveStackContainerConfig` caused
+ * stale stacks to mask newly-added ones. Owner case 2026-05-08:
+ * blackorchid_web had `[stack-static-hosting (May 1), stack-nextjs (May 8)]`;
+ * legacy ordering returned static-hosting → mounted /dist read-only →
+ * ENOENT for dev-mode projects with no build output.
+ *
+ * The fix: iterate stacks LATEST-FIRST by `addedAt`. This spec pins the
+ * sort behavior so a future refactor can't silently regress.
+ */
+
+import { describe, expect, it } from "vitest";
+import { orderStacksLatestFirst } from "./hosting-manager.js";
+import type { ProjectStackInstance } from "./stack-types.js";
+
+function instance(stackId: string, addedAt: string | undefined): ProjectStackInstance {
+  // ProjectStackInstance has only stackId, addedAt, optional db fields.
+  // The test cares about ordering — addedAt is the only field that matters.
+  return { stackId, addedAt: addedAt ?? "" } as unknown as ProjectStackInstance;
+}
+
+describe("orderStacksLatestFirst", () => {
+  it("returns stacks sorted by addedAt descending", () => {
+    const out = orderStacksLatestFirst([
+      instance("stack-static-hosting", "2026-05-01T05:16:58.137Z"),
+      instance("stack-nextjs", "2026-05-08T02:27:52.813Z"),
+    ]);
+    expect(out.map((s) => s.stackId)).toEqual(["stack-nextjs", "stack-static-hosting"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      instance("a", "2026-01-01T00:00:00Z"),
+      instance("b", "2026-02-01T00:00:00Z"),
+    ];
+    const snapshot = input.map((s) => s.stackId).join(",");
+    orderStacksLatestFirst(input);
+    expect(input.map((s) => s.stackId).join(",")).toBe(snapshot);
+  });
+
+  it("handles three+ stacks with mixed ordering", () => {
+    const out = orderStacksLatestFirst([
+      instance("middle", "2026-03-15T00:00:00Z"),
+      instance("oldest", "2026-01-01T00:00:00Z"),
+      instance("newest", "2026-06-30T00:00:00Z"),
+    ]);
+    expect(out.map((s) => s.stackId)).toEqual(["newest", "middle", "oldest"]);
+  });
+
+  it("treats missing addedAt as oldest (sorts to the end)", () => {
+    const out = orderStacksLatestFirst([
+      instance("with-ts", "2026-05-01T00:00:00Z"),
+      instance("no-ts", undefined),
+      instance("newer-ts", "2026-06-01T00:00:00Z"),
+    ]);
+    expect(out[0]?.stackId).toBe("newer-ts");
+    expect(out[1]?.stackId).toBe("with-ts");
+    expect(out[2]?.stackId).toBe("no-ts");
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(orderStacksLatestFirst([])).toEqual([]);
+  });
+
+  it("identical timestamps remain in input order (stable-sort signal)", () => {
+    // Node's Array.prototype.sort is stable since v12. We rely on that for
+    // deterministic ordering when two stacks were added at the same instant
+    // (rare but possible during scripted setup).
+    const out = orderStacksLatestFirst([
+      instance("a", "2026-05-01T00:00:00Z"),
+      instance("b", "2026-05-01T00:00:00Z"),
+      instance("c", "2026-05-01T00:00:00Z"),
+    ]);
+    expect(out.map((s) => s.stackId)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -888,6 +888,22 @@ const PORT_POOL_SIZE = 100;
  * Migration map: old framework-based project types → broad project types + corresponding stacks.
  * Used during initialize() to auto-migrate existing projects to the new model.
  */
+/**
+ * Sort stack instances LATEST-FIRST by `addedAt` (ISO 8601 timestamps,
+ * lexicographic order matches chronological order; missing timestamps sort
+ * to the end). Wish #15 (s150 follow-up) — the prior FIRST-wins semantics
+ * caused stale stacks to mask newly-added ones. Owner case 2026-05-08:
+ * blackorchid_web had `[stack-static-hosting (May 1), stack-nextjs (May 8)]`;
+ * the legacy ordering returned static-hosting and mounted /dist read-only,
+ * ENOENT-ing dev-mode projects with no build output.
+ *
+ * Module-scope + exported so it's unit-testable without a HostingManager
+ * instance.
+ */
+export function orderStacksLatestFirst(stacks: readonly ProjectStackInstance[]): ProjectStackInstance[] {
+  return [...stacks].sort((a, b) => (b.addedAt ?? "").localeCompare(a.addedAt ?? ""));
+}
+
 const MIGRATION_MAP: Record<string, { newType: string; autoStack: string }> = {
   laravel:      { newType: "web-app",      autoStack: "stack-laravel" },
   nextjs:       { newType: "web-app",      autoStack: "stack-nextjs" },
@@ -1849,7 +1865,7 @@ export class HostingManager {
     const stacks = this.getProjectStacks(hosted.path);
     if (stacks.length === 0) return null;
 
-    for (const instance of stacks) {
+    for (const instance of orderStacksLatestFirst(stacks)) {
       const def = this.stackReg.get(instance.stackId);
       if (def?.containerConfig && !def.containerConfig.shared) {
         return def.containerConfig;
@@ -1864,7 +1880,7 @@ export class HostingManager {
     if (!this.stackReg) return null;
 
     const stacks = this.getProjectStacks(hosted.path);
-    for (const instance of stacks) {
+    for (const instance of orderStacksLatestFirst(stacks)) {
       const def = this.stackReg.get(instance.stackId);
       if (def?.containerConfig && !def.containerConfig.shared) {
         return def;
@@ -4128,8 +4144,30 @@ export class HostingManager {
       addedAt: new Date().toISOString(),
     };
 
-    // Persist to ~/.agi/{slug}/project.json
+    // Persist to <projectPath>/project.json
     this.writeStackInstance(resolved, instance);
+
+    // Wish #15 — when the new stack brings its own container command, clear
+    // any stale user-set `hosting.startCommand` override so the stack's
+    // command takes effect on next restart. Without this clear, a previously-
+    // entered override (e.g. `npm run dev` typed before the stack was added)
+    // would silently win over the stack's command and the user would have to
+    // manually clear the field. Owner directive 2026-05-08.
+    if (def.containerConfig?.command !== undefined && this.configMgr) {
+      const existingHosting = this.configMgr.readHosting(resolved);
+      if (existingHosting?.startCommand !== null && existingHosting?.startCommand !== undefined) {
+        try {
+          await this.configMgr.updateHosting(resolved, { startCommand: null });
+          // Mirror in-memory hosted state so a restart in the same process
+          // sees the cleared override.
+          const hosted = this.projects.get(resolved);
+          if (hosted) hosted.meta.startCommand = null;
+          this.log.info(`[${this.slugFromPath(resolved)}] cleared startCommand override on addStack(${stackId}) — stack provides its own command`);
+        } catch (err) {
+          this.log.warn(`[${this.slugFromPath(resolved)}] could not clear startCommand override: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    }
 
     // Auto-run install actions sequentially
     const actionResults = await this.runInstallActions(resolved, def);


### PR DESCRIPTION
Two bugs from owner Playwright after s150 ship: (1) resolveStackContainerConfig returned FIRST stack, so stale stack-static-hosting masked stack-nextjs and mounted /dist read-only → ENOENT for dev-mode projects. Now iterates LATEST-FIRST. (2) addStack didn't clear hosting.startCommand override; user override masked stack's own command. Now cleared automatically when new stack provides containerConfig.command. 6 new ordering tests. Closes Wish #15.