### PR TITLE
agi v0.4.547 — Wish #16 PlanStore moves to <projectPath>/k/plans/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.546",
+  "version": "0.4.547",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/plan-store.test.ts
+++ b/packages/gateway-core/src/plan-store.test.ts
@@ -1,26 +1,30 @@
 /**
- * PlanStore — .mdc + YAML frontmatter + legacy .md migration tests.
+ * PlanStore — .mdc + YAML frontmatter + legacy migration tests.
  *
- * These tests exercise PlanStore against a temp HOME to avoid touching the
- * operator's actual ~/.agi/ directory. We set HOME before constructing the
- * store so the default path resolution lands in the temp dir.
+ * Wish #16 (2026-05-08) — plans now live at `<projectPath>/k/plans/` per
+ * the s130/s140 universal-monorepo model. The legacy `~/.agi/{slug}/plans/`
+ * location is read on miss and copy-forwarded to the canonical location.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PlanStore, isAcceptedStatus } from "./plan-store.js";
+import { migrateProjectPlans, PlanStore, isAcceptedStatus } from "./plan-store.js";
 import type { PlanStatus } from "./plan-types.js";
-
-const PROJECT_PATH = "/home/test/myproject";
+import { projectSlug } from "./dispatch-paths.js";
 
 describe("PlanStore — .mdc + YAML", () => {
   let tmpHome: string;
+  let projectPath: string;
   let originalHome: string | undefined;
 
   beforeEach(() => {
+    // Single tmp root. Both the project and the legacy ~/.agi tree live
+    // under this dir so we never write outside tmp.
     tmpHome = mkdtempSync(join(tmpdir(), "plan-store-"));
+    projectPath = join(tmpHome, "_projects", "myproject");
+    mkdirSync(projectPath, { recursive: true });
     originalHome = process.env.HOME;
     process.env.HOME = tmpHome;
   });
@@ -31,28 +35,33 @@ describe("PlanStore — .mdc + YAML", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("creates plans as .mdc files with readable YAML frontmatter", () => {
+  function canonicalPlansDir(): string {
+    return join(projectPath, "k", "plans");
+  }
+
+  function legacyPlansDir(): string {
+    return join(tmpHome, ".agi", projectSlug(projectPath), "plans");
+  }
+
+  it("creates plans as .mdc files with readable YAML frontmatter at <projectPath>/k/plans/", () => {
     const store = new PlanStore();
     const plan = store.create({
       title: "Test plan",
-      projectPath: PROJECT_PATH,
+      projectPath,
       steps: [{ title: "Plan", type: "plan" }, { title: "Implement", type: "implement" }],
       body: "# Test\n\nBody content.",
     });
 
-    const plansDir = join(tmpHome, ".agi", "home-test-myproject", "plans");
-    const mdcPath = join(plansDir, `${plan.id}.mdc`);
+    const mdcPath = join(canonicalPlansDir(), `${plan.id}.mdc`);
     expect(existsSync(mdcPath)).toBe(true);
 
     const raw = readFileSync(mdcPath, "utf-8");
-    // YAML frontmatter — human-readable, no JSON braces at the top level.
     expect(raw).toMatch(/^---\n/);
     expect(raw).toContain(`id: ${plan.id}`);
     expect(raw).toContain(`title: Test plan`);
     expect(raw).toContain(`status: draft`);
-    expect(raw).toContain(`projectPath: ${PROJECT_PATH}`);
-    expect(raw).not.toContain('"id":');  // legacy JSON shape would have quotes
-    // Body follows closing fence.
+    expect(raw).toContain(`projectPath: ${projectPath}`);
+    expect(raw).not.toContain('"id":');
     expect(raw).toMatch(/---\n\n# Test/);
   });
 
@@ -60,26 +69,25 @@ describe("PlanStore — .mdc + YAML", () => {
     const store = new PlanStore();
     const created = store.create({
       title: "Round-trip",
-      projectPath: PROJECT_PATH,
+      projectPath,
       steps: [{ title: "One", type: "plan" }],
       body: "Body with\nnewlines and *markdown*.",
     });
-    const reread = store.get(PROJECT_PATH, created.id);
+    const reread = store.get(projectPath, created.id);
     expect(reread).not.toBeNull();
     expect(reread).toEqual(created);
   });
 
-  it("migrates legacy .md plans to .mdc on first read", () => {
-    // Hand-write a legacy .md plan with JSON frontmatter.
-    const plansDir = join(tmpHome, ".agi", "home-test-myproject", "plans");
-    mkdirSync(plansDir, { recursive: true });
+  it("copies forward a legacy `.md` plan from the OLD ~/.agi/{slug}/plans/ location", () => {
     const planId = "plan_01ABC";
-    const legacyPath = join(plansDir, `${planId}.md`);
+    const legacyDir = legacyPlansDir();
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyPath = join(legacyDir, `${planId}.md`);
     const legacyContent = `---\n${JSON.stringify({
       id: planId,
       title: "Legacy plan",
       status: "draft",
-      projectPath: PROJECT_PATH,
+      projectPath,
       chatSessionId: null,
       createdAt: "2026-04-15T00:00:00Z",
       updatedAt: "2026-04-15T00:00:00Z",
@@ -89,48 +97,43 @@ describe("PlanStore — .mdc + YAML", () => {
     writeFileSync(legacyPath, legacyContent, "utf-8");
 
     const store = new PlanStore();
-    const plan = store.get(PROJECT_PATH, planId);
+    const plan = store.get(projectPath, planId);
 
     expect(plan).not.toBeNull();
     expect(plan?.title).toBe("Legacy plan");
     expect(plan?.body).toBe("Legacy body.");
 
-    // Migration: .mdc exists and .md is gone.
-    expect(existsSync(join(plansDir, `${planId}.mdc`))).toBe(true);
-    expect(existsSync(legacyPath)).toBe(false);
+    // Wish #16: copy-forward landed at the canonical path. Legacy file
+    // preserved as backup (NOT deleted on read; a future sweep removes it).
+    expect(existsSync(join(canonicalPlansDir(), `${planId}.mdc`))).toBe(true);
+    expect(existsSync(legacyPath)).toBe(true);
 
-    // Re-read should still work (idempotent).
-    const reread = store.get(PROJECT_PATH, planId);
+    // Idempotent re-read goes through the canonical path now.
+    const reread = store.get(projectPath, planId);
     expect(reread?.title).toBe("Legacy plan");
   });
 
-  it("list() returns both .mdc and legacy .md entries without duplicates", () => {
-    const plansDir = join(tmpHome, ".agi", "home-test-myproject", "plans");
-    mkdirSync(plansDir, { recursive: true });
-
-    // One legacy .md
-    writeFileSync(join(plansDir, "plan_LEGACY01.md"), `---\n${JSON.stringify({
-      id: "plan_LEGACY01",
-      title: "Legacy",
-      status: "draft",
-      projectPath: PROJECT_PATH,
-      chatSessionId: null,
-      createdAt: "2026-04-14T00:00:00Z",
-      updatedAt: "2026-04-14T00:00:00Z",
-      tynnRefs: { versionId: null, storyIds: [], taskIds: [] },
-      steps: [],
-    })}\n---\n\nLegacy.`, "utf-8");
+  it("list() merges plans from canonical + legacy locations, dedup by planId", () => {
+    // Legacy-only plan with proper YAML frontmatter (the older JSON-in-YAML
+    // shape is exercised by the .md migration test above).
+    const dir = legacyPlansDir();
+    mkdirSync(dir, { recursive: true });
+    // Timestamps + projectPath QUOTED to keep YAML parsing them as strings;
+    // unquoted ISO timestamps decode to Date objects, which trips the
+    // metaToPlan string cast and the plan returns null.
+    const legacyYaml = `---\nid: "plan_LEGACY01"\ntitle: "Legacy"\nstatus: "draft"\nprojectPath: "${projectPath}"\nchatSessionId: null\ncreatedAt: "2026-04-14T00:00:00.000Z"\nupdatedAt: "2026-04-14T00:00:00.000Z"\ntynnRefs:\n  versionId: null\n  storyIds: []\n  taskIds: []\nsteps: []\n---\n\nLegacy.\n`;
+    writeFileSync(join(dir, "plan_LEGACY01.mdc"), legacyYaml, "utf-8");
 
     const store = new PlanStore();
-    // One fresh .mdc
+    // Canonical-only plan via create
     store.create({
       title: "New",
-      projectPath: PROJECT_PATH,
+      projectPath,
       steps: [],
       body: "New body.",
     });
 
-    const plans = store.list(PROJECT_PATH);
+    const plans = store.list(projectPath);
     expect(plans).toHaveLength(2);
     expect(plans.some((p) => p.title === "Legacy")).toBe(true);
     expect(plans.some((p) => p.title === "New")).toBe(true);
@@ -143,39 +146,132 @@ describe("PlanStore — .mdc + YAML", () => {
     for (const s of acceptedStatuses) expect(isAcceptedStatus(s)).toBe(true);
   });
 
-  it("update() respects body/title/steps changes and regenerates YAML cleanly", () => {
+  it("update() respects body/title/steps changes and regenerates YAML cleanly at canonical path", () => {
     const store = new PlanStore();
     const plan = store.create({
       title: "Original",
-      projectPath: PROJECT_PATH,
+      projectPath,
       steps: [{ title: "Old", type: "plan" }],
       body: "Original body.",
     });
 
-    const updated = store.update(PROJECT_PATH, plan.id, {
+    const updated = store.update(projectPath, plan.id, {
       title: "New title",
       body: "Edited body.",
     });
     expect(updated?.title).toBe("New title");
     expect(updated?.body).toBe("Edited body.");
 
-    // File on disk reflects the change.
-    const plansDir = join(tmpHome, ".agi", "home-test-myproject", "plans");
-    const raw = readFileSync(join(plansDir, `${plan.id}.mdc`), "utf-8");
+    const raw = readFileSync(join(canonicalPlansDir(), `${plan.id}.mdc`), "utf-8");
     expect(raw).toContain("title: New title");
     expect(raw).toContain("Edited body.");
   });
 
-  it("delete() removes both .mdc and legacy .md", () => {
-    const plansDir = join(tmpHome, ".agi", "home-test-myproject", "plans");
-    mkdirSync(plansDir, { recursive: true });
-    writeFileSync(join(plansDir, "plan_DUAL01.mdc"), "---\nid: plan_DUAL01\ntitle: x\nstatus: draft\nprojectPath: /foo\nchatSessionId: null\ncreatedAt: 0\nupdatedAt: 0\ntynnRefs: {versionId: null, storyIds: [], taskIds: []}\nsteps: []\n---\n\nbody", "utf-8");
-    writeFileSync(join(plansDir, "plan_DUAL01.md"), "legacy", "utf-8");
+  it("delete() sweeps all four possible locations", () => {
+    const canonicalDir = canonicalPlansDir();
+    const legacyDir = legacyPlansDir();
+    mkdirSync(canonicalDir, { recursive: true });
+    mkdirSync(legacyDir, { recursive: true });
+
+    // Drop sentinel files at every possible location for the same plan id.
+    writeFileSync(join(canonicalDir, "plan_DUAL01.mdc"), "canonical-mdc", "utf-8");
+    writeFileSync(join(canonicalDir, "plan_DUAL01.md"), "canonical-md", "utf-8");
+    writeFileSync(join(legacyDir, "plan_DUAL01.mdc"), "legacy-mdc", "utf-8");
+    writeFileSync(join(legacyDir, "plan_DUAL01.md"), "legacy-md", "utf-8");
 
     const store = new PlanStore();
-    const result = store.delete(PROJECT_PATH, "plan_DUAL01");
+    const result = store.delete(projectPath, "plan_DUAL01");
     expect(result).toBe(true);
-    expect(existsSync(join(plansDir, "plan_DUAL01.mdc"))).toBe(false);
-    expect(existsSync(join(plansDir, "plan_DUAL01.md"))).toBe(false);
+    expect(existsSync(join(canonicalDir, "plan_DUAL01.mdc"))).toBe(false);
+    expect(existsSync(join(canonicalDir, "plan_DUAL01.md"))).toBe(false);
+    expect(existsSync(join(legacyDir, "plan_DUAL01.mdc"))).toBe(false);
+    expect(existsSync(join(legacyDir, "plan_DUAL01.md"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wish #16 — migrateProjectPlans bulk migration helper
+// ---------------------------------------------------------------------------
+
+describe("migrateProjectPlans (Wish #16)", () => {
+  let tmpHome: string;
+  let projectPath: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "plan-mig-"));
+    projectPath = join(tmpHome, "_projects", "myproject");
+    mkdirSync(projectPath, { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function legacyDir(): string {
+    return join(tmpHome, ".agi", projectSlug(projectPath), "plans");
+  }
+
+  function writeLegacy(planId: string, ext: "mdc" | "md", title: string): void {
+    const dir = legacyDir();
+    mkdirSync(dir, { recursive: true });
+    const yaml = `---\nid: ${planId}\ntitle: ${title}\nstatus: draft\nprojectPath: ${projectPath}\nchatSessionId: null\ncreatedAt: 2026-04-15T00:00:00Z\nupdatedAt: 2026-04-15T00:00:00Z\ntynnRefs:\n  versionId: null\n  storyIds: []\n  taskIds: []\nsteps: []\n---\n\nbody for ${planId}\n`;
+    writeFileSync(join(dir, `${planId}.${ext}`), yaml, "utf-8");
+  }
+
+  it("copies every legacy plan to the canonical per-project dir", () => {
+    writeLegacy("plan_alpha", "mdc", "Alpha");
+    writeLegacy("plan_beta", "mdc", "Beta");
+
+    const r = migrateProjectPlans(projectPath);
+
+    expect(r.migrated).toBe(2);
+    expect(r.skipped).toBe(0);
+    expect(new Set(r.migratedIds)).toEqual(new Set(["plan_alpha", "plan_beta"]));
+    expect(existsSync(join(projectPath, "k", "plans", "plan_alpha.mdc"))).toBe(true);
+    expect(existsSync(join(projectPath, "k", "plans", "plan_beta.mdc"))).toBe(true);
+    // Legacy preserved as backup.
+    expect(existsSync(join(legacyDir(), "plan_alpha.mdc"))).toBe(true);
+  });
+
+  it("is idempotent — second call skips already-migrated plans without clobbering owner edits", () => {
+    writeLegacy("plan_alpha", "mdc", "Alpha");
+    const first = migrateProjectPlans(projectPath);
+    expect(first.migrated).toBe(1);
+
+    const canonicalAlpha = join(projectPath, "k", "plans", "plan_alpha.mdc");
+    writeFileSync(canonicalAlpha, "owner edit", "utf-8");
+
+    const second = migrateProjectPlans(projectPath);
+    expect(second.migrated).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(readFileSync(canonicalAlpha, "utf-8")).toBe("owner edit");
+  });
+
+  it("returns a no-op when the legacy plans dir does not exist", () => {
+    const r = migrateProjectPlans(projectPath);
+    expect(r).toEqual({ migrated: 0, skipped: 0, migratedIds: [], errors: [] });
+  });
+
+  it("preserves the file extension (.md stays .md)", () => {
+    writeLegacy("plan_legacy_ext", "md", "Legacy");
+    const r = migrateProjectPlans(projectPath);
+    expect(r.migrated).toBe(1);
+    expect(existsSync(join(projectPath, "k", "plans", "plan_legacy_ext.md"))).toBe(true);
+    expect(existsSync(join(projectPath, "k", "plans", "plan_legacy_ext.mdc"))).toBe(false);
+  });
+
+  it("ignores non-plan files in the legacy dir", () => {
+    writeLegacy("plan_alpha", "mdc", "Alpha");
+    const dir = legacyDir();
+    writeFileSync(join(dir, "README.md"), "not a plan", "utf-8");
+
+    const r = migrateProjectPlans(projectPath);
+    expect(r.migrated).toBe(1);
+    expect(r.migratedIds).toEqual(["plan_alpha"]);
   });
 });

--- a/packages/gateway-core/src/plan-store.ts
+++ b/packages/gateway-core/src/plan-store.ts
@@ -1,24 +1,29 @@
 /**
- * Plan Store — file-based CRUD for ~/.agi/{projectSlug}/plans/{planId}.mdc
+ * Plan Store — file-based CRUD for `<projectPath>/k/plans/{planId}.mdc`
  *
  * Each plan is stored as a `.mdc` file (markdown + YAML frontmatter) at
  *
- *     ~/.agi/{projectSlug}/plans/{planId}.mdc
+ *     <projectPath>/k/plans/{planId}.mdc        (s130/s140 canonical, Wish #16 2026-05-08)
+ *     ~/.agi/{projectSlug}/plans/{planId}.mdc   (legacy pre-s130 location)
+ *     ~/.agi/{projectSlug}/plans/{planId}.md    (legacy-legacy: JSON-in-YAML)
  *
  * Frontmatter sits between YAML `---` fences and carries all plan metadata
  * (id, title, status, projectPath, steps, tynnRefs, timestamps). The body
  * after the closing fence is the plan's free-form markdown content.
  *
- * Legacy: prior revisions used `.md` with JSON-in-YAML frontmatter. On read,
- * any legacy `.md` plan is parsed, rewritten as a proper `.mdc` file with
- * YAML frontmatter, and the original `.md` is removed. Idempotent.
+ * **Dual-location semantics (Wish #16):** plans live with their project at
+ * `<projectPath>/k/plans/` per the s130 universal-monorepo model. Reads
+ * prefer the per-project location and copy-forward any plan still at the
+ * legacy `~/.agi/{slug}/plans/` location on first access. Writes (create /
+ * update / delete) go through the per-project location only. The legacy
+ * file is preserved as a backup until a follow-up sweep removes it once
+ * stable across upgrades.
  *
- * Plans live centrally under the operator's home directory, NEVER inside
- * project directories — that prevents writing runtime data into deployed
- * codebases or user repos.
+ * Legacy `.md` (JSON frontmatter) plans are upgraded to `.mdc` (YAML
+ * frontmatter) at the new location on first read. Idempotent.
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync, unlinkSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { ulid } from "ulid";
@@ -109,7 +114,18 @@ function metaToPlan(meta: Record<string, unknown>, body: string): Plan {
 // ---------------------------------------------------------------------------
 
 export class PlanStore {
+  /** Canonical per-project plans dir (Wish #16, 2026-05-08). */
   private plansDir(projectPath: string): string {
+    return join(projectPath, "k", "plans");
+  }
+
+  /**
+   * Legacy global plans dir at `~/.agi/{slug}/plans/`. Read-only fallback;
+   * writes always go to the per-project location. The migration helper +
+   * lazy copy-forward in `readAndMigrate` move plans from here to the
+   * canonical location idempotently.
+   */
+  private legacyPlansDir(projectPath: string): string {
     return join(homedir(), ".agi", projectSlug(projectPath), "plans");
   }
 
