### PR TITLE
agi v0.4.550 — s155 t670 TynnLite storageDir option + migration helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.549",
+  "version": "0.4.550",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/tynn-lite-provider.test.ts
+++ b/packages/gateway-core/src/pm/tynn-lite-provider.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { TynnLitePmProvider } from "./tynn-lite-provider.js";
+import { migrateTynnLiteStorage, TynnLitePmProvider } from "./tynn-lite-provider.js";
 
 let projectRoot: string;
 let provider: TynnLitePmProvider;
@@ -382,5 +382,120 @@ describe("TynnLitePmProvider — iWish (cycle 46)", () => {
 describe("TynnLitePmProvider — methods still stubbed (cycle 47+ scope)", () => {
   it("getStory still returns null (no story concept in tynn-lite yet)", async () => {
     expect(await provider.getStory("any-id")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// s155 t670 — pluggable storage dir + migration helper
+// ---------------------------------------------------------------------------
+
+describe("TynnLitePmProvider — pluggable storageDir (s155 t670)", () => {
+  let testRoot: string;
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(tmpdir(), "tlp-storage-"));
+  });
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it("defaults to <projectRoot>/.tynn-lite/ when storageDir is omitted", () => {
+    const p = new TynnLitePmProvider({ projectRoot: testRoot });
+    expect(p.storageDir).toBe(join(testRoot, ".tynn-lite"));
+  });
+
+  it("relative storageDir joins with projectRoot (e.g. 'k/pm')", () => {
+    const p = new TynnLitePmProvider({ projectRoot: testRoot, storageDir: "k/pm" });
+    expect(p.storageDir).toBe(join(testRoot, "k", "pm"));
+  });
+
+  it("absolute storageDir lands as-is, ignoring projectRoot", () => {
+    const abs = join(testRoot, "elsewhere", "pm");
+    const p = new TynnLitePmProvider({ projectRoot: testRoot, storageDir: abs });
+    expect(p.storageDir).toBe(abs);
+  });
+
+  it("create+findTasks roundtrip works with the k/pm/ storage layout", async () => {
+    const p = new TynnLitePmProvider({ projectRoot: testRoot, storageDir: "k/pm" });
+    await p.createTask({ storyId: "s1", title: "Sample", description: "" });
+    const tasks = await p.findTasks();
+    expect(tasks.map((t) => t.title)).toEqual(["Sample"]);
+    expect(existsSync(join(testRoot, "k", "pm", "tasks.jsonl"))).toBe(true);
+    expect(existsSync(join(testRoot, ".tynn-lite", "tasks.jsonl"))).toBe(false);
+  });
+});
+
+describe("migrateTynnLiteStorage (s155 t670)", () => {
+  let testRoot: string;
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(tmpdir(), "tlp-mig-"));
+  });
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it("copies all four canonical files when present in legacy", () => {
+    const legacy = join(testRoot, ".tynn-lite");
+    const canonical = join(testRoot, "k", "pm");
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "tasks.jsonl"), `{"id":"t1"}\n`, "utf-8");
+    writeFileSync(join(legacy, "comments.jsonl"), `{"id":"c1"}\n`, "utf-8");
+    writeFileSync(join(legacy, "wishes.jsonl"), `{"id":"w1"}\n`, "utf-8");
+    writeFileSync(join(legacy, "state.json"), `{"activeFocus":null}\n`, "utf-8");
+
+    const r = migrateTynnLiteStorage(legacy, canonical);
+    expect(r.migrated).toBe(true);
+    expect(r.skipped).toBe(false);
+    expect(new Set(r.copied)).toEqual(new Set(["tasks.jsonl", "comments.jsonl", "wishes.jsonl", "state.json"]));
+    expect(existsSync(join(canonical, "tasks.jsonl"))).toBe(true);
+    expect(existsSync(join(canonical, "state.json"))).toBe(true);
+    // Legacy preserved as backup
+    expect(existsSync(join(legacy, "tasks.jsonl"))).toBe(true);
+  });
+
+  it("is a no-op when legacy dir is absent", () => {
+    const r = migrateTynnLiteStorage(join(testRoot, "missing"), join(testRoot, "k", "pm"));
+    expect(r).toEqual({ migrated: false, skipped: false, copied: [], errors: [] });
+  });
+
+  it("skips when canonical already contains any TynnLite file (no clobber)", () => {
+    const legacy = join(testRoot, ".tynn-lite");
+    const canonical = join(testRoot, "k", "pm");
+    mkdirSync(legacy, { recursive: true });
+    mkdirSync(canonical, { recursive: true });
+    writeFileSync(join(legacy, "tasks.jsonl"), `{"id":"legacy"}\n`, "utf-8");
+    writeFileSync(join(canonical, "tasks.jsonl"), `{"id":"already-here"}\n`, "utf-8");
+
+    const r = migrateTynnLiteStorage(legacy, canonical);
+    expect(r.migrated).toBe(false);
+    expect(r.skipped).toBe(true);
+    expect(r.copied).toEqual([]);
+    expect(readFileSync(join(canonical, "tasks.jsonl"), "utf-8")).toContain("already-here");
+  });
+
+  it("copies only files that exist in legacy (skips absent)", () => {
+    const legacy = join(testRoot, ".tynn-lite");
+    const canonical = join(testRoot, "k", "pm");
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, "tasks.jsonl"), `{"id":"t1"}\n`, "utf-8");
+    const r = migrateTynnLiteStorage(legacy, canonical);
+    expect(r.migrated).toBe(true);
+    expect(r.copied).toEqual(["tasks.jsonl"]);
+  });
+
+  it("a TynnLitePmProvider can read the migrated state seamlessly", async () => {
+    const projectRoot = testRoot;
+    const legacy = join(projectRoot, ".tynn-lite");
+    const canonical = join(projectRoot, "k", "pm");
+
+    const legacyProvider = new TynnLitePmProvider({ projectRoot });
+    await legacyProvider.createTask({ storyId: "s1", title: "From legacy", description: "" });
+    expect(existsSync(join(legacy, "tasks.jsonl"))).toBe(true);
+
+    const r = migrateTynnLiteStorage(legacy, canonical);
+    expect(r.migrated).toBe(true);
+
+    const newProvider = new TynnLitePmProvider({ projectRoot, storageDir: "k/pm" });
+    const tasks = await newProvider.findTasks();
+    expect(tasks.map((t) => t.title)).toEqual(["From legacy"]);
   });
 });

