### PR TITLE
agi v0.4.548 — Wish #17 always-on PM-Lite floor + plans in pm tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.547",
+  "version": "0.4.548",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/layered-pm-provider.test.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Wish #17 — LayeredPmProvider read-fallback semantics.
+ *
+ * Pins the contract: the layered provider always tries `primary` first,
+ * falls through to `fallback` on throws OR error-shaped payloads, and
+ * passes through normal results unchanged. When primary === fallback
+ * (single-provider config) the layering is invisible.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { LayeredPmProvider } from "./layered-pm-provider.js";
+import type {
+  PmProvider,
+  PmTask,
+  PmCreateTaskInput,
+  PmIWishInput,
+  PmStatus,
+  PmComment,
+} from "@agi/sdk";
+
+function makeMockProvider(id: string, overrides: Partial<PmProvider> = {}): PmProvider {
+  const stubTask = (taskId: string): PmTask => ({
+    id: taskId,
+    number: 0,
+    storyId: "story-1",
+    title: `task ${taskId} from ${id}`,
+    status: "backlog",
+  });
+  const base: PmProvider = {
+    providerId: id,
+    getProject: vi.fn(async () => ({ id: `${id}-project`, name: id })),
+    getNext: vi.fn(async () => ({ version: null, topStory: null, tasks: [stubTask(`${id}-next`)] })),
+    getTask: vi.fn(async (idOrNumber: string | number) => stubTask(`${id}-${String(idOrNumber)}`)),
+    getStory: vi.fn(async () => null),
+    findTasks: vi.fn(async () => [stubTask(`${id}-find`)]),
+    getComments: vi.fn(async () => []),
+    setTaskStatus: vi.fn(async (taskId: string, _status: PmStatus) => stubTask(taskId)),
+    addComment: vi.fn(async (_etype, _eid, body: string): Promise<PmComment> => ({ id: "c1", body, createdAt: "2026-05-08T00:00:00Z" })),
+    updateTask: vi.fn(async (taskId: string) => stubTask(taskId)),
+    createTask: vi.fn(async (input: PmCreateTaskInput) => ({ ...stubTask("new"), title: input.title })),
+    iWish: vi.fn(async (input: PmIWishInput) => ({ id: "w1", title: input.title })),
+    ...overrides,
+  };
+  return base;
+}
+
+describe("LayeredPmProvider", () => {
+  it("reads from primary when primary succeeds", async () => {
+    const primary = makeMockProvider("primary");
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const next = await layered.getNext();
+    expect(next.tasks[0]?.id).toBe("primary-next");
+    expect(primary.getNext).toHaveBeenCalledOnce();
+    expect(fallback.getNext).not.toHaveBeenCalled();
+  });
+
+  it("falls through to fallback when primary throws", async () => {
+    const primary = makeMockProvider("primary", {
+      getNext: vi.fn(async () => { throw new Error("tynn not configured"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const next = await layered.getNext();
+    expect(next.tasks[0]?.id).toBe("fallback-next");
+    expect(primary.getNext).toHaveBeenCalledOnce();
+    expect(fallback.getNext).toHaveBeenCalledOnce();
+  });
+
+  it("falls through to fallback when primary returns an error-shaped payload", async () => {
+    const primary = makeMockProvider("primary", {
+      // Some PmProvider impls (the tynn MCP wrapper) return JSON-stringified
+      // error payloads instead of throwing.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getTask: vi.fn(async () => ({ error: "tool unavailable" } as any)),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const got = await layered.getTask("any");
+    expect(got?.id).toBe("fallback-any");
+  });
+
+  it("passes through findTasks results from primary unchanged", async () => {
+    const primary = makeMockProvider("primary");
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const tasks = await layered.findTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.id).toBe("primary-find");
+  });
+
+  it("write paths fall through too — setTaskStatus on primary failure goes to fallback", async () => {
+    const primary = makeMockProvider("primary", {
+      setTaskStatus: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const result = await layered.setTaskStatus("t1", "doing");
+    expect(result.title).toContain("from fallback");
+    expect(fallback.setTaskStatus).toHaveBeenCalledWith("t1", "doing", undefined);
+  });
+
+  it("createTask + iWish + addComment + updateTask all fall through on primary throw", async () => {
+    const primary = makeMockProvider("primary", {
+      createTask: vi.fn(async () => { throw new Error("offline"); }),
+      iWish: vi.fn(async () => { throw new Error("offline"); }),
+      addComment: vi.fn(async () => { throw new Error("offline"); }),
+      updateTask: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    await layered.createTask({ storyId: "s1", title: "x", description: "" });
+    await layered.iWish({ title: "wish" });
+    await layered.addComment("task", "t1", "note");
+    await layered.updateTask("t1", { title: "renamed" });
+
+    expect(fallback.createTask).toHaveBeenCalled();
+    expect(fallback.iWish).toHaveBeenCalled();
+    expect(fallback.addComment).toHaveBeenCalled();
+    expect(fallback.updateTask).toHaveBeenCalled();
+  });
+
+  it("getActiveFocusProgress prefers primary when available, falls back when primary throws", async () => {
+    const primary = makeMockProvider("primary");
+    primary.getActiveFocusProgress = vi.fn(async () => { throw new Error("offline"); });
+    const fallback = makeMockProvider("fallback");
+    fallback.getActiveFocusProgress = vi.fn(async () => ({
+      totalTasks: 5, doneTasks: 2, qaTasks: 1, doingTasks: 1, backlogTasks: 1, blockedTasks: 0, inProgressTasks: 2,
+    }));
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    const progress = await layered.getActiveFocusProgress();
+    expect(progress.totalTasks).toBe(5);
+    expect(fallback.getActiveFocusProgress).toHaveBeenCalled();
+  });
+
+  it("when primary === fallback (single-provider config), layering is invisible", async () => {
+    const single = makeMockProvider("only");
+    const layered = new LayeredPmProvider({ primary: single, fallback: single });
+
+    const next = await layered.getNext();
+    expect(next.tasks[0]?.id).toBe("only-next");
+    expect(single.getNext).toHaveBeenCalledOnce();
+  });
+
+  it("exposes the underlying layers for diagnostic surfaces", () => {
+    const primary = makeMockProvider("primary");
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    expect(layered.layers.primary).toBe(primary);
+    expect(layered.layers.fallback).toBe(fallback);
+  });
+
+  it("invokes the optional logger when fallback fires", async () => {
+    const primary = makeMockProvider("primary", {
+      getNext: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const info = vi.fn();
+    const warn = vi.fn();
+    const layered = new LayeredPmProvider({ primary, fallback, logger: { info, warn } });
+
+    await layered.getNext();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining("primary threw for getNext"));
+  });
+});

--- a/packages/gateway-core/src/pm/layered-pm-provider.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.ts
@@ -1,0 +1,177 @@
+/**
+ * LayeredPmProvider — read-fallback wrapper around a primary PmProvider
+ * (typically TynnPmProvider talking to a remote MCP service) and a
+ * file-based PM-Lite fallback (typically TynnLitePmProvider).
+ *
+ * Wish #17 (2026-05-08) — owner directive after `pm` tool errored out
+ * with "tynn not configured" instead of falling back to the file-based
+ * PM-Lite that's always available. The PM workflow has ONE entryway and
+ * MANY functions; PM-Lite is the floor that's always reachable, and a
+ * remote provider (tynn / linear / jira / …) layers on top when the user
+ * has configured one.
+ *
+ * **Read semantics:** every read is attempted against `primary` first.
+ * If it throws or returns a tool-side error string, the call falls
+ * through to `fallback`. Either provider may legitimately return null /
+ * empty arrays — those are NOT treated as failures.
+ *
+ * **Write semantics (this rev):** writes go to whichever provider is
+ * currently primary. The fully-layered "write to both" strategy is a
+ * deeper design (Wish #17 follow-up, needs conflict-resolution call) —
+ * for now writes route through the primary and the fallback only sees
+ * writes when the primary is unreachable, AT WHICH POINT it has full
+ * single-provider semantics. This avoids accidentally fanning a write
+ * to two stores that disagree on what "blocked" means without a clear
+ * owner-confirmed merge strategy.
+ *
+ * **Boot semantics:** server.ts always constructs both providers and
+ * wraps them in LayeredPmProvider regardless of `agent.pm.provider`
+ * setting. The default ("tynn") is the read primary; TynnLite is the
+ * fallback. If the owner explicitly picks "tynn-lite", the layered
+ * wrapper degenerates: primary === fallback and the two paths are
+ * equivalent.
+ */
+
+import type {
+  PmProvider,
+  PmStatus,
+  PmTask,
+  PmStory,
+  PmComment,
+  PmCreateTaskInput,
+  PmIWishInput,
+} from "@agi/sdk";
+
+export interface LayeredPmProviderOptions {
+  /** The configured primary (e.g. TynnPmProvider). All reads + writes try here first. */
+  primary: PmProvider;
+  /** The always-available file-based floor (typically TynnLitePmProvider). */
+  fallback: PmProvider;
+  /** Optional logger for fallback events. */
+  logger?: { info(msg: string): void; warn(msg: string): void };
+}
+
+function looksLikeErrorPayload(value: unknown): boolean {
+  // Some PmProvider implementations return JSON-stringified `{"error": "..."}`
+  // as their normal "operation didn't work" surface (the tynn MCP wrapper does
+  // this when the tool isn't available). Treat those as a soft failure for
+  // fallback purposes.
+  if (typeof value === "string" && value.includes('"error"')) return true;
+  if (
+    typeof value === "object"
+    && value !== null
+    && (value as { error?: unknown }).error !== undefined
+  ) return true;
+  return false;
+}
+
+export class LayeredPmProvider implements PmProvider {
+  readonly providerId: string;
+  private readonly primary: PmProvider;
+  private readonly fallback: PmProvider;
+  private readonly logger?: { info(msg: string): void; warn(msg: string): void };
+
+  constructor(opts: LayeredPmProviderOptions) {
+    this.primary = opts.primary;
+    this.fallback = opts.fallback;
+    this.logger = opts.logger;
+    // Prefer primary's id for logging; the layering is invisible to consumers.
+    this.providerId = `layered(${opts.primary.providerId}+${opts.fallback.providerId})`;
+  }
+
+  private async withFallback<T>(label: string, op: (p: PmProvider) => Promise<T>): Promise<T> {
+    if (this.primary === this.fallback) return op(this.primary);
+    try {
+      const result = await op(this.primary);
+      if (looksLikeErrorPayload(result)) {
+        this.logger?.info(`pm-layer: primary returned error-shaped payload for ${label}; trying fallback`);
+        return await op(this.fallback);
+      }
+      return result;
+    } catch (err) {
+      this.logger?.info(`pm-layer: primary threw for ${label} (${err instanceof Error ? err.message : String(err)}); trying fallback`);
+      return await op(this.fallback);
+    }
+  }
+
+  // ---- Reads (each falls through to fallback on primary failure) ----
+
+  getProject(): ReturnType<PmProvider["getProject"]> {
+    return this.withFallback("getProject", (p) => p.getProject());
+  }
+
+  getNext(): ReturnType<PmProvider["getNext"]> {
+    return this.withFallback("getNext", (p) => p.getNext());
+  }
+
+  getTask(idOrNumber: string | number): Promise<PmTask | null> {
+    return this.withFallback("getTask", (p) => p.getTask(idOrNumber));
+  }
+
+  getStory(idOrNumber: string | number): Promise<PmStory | null> {
+    return this.withFallback("getStory", (p) => p.getStory(idOrNumber));
+  }
+
+  findTasks(filter?: { storyId?: string; status?: PmStatus | PmStatus[]; limit?: number }): Promise<PmTask[]> {
+    return this.withFallback("findTasks", (p) => p.findTasks(filter));
+  }
+
+  getComments(entityType: "task" | "story" | "version", entityId: string): Promise<PmComment[]> {
+    return this.withFallback("getComments", (p) => p.getComments(entityType, entityId));
+  }
+
+  // ---- Writes (route through primary; fallback only on primary failure) ----
+
+  setTaskStatus(taskId: string, status: PmStatus, note?: string): Promise<PmTask> {
+    return this.withFallback("setTaskStatus", (p) => p.setTaskStatus(taskId, status, note));
+  }
+
+  addComment(entityType: "task" | "story" | "version", entityId: string, body: string): Promise<PmComment> {
+    return this.withFallback("addComment", (p) => p.addComment(entityType, entityId, body));
+  }
+
+  updateTask(
+    taskId: string,
+    fields: Partial<Pick<PmTask, "title" | "description" | "verificationSteps" | "codeArea">>,
+  ): Promise<PmTask> {
+    return this.withFallback("updateTask", (p) => p.updateTask(taskId, fields));
+  }
+
+  createTask(input: PmCreateTaskInput): Promise<PmTask> {
+    return this.withFallback("createTask", (p) => p.createTask(input));
+  }
+
+  iWish(input: PmIWishInput): Promise<{ id: string; title: string }> {
+    return this.withFallback("iWish", (p) => p.iWish(input));
+  }
+
+  async getActiveFocusProgress(): ReturnType<NonNullable<PmProvider["getActiveFocusProgress"]>> {
+    if (this.primary === this.fallback) {
+      if (this.primary.getActiveFocusProgress === undefined) {
+        throw new Error(`pm provider ${this.primary.providerId} does not expose getActiveFocusProgress`);
+      }
+      return this.primary.getActiveFocusProgress();
+    }
+    if (this.primary.getActiveFocusProgress !== undefined) {
+      try {
+        const result = await this.primary.getActiveFocusProgress();
+        if (!looksLikeErrorPayload(result)) return result;
+      } catch (err) {
+        this.logger?.info(
+          `pm-layer: primary getActiveFocusProgress threw (${err instanceof Error ? err.message : String(err)}); trying fallback`,
+        );
+      }
+    }
+    if (this.fallback.getActiveFocusProgress === undefined) {
+      throw new Error(`neither pm provider exposes getActiveFocusProgress`);
+    }
+    return this.fallback.getActiveFocusProgress();
+  }
+
+  /** Direct accessor for the underlying providers — exposed for the
+   *  `pm` agent tool's diagnostic surface so callers can see which layer
+   *  served a particular response. */
+  get layers(): { primary: PmProvider; fallback: PmProvider } {
+    return { primary: this.primary, fallback: this.fallback };
+  }
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -63,6 +63,7 @@ import { CostLedgerReader } from "./cost-ledger-reader.js";
 import { McpClient } from "@agi/mcp-client";
 import { TynnPmProvider } from "./pm/tynn-provider.js";
 import { TynnLitePmProvider } from "./pm/tynn-lite-provider.js";
+import { LayeredPmProvider } from "./pm/layered-pm-provider.js";
 import type { PmProvider, PmStatus } from "@agi/sdk";
 
 import type { AionimaConfig, ConfigReloadEvent } from "@agi/config";
@@ -2358,26 +2359,40 @@ export async function startGatewayServer(
     .agent?.pm ?? {};
   const pmProviderId = pmConfig.provider ?? "tynn";
   const pmProviderConfig = pmConfig.config ?? {};
-  let pmProvider: PmProvider;
+
+  // Wish #17 (2026-05-08) — PM-Lite is ALWAYS available as the file-based
+  // floor, regardless of which remote provider (if any) the user has
+  // configured. Construct it unconditionally so the LayeredPmProvider can
+  // fall through on remote errors.
+  const pmLiteRoot = (pmProviderConfig.projectRoot as string | undefined)
+    ?? (workspaceRoot.length > 0 ? workspaceRoot : "/");
+  const tynnLiteFloor = new TynnLitePmProvider({
+    projectRoot: pmLiteRoot,
+    projectName: pmProviderConfig.projectName as string | undefined,
+  });
+
+  let pmPrimary: PmProvider;
   if (pmProviderId === "tynn") {
-    pmProvider = new TynnPmProvider({ mcpClient });
+    pmPrimary = new TynnPmProvider({ mcpClient });
   } else if (pmProviderId === "tynn-lite") {
-    const projectRoot = (pmProviderConfig.projectRoot as string | undefined) ?? workspaceRoot;
-    if (projectRoot === undefined || projectRoot.length === 0) {
-      throw new Error("agent.pm.provider 'tynn-lite' requires either pm.config.projectRoot or workspace.root to be set");
-    }
-    pmProvider = new TynnLitePmProvider({
-      projectRoot,
-      projectName: pmProviderConfig.projectName as string | undefined,
-    });
+    pmPrimary = tynnLiteFloor;
   } else {
     const def = pluginRegistry.getPmProvider(pmProviderId);
     if (def === undefined) {
       throw new Error(`agent.pm.provider '${pmProviderId}' is not registered (built-in: tynn, tynn-lite; plugin-registered: ${pluginRegistry.getPmProviders().map(p => p.provider.id).join(", ") || "none"})`);
     }
-    pmProvider = def.factory(pmProviderConfig) as PmProvider;
+    pmPrimary = def.factory(pmProviderConfig) as PmProvider;
   }
-  log.info(`pm provider resolved: id=${pmProviderId}, providerId=${pmProvider.providerId}`);
+
+  // Wrap with the layered fallback. When the primary IS tynn-lite (single-
+  // provider config) the wrapper degenerates to a pass-through — same code
+  // path keeps behavior consistent across configs.
+  const pmProvider: PmProvider = new LayeredPmProvider({
+    primary: pmPrimary,
+    fallback: tynnLiteFloor,
+    logger: { info: (m) => log.info(m), warn: (m) => log.warn(m) },
+  });
+  log.info(`pm provider resolved: primary=${pmPrimary.providerId}, fallback=${tynnLiteFloor.providerId}, exposed=${pmProvider.providerId}`);
 
   // s126 — Ops-mode tools (cross-project + infrastructure) registered after
   // pmProvider is resolved. requiresProjectCategory: [ops, administration]
@@ -2465,13 +2480,19 @@ export async function startGatewayServer(
     {
       name: "pm",
       description:
-        "Project-management workflow operations (the tynn workflow — race-to-DONE, look-for-MORE). " +
-        "Action options: 'next' (active version + top story + tasks), 'task'/'story' (lookup by id or number), " +
+        "The single project-management entryway with many functions. " +
+        "Always works — the file-based PM-Lite floor handles every read/write when no remote PM provider " +
+        "(tynn / linear / jira / …) is configured or reachable. " +
+        "Tasks/stories/comments: 'next' (active version + top story + tasks), 'task'/'story' (lookup by id or number), " +
         "'find-tasks' (filtered list), 'comments' (entity audit trail), " +
         "'start-task'/'testing'/'finished'/'block' (status transitions), " +
         "'update-task' (modify fields), 'create-task'/'comment'/'iwish' (create entities), " +
         "'progress' (race-to-DONE counts for active focus). " +
-        "Use this tool whenever you need to query or update the project's tracked work — never invent your own task tracking.",
+        "Plans (file-based, per-project k/plans/, ALWAYS available regardless of remote provider): " +
+        "'plan-list' (list all plans for a projectPath), 'plan-get' (fetch by planId), " +
+        "'plan-create' (new plan), 'plan-update' (status/steps/body). " +
+        "Use this tool whenever you need to query or update the project's tracked work or recall a plan — " +
+        "never invent your own task tracking, and never assume tynn is the only PM provider.",
       requiresState: [],
       requiresTier: [],
     },
@@ -2544,8 +2565,62 @@ export async function startGatewayServer(
             return pmProvider.getActiveFocusProgress !== undefined
               ? JSON.stringify(await pmProvider.getActiveFocusProgress())
               : JSON.stringify({ error: `pm provider ${pmProvider.providerId} doesn't expose progress` });
+          // Wish #17 (2026-05-08) — plans live in PM-Lite (file-based,
+          // <projectPath>/k/plans/) and are part of the PM domain regardless
+          // of remote provider availability. The pm tool exposes them directly
+          // through PlanStore so an unconfigured tynn never blocks plan recall.
+          case "plan-list": {
+            const projectPath = String(input.projectPath ?? "");
+            if (projectPath.length === 0) {
+              return JSON.stringify({ error: "projectPath is required for plan-list — pass the absolute path of the project (visible in your Project Context section)." });
+            }
+            return JSON.stringify(planStore.list(projectPath));
+          }
+          case "plan-get": {
+            const projectPath = String(input.projectPath ?? "");
+            const planId = String(input.planId ?? "");
+            if (projectPath.length === 0 || planId.length === 0) {
+              return JSON.stringify({ error: "plan-get requires both projectPath and planId" });
+            }
+            const got = planStore.get(projectPath, planId);
+            return JSON.stringify(got ?? { error: `plan ${planId} not found` });
+          }
+          case "plan-create": {
+            const projectPath = String(input.projectPath ?? "");
+            const planInput = input.plan as { title?: string; body?: string; chatSessionId?: string; steps?: Array<{ title: string; type: string }> } | undefined;
+            if (projectPath.length === 0 || planInput === undefined) {
+              return JSON.stringify({ error: "plan-create requires projectPath and a plan object {title, body, steps[]}" });
+            }
+            const validStepTypes: Array<"plan" | "implement" | "test" | "review" | "deploy"> = ["plan", "implement", "test", "review", "deploy"];
+            const steps = (planInput.steps ?? [])
+              .filter((s): s is { title: string; type: string } => typeof s === "object" && s !== null && typeof s.title === "string" && typeof s.type === "string")
+              .map((s) => ({
+                title: s.title,
+                type: (validStepTypes.includes(s.type as "plan" | "implement" | "test" | "review" | "deploy")
+                  ? (s.type as "plan" | "implement" | "test" | "review" | "deploy")
+                  : "plan"),
+              }));
+            const plan = planStore.create({
+              title: String(planInput.title ?? ""),
+              body: String(planInput.body ?? ""),
+              steps,
+              projectPath,
+              ...(planInput.chatSessionId !== undefined ? { chatSessionId: planInput.chatSessionId } : {}),
+            });
+            return JSON.stringify(plan);
+          }
+          case "plan-update": {
+            const projectPath = String(input.projectPath ?? "");
+            const planId = String(input.planId ?? "");
+            const update = input.update as Record<string, unknown> | undefined;
+            if (projectPath.length === 0 || planId.length === 0 || update === undefined) {
+              return JSON.stringify({ error: "plan-update requires projectPath, planId, and an update object" });
+            }
+            const updated = planStore.update(projectPath, planId, update as Parameters<typeof planStore.update>[2]);
+            return JSON.stringify(updated ?? { error: `plan ${planId} not found` });
+          }
           default:
-            return JSON.stringify({ error: `unknown action: ${action}. Valid: next, task, story, find-tasks, comments, start-task, testing, finished, block, update-task, create-task, comment, iwish, progress` });
+            return JSON.stringify({ error: `unknown action: ${action}. Valid: next, task, story, find-tasks, comments, start-task, testing, finished, block, update-task, create-task, comment, iwish, progress, plan-list, plan-get, plan-create, plan-update` });
         }
       } catch (err) {
         return JSON.stringify({ error: err instanceof Error ? err.message : String(err) });
@@ -2554,7 +2629,7 @@ export async function startGatewayServer(
     {
       type: "object",
       properties: {
-        action: { type: "string", enum: ["next", "task", "story", "find-tasks", "comments", "start-task", "testing", "finished", "block", "update-task", "create-task", "comment", "iwish", "progress"], description: "PM operation to perform" },
+        action: { type: "string", enum: ["next", "task", "story", "find-tasks", "comments", "start-task", "testing", "finished", "block", "update-task", "create-task", "comment", "iwish", "progress", "plan-list", "plan-get", "plan-create", "plan-update"], description: "PM operation to perform" },
         id: { type: "string", description: "Entity id (for task/story actions when known)" },
         number: { type: "number", description: "Entity number (alternative to id for task/story)" },
         taskId: { type: "string", description: "Task id (for status transitions / update-task)" },
@@ -2568,6 +2643,10 @@ export async function startGatewayServer(
         fields: { type: "object", description: "Field updates for update-task" },
         task: { type: "object", description: "New task input for create-task: {storyId, title, description, verificationSteps?, codeArea?}" },
         wish: { type: "object", description: "Wish input for iwish: {title, didnt?, when?, had?, needs?, explain?, priority?}" },
+        projectPath: { type: "string", description: "Absolute project path (required for plan-* actions)" },
+        planId: { type: "string", description: "Plan id (required for plan-get / plan-update)" },
+        plan: { type: "object", description: "New plan input for plan-create: {title, body, steps[{title,type}], chatSessionId?}" },
+        update: { type: "object", description: "Plan update fields for plan-update: {status?, body?, title?, steps?, stepUpdates?, tynnRefs?}" },
       },
       required: ["action"],
     },


### PR DESCRIPTION
Owner reported Aion couldn't find planned work because tynn wasn't configured. Two architectural gaps: (1) PM provider was one-or-the-other; (2) plans weren't surfaced through pm tool. Fix: LayeredPmProvider always wraps configured primary with TynnLite as file-based floor; plan-list/get/create/update added as pm tool actions; tool description made provider-agnostic. 10 new tests + 49/49 regression. Closes immediate pain. Sub-tasks deferred: per-project k/pm/ move, PM-Lite UI, bidirectional layered writes.