### PR TITLE
agi v0.4.549 — s155 t671 /api/pm REST surface + PM-Lite dashboard panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.548",
+  "version": "0.4.549",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm-api.test.ts
+++ b/packages/gateway-core/src/pm-api.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Wish #17 / s155 t671 — pm-api REST surface contract.
+ *
+ * Pins the view-tab semantics (DONE = finished; CURRENT = starting/doing/
+ * testing; NEXT = backlog/blocked) and the projectPath-validation guard
+ * on /api/pm/plans*. Uses Fastify's app.inject() pattern so the test
+ * runs entirely in-process without a real HTTP socket.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import { PM_VIEW_STATUSES, registerPmRoutes } from "./pm-api.js";
+import { PlanStore } from "./plan-store.js";
+import type {
+  PmProvider,
+  PmStatus,
+  PmTask,
+  PmCreateTaskInput,
+  PmIWishInput,
+  PmComment,
+} from "@agi/sdk";
+
+function makeProvider(overrides: Partial<PmProvider> = {}): PmProvider {
+  const stub = (id: string, status: PmStatus = "backlog"): PmTask => ({
+    id, number: 0, storyId: "s1", title: id, status,
+  });
+  return {
+    providerId: "test",
+    getProject: async () => ({ id: "p", name: "Test Project" }),
+    getNext: async () => ({ version: null, topStory: null, tasks: [stub("t-next")] }),
+    getTask: async (idOrNumber) => stub(`t-${String(idOrNumber)}`),
+    getStory: async () => null,
+    findTasks: async (filter) => {
+      // Echo back the status filter so the test can assert it was forwarded.
+      const wanted = Array.isArray(filter?.status) ? filter.status : (filter?.status ? [filter.status] : []);
+      if (wanted.length === 0) return [stub("t-all")];
+      return wanted.map((s) => stub(`t-${s}`, s));
+    },
+    getComments: async () => [],
+    setTaskStatus: async (id: string, s: PmStatus) => stub(id, s),
+    addComment: async (_e, _id, body): Promise<PmComment> => ({ id: "c", body, createdAt: "2026-05-08T00:00:00Z" }),
+    updateTask: async (id: string) => stub(id),
+    createTask: async (i: PmCreateTaskInput) => ({ ...stub("new"), title: i.title }),
+    iWish: async (i: PmIWishInput) => ({ id: "w", title: i.title }),
+    ...overrides,
+  };
+}
+
+describe("pm-api routes", () => {
+  let app: FastifyInstance;
+  let tmpRoot: string;
+  let workspace: string;
+  let projectPath: string;
+  let originalHome: string | undefined;
+  let planStore: PlanStore;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "pm-api-"));
+    workspace = join(tmpRoot, "_projects");
+    projectPath = join(workspace, "myproject");
+    mkdirSync(projectPath, { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpRoot;
+    planStore = new PlanStore();
+
+    app = Fastify();
+    registerPmRoutes(app, {
+      pmProvider: makeProvider(),
+      planStore,
+      workspaceProjects: [workspace],
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await app.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("GET /api/pm/next", () => {
+    it("returns the active version + top story + tasks tuple from pmProvider", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/next" });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { tasks: PmTask[]; providerId: string };
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0]?.id).toBe("t-next");
+      expect(body.providerId).toBe("test");
+    });
+  });
+
+  describe("GET /api/pm/find-tasks", () => {
+    it("forwards string status filter", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/find-tasks?status=doing" });
+      expect(r.statusCode).toBe(200);
+      const { tasks } = r.json() as { tasks: PmTask[] };
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]?.status).toBe("doing");
+    });
+
+    it("forwards array status filter via repeated query params", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: "/api/pm/find-tasks?status=doing&status=testing",
+      });
+      const { tasks } = r.json() as { tasks: PmTask[] };
+      expect(tasks.map((t) => t.status).sort()).toEqual(["doing", "testing"]);
+    });
+
+    it("returns all when no filter is provided", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/find-tasks" });
+      const { tasks } = r.json() as { tasks: PmTask[] };
+      expect(tasks[0]?.id).toBe("t-all");
+    });
+
+    it("forwards limit as a number", async () => {
+      // Provider implementation here ignores limit; assert no crash + 200.
+      const r = await app.inject({ method: "GET", url: "/api/pm/find-tasks?limit=5" });
+      expect(r.statusCode).toBe(200);
+    });
+  });
+
+  describe("GET /api/pm/view", () => {
+    it("DONE view filters to finished status", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/view?view=done" });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { view: string; tasks: PmTask[] };
+      expect(body.view).toBe("done");
+      expect(body.tasks.map((t) => t.status)).toEqual(["finished"]);
+    });
+
+    it("CURRENT view filters to starting/doing/testing", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/view?view=current" });
+      const body = r.json() as { tasks: PmTask[] };
+      expect(body.tasks.map((t) => t.status).sort()).toEqual(["doing", "starting", "testing"]);
+    });
+
+    it("NEXT view filters to backlog/blocked", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/view?view=next" });
+      const body = r.json() as { tasks: PmTask[] };
+      expect(body.tasks.map((t) => t.status).sort()).toEqual(["backlog", "blocked"]);
+    });
+
+    it("rejects unknown views with 400", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/view?view=nope" });
+      expect(r.statusCode).toBe(400);
+      const body = r.json() as { error: string };
+      expect(body.error).toContain("unknown view");
+    });
+
+    it("PM_VIEW_STATUSES constant matches the route behavior", () => {
+      expect(PM_VIEW_STATUSES.done).toContain("finished");
+      expect(PM_VIEW_STATUSES.current).toEqual(expect.arrayContaining(["starting", "doing", "testing"]));
+      expect(PM_VIEW_STATUSES.next).toEqual(expect.arrayContaining(["backlog", "blocked"]));
+    });
+  });
+
+  describe("GET /api/pm/plans", () => {
+    it("requires projectPath query param", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/plans" });
+      expect(r.statusCode).toBe(400);
+    });
+
+    it("returns 403 when projectPath is outside workspace", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans?projectPath=${encodeURIComponent("/etc/passwd")}`,
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    it("returns 403 when projectPath EQUALS the workspace root (not a project)", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans?projectPath=${encodeURIComponent(workspace)}`,
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    it("returns plans list for a valid project (empty when no plans exist)", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { plans: unknown[]; projectPath: string };
+      expect(body.plans).toEqual([]);
+      expect(body.projectPath).toBe(projectPath);
+    });
+
+    it("surfaces a plan after one is created via PlanStore", async () => {
+      const created = planStore.create({
+        title: "Sample plan",
+        body: "Body",
+        steps: [{ title: "do thing", type: "plan" }],
+        projectPath,
+      });
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      const body = r.json() as { plans: { id: string; title: string }[] };
+      expect(body.plans.map((p) => p.id)).toContain(created.id);
+    });
+  });
+
+  describe("GET /api/pm/plans/:planId", () => {
+    it("returns 404 when the plan does not exist", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans/plan_nope?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      expect(r.statusCode).toBe(404);
+    });
+
+    it("returns the plan when it exists", async () => {
+      const created = planStore.create({
+        title: "Detail plan",
+        body: "B",
+        steps: [],
+        projectPath,
+      });
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans/${created.id}?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { id: string; title: string };
+      expect(body.id).toBe(created.id);
+      expect(body.title).toBe("Detail plan");
+    });
+
+    it("rejects projectPath outside workspace", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/pm/plans/plan_x?projectPath=${encodeURIComponent("/elsewhere")}`,
+      });
+      expect(r.statusCode).toBe(403);
+    });
+  });
+});

--- a/packages/gateway-core/src/pm-api.ts
+++ b/packages/gateway-core/src/pm-api.ts
@@ -1,0 +1,184 @@
+/**
+ * PM API — Settings/Project → Plans REST surface (s155 t671 / Wish #17).
+ *
+ * Owner directive 2026-05-08: "there should always be the PM-lite workflow
+ * and UI that is always available and file based … project management
+ * should have one entryway but many functions, so reading/writing/updating
+ * plans should be part of the pm agent tool and our tools should layer
+ * operations."
+ *
+ * The agent already has the `pm` tool (server.ts) wired through
+ * LayeredPmProvider. This file is the dashboard-facing twin: same
+ * pmProvider + planStore consumed via REST so the PM-Lite UI panel can
+ * surface DONE/CURRENT/NEXT views regardless of remote PM provider
+ * availability.
+ *
+ * Naming note: the dashboard refers to this surface as "PM-Lite" (the
+ * file-based floor; the always-available view). The provider behind the
+ * REST endpoints may be tynn-lite, tynn (remote), or any plugin-registered
+ * provider — the LayeredPmProvider hides that decision from the UI. From
+ * the user's POV, "PM" / "Plans" is one surface that always works.
+ */
+
+import type { FastifyInstance } from "fastify";
+import type { PmProvider, PmStatus } from "@agi/sdk";
+import type { PlanStore } from "./plan-store.js";
+
+export interface PmApiDeps {
+  pmProvider: PmProvider;
+  planStore: PlanStore;
+  /** Workspace project paths — used to validate `projectPath` query params
+   *  belong to a configured workspace. Mirrors the pattern used by
+   *  /api/projects routes. */
+  workspaceProjects: string[];
+}
+
+/**
+ * View → status filter mapping for DONE/CURRENT/NEXT.
+ *
+ * Owner clarified DONE/CURRENT/NEXT are VIEWS, not kanban status/state —
+ * the kanban states (backlog/starting/doing/testing/finished/blocked) feed
+ * into these views per a fixed shape:
+ *   - DONE    = anything finished (completed work)
+ *   - CURRENT = in-flight (starting, doing, testing)
+ *   - NEXT    = upcoming (backlog) PLUS currently-blocked items so they
+ *               surface where the owner expects to see "what should we work on"
+ *
+ * Archived tasks are out of every view by default.
+ */
+export const PM_VIEW_STATUSES: Record<"done" | "current" | "next", PmStatus[]> = Object.freeze({
+  done: ["finished"],
+  current: ["starting", "doing", "testing"],
+  next: ["backlog", "blocked"],
+});
+
+export type PmView = keyof typeof PM_VIEW_STATUSES;
+
+function isPmView(value: string): value is PmView {
+  return value === "done" || value === "current" || value === "next";
+}
+
+export function registerPmRoutes(app: FastifyInstance, deps: PmApiDeps): void {
+  /**
+   * GET /api/pm/next
+   *
+   * The current "what should we work on" tuple — active version + top story
+   * + active tasks. Mirror of the agent tool's `pm action=next`. Used by
+   * the dashboard's PM-Lite shelf header.
+   */
+  app.get("/api/pm/next", async () => {
+    const result = await deps.pmProvider.getNext();
+    return {
+      ...result,
+      providerId: deps.pmProvider.providerId,
+    };
+  });
+
+  /**
+   * GET /api/pm/find-tasks?storyId=...&status=...&limit=...
+   *
+   * Filtered task list. Both string and array statuses are accepted via
+   * repeated `?status=` params. Powers DONE/CURRENT/NEXT view tabs by
+   * passing the matching `PM_VIEW_STATUSES[view]` array.
+   */
+  app.get("/api/pm/find-tasks", async (request) => {
+    const query = request.query as { storyId?: string; status?: string | string[]; limit?: string };
+    const filter: { storyId?: string; status?: PmStatus | PmStatus[]; limit?: number } = {};
+    if (typeof query.storyId === "string" && query.storyId.length > 0) {
+      filter.storyId = query.storyId;
+    }
+    if (Array.isArray(query.status)) {
+      filter.status = query.status as PmStatus[];
+    } else if (typeof query.status === "string" && query.status.length > 0) {
+      filter.status = query.status as PmStatus;
+    }
+    if (typeof query.limit === "string" && query.limit.length > 0) {
+      const n = Number(query.limit);
+      if (Number.isFinite(n) && n > 0) filter.limit = Math.floor(n);
+    }
+    const tasks = await deps.pmProvider.findTasks(filter);
+    return { tasks, providerId: deps.pmProvider.providerId };
+  });
+
+  /**
+   * GET /api/pm/view?view=done|current|next&storyId=...
+   *
+   * Convenience wrapper around find-tasks for the three canonical views.
+   * Single round-trip from the dashboard; same pmProvider + same response
+   * shape as find-tasks but with the view label echoed for the UI tab.
+   */
+  app.get("/api/pm/view", async (request, reply) => {
+    const query = request.query as { view?: string; storyId?: string; limit?: string };
+    const viewParam = String(query.view ?? "current");
+    if (!isPmView(viewParam)) {
+      return reply.code(400).send({
+        error: `unknown view: ${viewParam}. Valid: done, current, next`,
+      });
+    }
+    const filter: { storyId?: string; status: PmStatus[]; limit?: number } = {
+      status: [...PM_VIEW_STATUSES[viewParam]],
+    };
+    if (typeof query.storyId === "string" && query.storyId.length > 0) {
+      filter.storyId = query.storyId;
+    }
+    if (typeof query.limit === "string" && query.limit.length > 0) {
+      const n = Number(query.limit);
+      if (Number.isFinite(n) && n > 0) filter.limit = Math.floor(n);
+    }
+    const tasks = await deps.pmProvider.findTasks(filter);
+    return { view: viewParam, tasks, providerId: deps.pmProvider.providerId };
+  });
+
+  /**
+   * GET /api/pm/plans?projectPath=/abs/path
+   *
+   * Per-project plan list straight from PlanStore (file-based, always
+   * available regardless of remote PM provider). projectPath must match
+   * one of the configured workspace.projects roots.
+   */
+  app.get("/api/pm/plans", async (request, reply) => {
+    const query = request.query as { projectPath?: string };
+    const projectPath = String(query.projectPath ?? "");
+    if (projectPath.length === 0) {
+      return reply.code(400).send({ error: "projectPath query param is required" });
+    }
+    if (!isInsideWorkspace(projectPath, deps.workspaceProjects)) {
+      return reply.code(403).send({ error: "projectPath is not inside a configured workspace.projects directory" });
+    }
+    const plans = deps.planStore.list(projectPath);
+    return { plans, projectPath };
+  });
+
+  /**
+   * GET /api/pm/plans/:planId?projectPath=/abs/path
+   *
+   * Single plan lookup. Same projectPath validation as the list endpoint.
+   */
+  app.get<{ Params: { planId: string } }>("/api/pm/plans/:planId", async (request, reply) => {
+    const { planId } = request.params;
+    const query = request.query as { projectPath?: string };
+    const projectPath = String(query.projectPath ?? "");
+    if (projectPath.length === 0) {
+      return reply.code(400).send({ error: "projectPath query param is required" });
+    }
+    if (!isInsideWorkspace(projectPath, deps.workspaceProjects)) {
+      return reply.code(403).send({ error: "projectPath is not inside a configured workspace.projects directory" });
+    }
+    const plan = deps.planStore.get(projectPath, planId);
+    if (plan === null) {
+      return reply.code(404).send({ error: `plan ${planId} not found in ${projectPath}` });
+    }
+    return plan;
+  });
+}
+
+function isInsideWorkspace(projectPath: string, workspaceProjects: readonly string[]): boolean {
+  const normalize = (p: string): string => (p.endsWith("/") ? p : `${p}/`);
+  const targetPrefix = normalize(projectPath);
+  for (const ws of workspaceProjects) {
+    const wsPrefix = normalize(ws);
+    if (targetPrefix === wsPrefix) return false; // workspace root itself is not a project
+    if (projectPath.startsWith(wsPrefix)) return true;
+  }
+  return false;
+}

--- a/packages/gateway-core/src/pm/layered-pm-provider.test.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.test.ts
@@ -131,7 +131,7 @@ describe("LayeredPmProvider", () => {
     primary.getActiveFocusProgress = vi.fn(async () => { throw new Error("offline"); });
     const fallback = makeMockProvider("fallback");
     fallback.getActiveFocusProgress = vi.fn(async () => ({
-      totalTasks: 5, doneTasks: 2, qaTasks: 1, doingTasks: 1, backlogTasks: 1, blockedTasks: 0, inProgressTasks: 2,
+      totalTasks: 5, doneTasks: 2, qaTasks: 1, doingTasks: 1, backlogTasks: 1, blockedTasks: 0, inProgressTasks: 2, percentComplete: 40,
     }));
     const layered = new LayeredPmProvider({ primary, fallback });
 

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -50,6 +50,7 @@ import { BackupManager } from "./backup-manager.js";
 import { registerComplianceRoutes } from "./compliance-api.js";
 import { registerSecurityRoutes } from "./security-api.js";
 import { registerProvidersRoutes } from "./providers-api.js";
+import { registerPmRoutes } from "./pm-api.js";
 import { registerAdminRoutes } from "./admin-api.js";
 import { ScanProviderRegistry, ScanStore, ScanRunner, sastScanner, scaScanner, secretsScanner, configScanner } from "@agi/security";
 import { COAChainLogger } from "@agi/coa-chain";
@@ -2962,6 +2963,15 @@ export async function startGatewayServer(
             const provider = getLLMProvider();
             return provider instanceof AgentRouter ? provider.getRecentDecisions(limit) : [];
           },
+        }),
+        // s155 t671 — PM REST surface. Mirrors the agent's `pm` tool but
+        // for the dashboard PM-Lite panel (DONE/CURRENT/NEXT views).
+        // Wraps the same LayeredPmProvider so reads + plan lookups always
+        // succeed, even if no remote PM provider is configured.
+        (f) => registerPmRoutes(f, {
+          pmProvider,
+          planStore,
+          workspaceProjects: projectPaths,
         }),
         (f) => registerAdminRoutes(f, createComponentLogger(logger, "admin-api"), aionMicroManager),
         (f: import("fastify").FastifyInstance) => registerHfRoutes(f, hfApiDeps),

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -150,6 +150,67 @@ export async function fetchProjects(): Promise<ProjectInfo[]> {
   return res.json() as Promise<ProjectInfo[]>;
 }
 
+// ---------------------------------------------------------------------------
+// PM-Lite — Wish #17 / s155 t671. Owner directive: "always available file-
+// based PM workflow + UI" with DONE/CURRENT/NEXT views.
+// ---------------------------------------------------------------------------
+
+export type PmView = "done" | "current" | "next";
+
+export interface PmTaskLite {
+  id: string;
+  number: number;
+  storyId: string;
+  title: string;
+  status: string;
+  description?: string;
+  priority?: "active" | "qa" | "blocked";
+  verificationSteps?: string[];
+  codeArea?: string;
+}
+
+export interface PmPlanLite {
+  id: string;
+  title: string;
+  status: string;
+  projectPath: string;
+  createdAt: string;
+  updatedAt: string;
+  steps: Array<{ id: string; title: string; type: string; status: string }>;
+  body: string;
+}
+
+export async function fetchPmView(view: PmView, opts: { storyId?: string; limit?: number } = {}): Promise<{ view: PmView; tasks: PmTaskLite[]; providerId: string }> {
+  const params = new URLSearchParams({ view });
+  if (opts.storyId !== undefined) params.set("storyId", opts.storyId);
+  if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+  const res = await fetch(`/api/pm/view?${params.toString()}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<{ view: PmView; tasks: PmTaskLite[]; providerId: string }>;
+}
+
+export async function fetchPmPlans(projectPath: string): Promise<PmPlanLite[]> {
+  const res = await fetch(`/api/pm/plans?projectPath=${encodeURIComponent(projectPath)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  const data = await res.json() as { plans: PmPlanLite[] };
+  return data.plans;
+}
+
+export async function fetchPmPlan(projectPath: string, planId: string): Promise<PmPlanLite> {
+  const res = await fetch(`/api/pm/plans/${encodeURIComponent(planId)}?projectPath=${encodeURIComponent(projectPath)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<PmPlanLite>;
+}
+
 export async function createProject(params: {
   name: string;
   tynnToken?: string;

--- a/ui/dashboard/src/components/PmLitePanel.tsx
+++ b/ui/dashboard/src/components/PmLitePanel.tsx
@@ -1,0 +1,203 @@
+/**
+ * PmLitePanel — always-available, file-based PM-Lite UI surface for a project.
+ *
+ * Wish #17 / s155 t671 — owner directive 2026-05-08:
+ *   "there should always be the PM-lite workflow and UI that is always
+ *    available and file based … project management should have one entryway
+ *    but many functions … local pm-lite is always updated based on
+ *    DONE, CURRENT, NEXT (these are views, not kanban status/state)."
+ *
+ * Three view tabs:
+ *   - DONE     — finished work
+ *   - CURRENT  — in-flight (starting/doing/testing)
+ *   - NEXT     — upcoming (backlog/blocked)
+ *
+ * Plus a Plans section sourced directly from `<projectPath>/k/plans/` via
+ * `/api/pm/plans` so plans surface regardless of remote PM provider state.
+ *
+ * The backend route is wrapped around LayeredPmProvider, so reads always
+ * succeed: when the configured remote provider (tynn / linear / …) is
+ * unreachable, the layer falls through to TynnLite. That makes this panel
+ * a true floor — never an empty error state due to "tynn not configured."
+ */
+
+import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { Card } from "@/components/ui/card";
+import { fetchPmPlans, fetchPmView, type PmPlanLite, type PmTaskLite, type PmView } from "../api.js";
+
+const VIEW_PILL_CLASS =
+  "px-2 py-1 text-[12px] rounded transition-colors data-[active=true]:bg-foreground data-[active=true]:text-background";
+
+const STATUS_BADGE: Record<string, string> = {
+  finished: "bg-green/20 text-green",
+  doing: "bg-blue/20 text-blue",
+  testing: "bg-orange/20 text-orange",
+  starting: "bg-yellow/20 text-yellow",
+  backlog: "bg-secondary text-muted-foreground",
+  blocked: "bg-red/20 text-red",
+  archived: "bg-secondary text-muted-foreground/50",
+};
+
+const PLAN_STATUS_BADGE: Record<string, string> = {
+  draft: "bg-secondary text-muted-foreground",
+  reviewing: "bg-yellow/20 text-yellow",
+  approved: "bg-blue/20 text-blue",
+  executing: "bg-orange/20 text-orange",
+  testing: "bg-orange/20 text-orange",
+  complete: "bg-green/20 text-green",
+  failed: "bg-red/20 text-red",
+};
+
+export interface PmLitePanelProps {
+  projectPath: string;
+}
+
+export function PmLitePanel({ projectPath }: PmLitePanelProps): ReactElement {
+  const [view, setView] = useState<PmView>("current");
+  const [tasks, setTasks] = useState<PmTaskLite[]>([]);
+  const [plans, setPlans] = useState<PmPlanLite[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(false);
+  const [tasksError, setTasksError] = useState<string | null>(null);
+  const [plansLoading, setPlansLoading] = useState(false);
+  const [plansError, setPlansError] = useState<string | null>(null);
+  const [providerId, setProviderId] = useState<string | null>(null);
+
+  const loadView = useCallback(async (target: PmView) => {
+    setTasksLoading(true);
+    setTasksError(null);
+    try {
+      const result = await fetchPmView(target);
+      setTasks(result.tasks);
+      setProviderId(result.providerId);
+    } catch (err) {
+      setTasksError(err instanceof Error ? err.message : String(err));
+      setTasks([]);
+    } finally {
+      setTasksLoading(false);
+    }
+  }, []);
+
+  const loadPlans = useCallback(async () => {
+    setPlansLoading(true);
+    setPlansError(null);
+    try {
+      const result = await fetchPmPlans(projectPath);
+      setPlans(result);
+    } catch (err) {
+      setPlansError(err instanceof Error ? err.message : String(err));
+      setPlans([]);
+    } finally {
+      setPlansLoading(false);
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void loadView(view);
+  }, [view, loadView]);
+
+  useEffect(() => {
+    void loadPlans();
+  }, [loadPlans]);
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="pm-lite-panel">
+      {/* DONE / CURRENT / NEXT view tabs over tasks */}
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+          <div className="flex items-center gap-1" data-testid="pm-view-tabs">
+            {(["next", "current", "done"] as PmView[]).map((v) => (
+              <button
+                key={v}
+                type="button"
+                className={VIEW_PILL_CLASS}
+                data-active={v === view}
+                data-testid={`pm-view-${v}`}
+                onClick={() => setView(v)}
+              >
+                {v.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          {providerId !== null && (
+            <span className="text-[10px] text-muted-foreground/70 font-mono" title="Provider id resolving these reads">
+              {providerId}
+            </span>
+          )}
+        </div>
+
+        {tasksLoading && (
+          <p className="text-[12px] text-muted-foreground italic" data-testid="pm-tasks-loading">Loading…</p>
+        )}
+        {!tasksLoading && tasksError !== null && (
+          <p className="text-[12px] text-red" data-testid="pm-tasks-error">{tasksError}</p>
+        )}
+        {!tasksLoading && tasksError === null && tasks.length === 0 && (
+          <p className="text-[12px] text-muted-foreground italic" data-testid="pm-tasks-empty">
+            No tasks in {view.toUpperCase()}.
+          </p>
+        )}
+        {!tasksLoading && tasksError === null && tasks.length > 0 && (
+          <ul className="space-y-1.5" data-testid="pm-tasks-list">
+            {tasks.map((task) => (
+              <li
+                key={task.id}
+                className="flex items-start gap-2 text-[13px] py-1 px-2 rounded hover:bg-secondary/40"
+                data-testid="pm-task-row"
+              >
+                <span className="text-[10px] text-muted-foreground/60 font-mono mt-0.5 min-w-[3ch] text-right">
+                  {task.number > 0 ? `t${String(task.number)}` : ""}
+                </span>
+                <span className={`px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider font-medium ${STATUS_BADGE[task.status] ?? "bg-secondary"}`}>
+                  {task.status}
+                </span>
+                <span className="flex-1 truncate" title={task.title}>{task.title}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {/* Plans — file-based, always available regardless of remote PM provider */}
+      <Card className="p-4" data-testid="pm-plans-card">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Plans
+          </h3>
+          <span className="text-[10px] text-muted-foreground/60" title="Source: <projectPath>/k/plans/">
+            file-based · always available
+          </span>
+        </div>
+        {plansLoading && (
+          <p className="text-[12px] text-muted-foreground italic" data-testid="pm-plans-loading">Loading plans…</p>
+        )}
+        {!plansLoading && plansError !== null && (
+          <p className="text-[12px] text-red" data-testid="pm-plans-error">{plansError}</p>
+        )}
+        {!plansLoading && plansError === null && plans.length === 0 && (
+          <p className="text-[12px] text-muted-foreground italic" data-testid="pm-plans-empty">
+            No plans yet for this project. Aion creates plans via the <code>pm</code> tool's <code>plan-create</code> action.
+          </p>
+        )}
+        {!plansLoading && plansError === null && plans.length > 0 && (
+          <ul className="space-y-1.5" data-testid="pm-plans-list">
+            {plans.map((plan) => (
+              <li
+                key={plan.id}
+                className="flex items-start gap-2 text-[13px] py-1 px-2 rounded hover:bg-secondary/40"
+                data-testid="pm-plan-row"
+              >
+                <span className={`px-1.5 py-0.5 rounded text-[10px] uppercase tracking-wider font-medium ${PLAN_STATUS_BADGE[plan.status] ?? "bg-secondary"}`}>
+                  {plan.status}
+                </span>
+                <span className="flex-1 truncate" title={plan.title}>{plan.title}</span>
+                <span className="text-[10px] text-muted-foreground/60 font-mono whitespace-nowrap">
+                  {String(plan.steps.length)} step{plan.steps.length === 1 ? "" : "s"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -23,6 +23,7 @@ import { CoreForkRepoPanel } from "./CoreForkRepoPanel.js";
 import { HostingPanel } from "./HostingPanel.js";
 import { EnvManager } from "./EnvManager.js";
 import { TaskmasterTab } from "./TaskmasterTab.js";
+import { PmLitePanel } from "./PmLitePanel.js";
 import { IterativeWorkTab } from "./IterativeWorkTab.js";
 import { MCPTab } from "./MCPTab.js";
 import { ProjectActivityTab } from "./ProjectActivityTab.js";
@@ -83,6 +84,9 @@ const CANVAS_LABELS: Record<string, string> = {
   // s150 t637 — "magic-apps" tab dropped; MApps config now lives inside the
   // Hosting tab when type is Desktop-served. Label removed from this map.
   taskmaster: "TaskMaster",
+  // Wish #17 / s155 t671 — Plans tab. Always available file-based PM-Lite
+  // surface with DONE/CURRENT/NEXT views.
+  plans: "Plans",
   security: "Security",
   activity: "Activity",
 };
@@ -200,6 +204,8 @@ export function ProjectDetail({
     // s150 t637 — "magic-apps" tab dropped; MApps config now lives inside the
     // Hosting tab when type is Desktop-served.
     "taskmaster": "coordinate",
+    // Wish #17 / s155 t671 — Plans tab in coordinate mode (PM workflow).
+    "plans": "coordinate",
     "security": "insight",
     "activity": "insight",
   };
@@ -216,7 +222,7 @@ export function ProjectDetail({
   useEffect(() => {
     if (!tabBelongsToMode(activeTab)) {
       // Find first tab in current mode (prefer the canonical first one)
-      const candidates = ["details", "files", "repository", "environment", "hosting", "iterative-work", "mcp", "taskmaster", "security", "activity"];
+      const candidates = ["details", "files", "repository", "environment", "hosting", "iterative-work", "mcp", "taskmaster", "plans", "security", "activity"];
       const firstInMode = candidates.find((id) => TAB_MODES[id] === currentMode);
       if (firstInMode) setActiveTab(firstInMode);
     }
@@ -691,6 +697,9 @@ export function ProjectDetail({
                 entries.push({ value: "environment", label: "Environment" });
               }
               if (tabBelongsToMode("taskmaster")) entries.push({ value: "taskmaster", label: "TaskMaster" });
+              // Wish #17 / s155 t671 — Plans entry. Available for every
+              // project (no hasCode gate) since PM-Lite is universal.
+              if (tabBelongsToMode("plans")) entries.push({ value: "plans", label: "Plans" });
               if (
                 tabBelongsToMode("iterative-work")
                 && (project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible)
@@ -1407,6 +1416,13 @@ export function ProjectDetail({
           <Card className="p-4">
             <TaskmasterTab projectPath={project.path} />
           </Card>
+        </TabsContent>
+
+        {/* Wish #17 / s155 t671 — Plans tab (PM-Lite). Always available;
+            DONE/CURRENT/NEXT views over the layered PM provider, plus a
+            file-based plan list straight from <projectPath>/k/plans/. */}
+        <TabsContent value="plans" className="mt-4 flex-1 min-h-0 overflow-y-auto">
+          <PmLitePanel projectPath={project.path} />
         </TabsContent>
 
         {(project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible) && (


### PR DESCRIPTION
Owner directive (Wish #17): 'always-available file-based PM-lite workflow + UI' with DONE/CURRENT/NEXT views. New pm-api.ts (next/find-tasks/view/plans/plans:id) wraps LayeredPmProvider + PlanStore. New PmLitePanel.tsx mounted in ProjectDetail as Plans secondary tab. Three view tabs over the layered provider; plans card from per-project k/plans/. 18 new tests + 67/67 regression. Closes s155 t671 (1 of 3 sub-tasks). Two remaining: t670 per-project TynnLite move, t672 bidirectional writes.