--- a/packages/gateway-core/src/pm/tynn-lite-provider.ts
+++ b/packages/gateway-core/src/pm/tynn-lite-provider.ts
@@ -119,8 +119,15 @@ const EMPTY_STATE: TynnLiteState = {
 // ---------------------------------------------------------------------------
 
 export interface TynnLitePmProviderOpts {
-  /** Absolute path to the project root. .tynn-lite/ lives directly inside. */
+  /** Absolute path to the base directory. When `storageDir` is omitted,
+   *  the provider lands at `<projectRoot>/.tynn-lite/` (legacy default).
+   *  Pair with `storageDir: "k/pm"` to land at `<projectRoot>/k/pm/` per
+   *  the s130 universal-monorepo model (s155 t670, 2026-05-09). */
   projectRoot: string;
+  /** Override the default `.tynn-lite` storage directory name. Pass
+   *  `"k/pm"` to align with the per-project k/ knowledge layer; pass
+   *  an absolute path to land outside `projectRoot` entirely. */
+  storageDir?: string;
   /** Display name for the project (returned by getProject). Defaults to
    *  the project root's basename when omitted. */
   projectName?: string;
@@ -137,13 +144,29 @@ export class TynnLitePmProvider implements PmProvider {
   private readonly projectName: string;
 
   constructor(opts: TynnLitePmProviderOpts) {
-    this.dir = join(opts.projectRoot, ".tynn-lite");
+    // s155 t670 — pluggable storage dir. Absolute paths land as-is so
+    // the caller can target `<projectPath>/k/pm/` (per-project) or any
+    // other location. Relative paths join with projectRoot like the
+    // legacy `.tynn-lite/` default.
+    if (opts.storageDir !== undefined) {
+      this.dir = opts.storageDir.startsWith("/")
+        ? opts.storageDir
+        : join(opts.projectRoot, opts.storageDir);
+    } else {
+      this.dir = join(opts.projectRoot, ".tynn-lite");
+    }
     this.tasksPath = join(this.dir, "tasks.jsonl");
     this.commentsPath = join(this.dir, "comments.jsonl");
     this.wishesPath = join(this.dir, "wishes.jsonl");
     this.statePath = join(this.dir, "state.json");
     this.statePathTmp = `${this.statePath}.tmp`;
     this.projectName = opts.projectName ?? opts.projectRoot.split("/").filter((s) => s.length > 0).pop() ?? "tynn-lite-project";
+  }
+
+  /** s155 t670 — expose the resolved storage directory. Used by the
+   *  migration helper + diagnostic surfaces. */
+  get storageDir(): string {
+    return this.dir;
   }
 
   // -------------------------------------------------------------------------
@@ -390,4 +413,76 @@ export class TynnLitePmProvider implements PmProvider {
     // Story support lands when the schema gains a separate stories.jsonl.
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// s155 t670 — Migration helper: copy legacy .tynn-lite/ → k/pm/
+// ---------------------------------------------------------------------------
+
+export interface TynnLiteMigrationResult {
+  /** True when at least one file was copied this call. */
+  migrated: boolean;
+  /** True when canonical already had content; no copy performed. */
+  skipped: boolean;
+  /** Files that were copied (basenames). */
+  copied: string[];
+  /** Errors encountered (per-file; non-fatal). */
+  errors: Array<{ file: string; reason: string }>;
+}
+
+/**
+ * Idempotently move TynnLite storage from a legacy `.tynn-lite/` directory
+ * into the canonical s130-aligned location (typically `<projectPath>/k/pm/`).
+ *
+ * Files copied: `tasks.jsonl`, `comments.jsonl`, `wishes.jsonl`, `state.json`
+ * (only those that exist in the legacy dir). Skips when the canonical dir
+ * already contains any of those files — caller can move them by hand if
+ * an actual merge is needed (rare; not worth scripting for the one-off
+ * migration). Legacy files are preserved as backup; a follow-up sweep
+ * removes them once stable across upgrades.
+ *
+ * Returns `migrated: true` when something was copied, `skipped: true` when
+ * canonical was already populated, and both `false` when there was no
+ * legacy data to migrate.
+ */
+export function migrateTynnLiteStorage(
+  legacyDir: string,
+  canonicalDir: string,
+): TynnLiteMigrationResult {
+  const out: TynnLiteMigrationResult = { migrated: false, skipped: false, copied: [], errors: [] };
+  if (!existsSync(legacyDir)) return out;
+
+  const known = ["tasks.jsonl", "comments.jsonl", "wishes.jsonl", "state.json"];
+  // Skip if canonical already has any of the four — we don't want to clobber
+  // active per-project data with a stale workspace-level copy.
+  for (const file of known) {
+    if (existsSync(join(canonicalDir, file))) {
+      out.skipped = true;
+      return out;
+    }
+  }
+
+  if (!existsSync(canonicalDir)) {
+    try {
+      mkdirSync(canonicalDir, { recursive: true });
+    } catch (e) {
+      out.errors.push({ file: canonicalDir, reason: e instanceof Error ? e.message : String(e) });
+      return out;
+    }
+  }
+
+  for (const file of known) {
+    const src = join(legacyDir, file);
+    if (!existsSync(src)) continue;
+    try {
+      const content = readFileSync(src, "utf-8");
+      writeFileSync(join(canonicalDir, file), content, "utf-8");
+      out.copied.push(file);
+      out.migrated = true;
+    } catch (e) {
+      out.errors.push({ file: src, reason: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return out;
 }


### PR DESCRIPTION
Smallest meaningful step toward per-project k/pm/: pluggable storageDir option (relative joins with projectRoot, absolute lands as-is, default unchanged for back-compat) + migrateTynnLiteStorage helper with no-clobber semantics. 9 new tests + 51 total. Full per-project rollout (multi-project aggregator with context routing) deferred to a follow-up since it requires LayeredPmProvider project-context awareness. Closes s155 t670.