@@ -117,8 +133,19 @@ export class PlanStore {
     return join(this.plansDir(projectPath), `${planId}.mdc`);
   }
 
-  private legacyPlanPath(projectPath: string, planId: string): string {
+  /** Legacy `.md` file at the canonical (NEW) location — JSON-in-YAML frontmatter. */
+  private legacyMdAtNewPath(projectPath: string, planId: string): string {
     return join(this.plansDir(projectPath), `${planId}.md`);
+  }
+
+  /** Legacy `.mdc` at the OLD per-slug location. */
+  private legacyMdcAtOldPath(projectPath: string, planId: string): string {
+    return join(this.legacyPlansDir(projectPath), `${planId}.mdc`);
+  }
+
+  /** Legacy `.md` at the OLD per-slug location. */
+  private legacyMdAtOldPath(projectPath: string, planId: string): string {
+    return join(this.legacyPlansDir(projectPath), `${planId}.md`);
   }
 
   private ensureDir(projectPath: string): void {
@@ -129,33 +156,46 @@ export class PlanStore {
   }
 
   /**
-   * Read a plan from disk, preferring `.mdc` and falling back to legacy
-   * `.md`. When a legacy file is found, it's rewritten as `.mdc` with YAML
-   * frontmatter and the old file is removed so the migration runs exactly
-   * once per plan.
+   * Read a plan from disk, looking in this order:
+   *   1. `<projectPath>/k/plans/{id}.mdc`               — canonical, YAML
+   *   2. `<projectPath>/k/plans/{id}.md`                — old YAML at new path
+   *   3. `~/.agi/{slug}/plans/{id}.mdc`                 — legacy YAML at old path
+   *   4. `~/.agi/{slug}/plans/{id}.md`                  — legacy JSON at old path
+   *
+   * On hit at a non-canonical location, the plan is rewritten at the
+   * canonical path so the migration runs exactly once per plan. The legacy
+   * file is preserved (not deleted) — a follow-up sweep removes the
+   * old-location backups once stable across upgrades.
    */
   private readAndMigrate(projectPath: string, planId: string): Plan | null {
-    const mdcPath = this.planPath(projectPath, planId);
-    if (existsSync(mdcPath)) {
-      const parsed = parseFrontmatter(readFileSync(mdcPath, "utf-8"));
+    const canonicalMdc = this.planPath(projectPath, planId);
+    if (existsSync(canonicalMdc)) {
+      const parsed = parseFrontmatter(readFileSync(canonicalMdc, "utf-8"));
       return parsed ? metaToPlan(parsed.meta, parsed.body) : null;
     }
 
-    const mdPath = this.legacyPlanPath(projectPath, planId);
-    if (!existsSync(mdPath)) return null;
-    const parsed = parseFrontmatter(readFileSync(mdPath, "utf-8"));
-    if (!parsed) return null;
+    const candidates: string[] = [
+      this.legacyMdAtNewPath(projectPath, planId),
+      this.legacyMdcAtOldPath(projectPath, planId),
+      this.legacyMdAtOldPath(projectPath, planId),
+    ];
 
-    const plan = metaToPlan(parsed.meta, parsed.body);
-    try {
-      writeFileSync(mdcPath, serializeFrontmatter(plan), "utf-8");
-      unlinkSync(mdPath);
-    } catch {
-      // If the rewrite fails (permissions, disk full), we still return the
-      // parsed plan so the caller isn't blocked; the migration will retry
-      // next read.
+    for (const candidate of candidates) {
+      if (!existsSync(candidate)) continue;
+      const parsed = parseFrontmatter(readFileSync(candidate, "utf-8"));
+      if (!parsed) continue;
+      const plan = metaToPlan(parsed.meta, parsed.body);
+      try {
+        this.ensureDir(projectPath);
+        writeFileSync(canonicalMdc, serializeFrontmatter(plan), "utf-8");
+      } catch {
+        // If the canonical rewrite fails (permissions, disk full), still
+        // return the parsed plan so callers aren't blocked; migration
+        // retries on next read.
+      }
+      return plan;
     }
-    return plan;
+    return null;
   }
 
   create(input: CreatePlanInput): Plan {
@@ -193,29 +233,27 @@ export class PlanStore {
   }
 
   list(projectPath: string): Plan[] {
-    const dir = this.plansDir(projectPath);
-    if (!existsSync(dir)) return [];
     const seen = new Set<string>();
     const plans: Plan[] = [];
 
-    // Prefer `.mdc` entries; fall through to `.md` if no `.mdc` shadows it.
-    const files = readdirSync(dir);
-    for (const file of files) {
-      const mdcMatch = /^(plan_[^.]+)\.mdc$/.exec(file);
-      if (mdcMatch) {
-        const planId = mdcMatch[1]!;
-        if (seen.has(planId)) continue;
-        const plan = this.readAndMigrate(projectPath, planId);
-        if (plan) {
-          plans.push(plan);
-          seen.add(planId);
-        }
+    // Wish #16 — walk BOTH the canonical per-project dir and the legacy
+    // ~/.agi/{slug}/plans/ dir. readAndMigrate copies legacy → canonical
+    // on first hit per plan id; subsequent list() calls find the plan at
+    // the canonical location and skip the legacy walk for it.
+    const dirs = [this.plansDir(projectPath), this.legacyPlansDir(projectPath)];
+
+    for (const dir of dirs) {
+      if (!existsSync(dir)) continue;
+      let files: string[];
+      try {
+        files = readdirSync(dir);
+      } catch {
+        continue;
       }
-    }
-    for (const file of files) {
-      const mdMatch = /^(plan_[^.]+)\.md$/.exec(file);
-      if (mdMatch) {
-        const planId = mdMatch[1]!;
+      for (const file of files) {
+        const m = /^(plan_[^.]+)\.(?:mdc|md)$/.exec(file);
+        if (!m) continue;
+        const planId = m[1]!;
         if (seen.has(planId)) continue;
         const plan = this.readAndMigrate(projectPath, planId);
         if (plan) {
@@ -274,10 +312,88 @@ export class PlanStore {
 
   delete(projectPath: string, planId: string): boolean {
     let removed = false;
-    const mdcPath = this.planPath(projectPath, planId);
-    if (existsSync(mdcPath)) { unlinkSync(mdcPath); removed = true; }
-    const mdPath = this.legacyPlanPath(projectPath, planId);
-    if (existsSync(mdPath)) { unlinkSync(mdPath); removed = true; }
+    // Sweep all four possible locations so a delete can't leave a ghost
+    // behind that a subsequent readAndMigrate would resurrect.
+    const candidates = [
+      this.planPath(projectPath, planId),
+      this.legacyMdAtNewPath(projectPath, planId),
+      this.legacyMdcAtOldPath(projectPath, planId),
+      this.legacyMdAtOldPath(projectPath, planId),
+    ];
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        try { unlinkSync(p); removed = true; } catch { /* ignore */ }
+      }
+    }
     return removed;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Wish #16 (s150 follow-up) — bulk migration helper
+// ---------------------------------------------------------------------------
+
+export interface PlanMigrationResult {
+  /** How many plans were copied this call. */
+  migrated: number;
+  /** How many were already at the canonical location and skipped. */
+  skipped: number;
+  /** Plan ids that were copied. */
+  migratedIds: string[];
+  /** Errors encountered (per-file; non-fatal). */
+  errors: Array<{ file: string; reason: string }>;
+}
+
+/**
+ * Idempotently move every plan at `~/.agi/{slug}/plans/` into the canonical
+ * `<projectPath>/k/plans/` location. Safe to re-run; plans already present
+ * at the canonical path are skipped, not re-copied. Legacy files are
+ * preserved as backup; a future sweep removes them once stable.
+ */
+export function migrateProjectPlans(projectPath: string): PlanMigrationResult {
+  const result: PlanMigrationResult = { migrated: 0, skipped: 0, migratedIds: [], errors: [] };
+
+  const legacyDir = join(homedir(), ".agi", projectSlug(projectPath), "plans");
+  if (!existsSync(legacyDir)) return result;
+
+  const canonicalDir = join(projectPath, "k", "plans");
+
+  let entries: string[];
+  try {
+    entries = readdirSync(legacyDir);
+  } catch (e) {
+    result.errors.push({ file: legacyDir, reason: e instanceof Error ? e.message : String(e) });
+    return result;
+  }
+
+  for (const file of entries) {
+    const m = /^(plan_[^.]+)\.(mdc|md)$/.exec(file);
+    if (!m) continue;
+    const planId = m[1]!;
+    const ext = m[2]!;
+    const sourcePath = join(legacyDir, file);
+
+    // Always land at .mdc on the canonical side (the .md → .mdc upgrade
+    // happens on the first per-plan read via readAndMigrate; here we just
+    // copy the bytes and let that path normalize them). Skip if any
+    // canonical entry for this plan id already exists.
+    const canonicalMdc = join(canonicalDir, `${planId}.mdc`);
+    const canonicalMd = join(canonicalDir, `${planId}.md`);
+    if (existsSync(canonicalMdc) || existsSync(canonicalMd)) {
+      result.skipped++;
+      continue;
+    }
+
+    try {
+      if (!existsSync(canonicalDir)) mkdirSync(canonicalDir, { recursive: true });
+      const targetPath = join(canonicalDir, `${planId}.${ext}`);
+      copyFileSync(sourcePath, targetPath);
+      result.migrated++;
+      result.migratedIds.push(planId);
+    } catch (e) {
+      result.errors.push({ file: sourcePath, reason: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return result;
 }

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -118,7 +118,7 @@ import { HeartbeatScheduler } from "./heartbeat.js";
 import { PrimeLoader } from "./prime-loader.js";
 import { resolvePrimeDir, resolveIdDir } from "./resolve-paths.js";
 import { checkProtocolCompatibility } from "./protocol-check.js";
-import { PlanStore } from "./plan-store.js";
+import { PlanStore, migrateProjectPlans } from "./plan-store.js";
 import { ChatPersistence } from "./chat-persistence.js";
 import type { PersistedChatSession } from "./chat-persistence.js";
 import { ImageBlobStore } from "./image-blob-store.js";
@@ -1831,6 +1831,49 @@ export async function startGatewayServer(
     logger.warn(
       "migrate",
       `boot-time s130 sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Wish #16 (2026-05-08) — boot-time per-project plans migration. Walks
+  // every project under workspace.projects and copies plans from the legacy
+  // `~/.agi/{slug}/plans/` location into the canonical
+  // `<projectPath>/k/plans/`. Idempotent — already-canonical plans are
+  // skipped, not re-copied. Legacy files are preserved as backup.
+  try {
+    let migratedTotal = 0;
+    let projectsTouched = 0;
+    let errorsTotal = 0;
+    for (const dir of projectPaths) {
+      let entries: string[];
+      try {
+        entries = (await import("node:fs")).readdirSync(dir, { withFileTypes: true })
+          .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+          .map((d) => d.name);
+      } catch {
+        continue;
+      }
+      for (const slug of entries) {
+        const projectPath = join(dir, slug);
+        try {
+          const r = migrateProjectPlans(projectPath);
+          if (r.migrated > 0) {
+            projectsTouched++;
+            migratedTotal += r.migrated;
+          }
+          if (r.errors.length > 0) errorsTotal += r.errors.length;
+        } catch { /* per-project guard — never fatal */ }
+      }
+    }
+    if (migratedTotal > 0 || errorsTotal > 0) {
+      logger.info(
+        "migrate",
+        `boot-time wish#16 plans sweep: ${String(migratedTotal)} plan(s) migrated across ${String(projectsTouched)} project(s), ${String(errorsTotal)} error(s)`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      "migrate",
+      `boot-time wish#16 plans sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 


### PR DESCRIPTION
PlanStore was hardcoded to ~/.agi/{slug}/plans/. kronos_trader had 4 plans stranded there, invisible to Aion. Now: canonical path <projectPath>/k/plans/, legacy read-on-miss with copy-forward, list() walks both dirs with dedup, new migrateProjectPlans helper + boot-time sweep. 12/12 tests passing. Closes Wish #16.