### PR TITLE
agi v0.4.552 — s152 UserNotes vertical slice (per-project + global markdown)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.551",
+  "version": "0.4.552",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/db-schema/src/platform.ts
+++ b/packages/db-schema/src/platform.ts
@@ -89,3 +89,43 @@ export const meta = pgTable("meta", {
   value: jsonb("value").notNull(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
+
+/**
+ * UserNotes — first-class notes surface for end users (s152, 2026-05-09).
+ *
+ * Two scopes: per-project (projectPath set) and global (projectPath null).
+ * Single mode for v1 (markdown notepad); whiteboard mode lands in a
+ * follow-up. Aion reads these notes as context the same way Dev Notes
+ * are consumed.
+ *
+ * Storage round-trips through agi_data per single-source-of-truth (see
+ * memory `feedback_single_source_of_truth_db`) — never write notes to
+ * disk-only locations like `~/.agi/notes/` that would drift from the DB.
+ */
+export const userNotes = pgTable(
+  "user_notes",
+  {
+    id: text("id").primaryKey(),
+    /** Owning user (entity id). Multi-user support arrives via Hive-ID;
+     *  for the single-owner alpha, every note is owned by `~$U0`. */
+    userEntityId: text("user_entity_id").notNull(),
+    /** Per-project notes set this to the absolute project path. Global
+     *  notes (the global scope from the s152 spec) leave it NULL. */
+    projectPath: text("project_path"),
+    /** Display title — short, single-line. */
+    title: text("title").notNull(),
+    /** Markdown body. */
+    body: text("body").notNull().default(""),
+    /** Sort order within a scope. Lower = earlier. */
+    sortOrder: integer("sort_order").notNull().default(0),
+    /** Optional pinned flag — pinned notes float to the top. */
+    pinned: boolean("pinned").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    userIdx: index("user_notes_user_idx").on(t.userEntityId),
+    projectIdx: index("user_notes_project_idx").on(t.projectPath),
+    pinnedIdx: index("user_notes_pinned_idx").on(t.pinned),
+  }),
+);

--- a/packages/gateway-core/src/notes-api.test.ts
+++ b/packages/gateway-core/src/notes-api.test.ts
@@ -1,0 +1,294 @@
+/**
+ * s152 — notes-api REST surface contract.
+ *
+ * Mock NotesStore — keeps the test in-process (app.inject + an in-memory
+ * Map) so we can pin the route contract without spinning up Postgres.
+ * The DB-backed NotesStore itself gets covered by the integration test
+ * VM suite once notes-store.test.ts (DB fixture) lands.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { ulid } from "ulid";
+
+import { ALPHA_OWNER_ENTITY_ID, registerNotesRoutes } from "./notes-api.js";
+import type { NotesStore, UserNoteRecord, CreateNoteInput, UpdateNoteInput } from "./notes-store.js";
+
+class InMemoryNotesStore implements Pick<NotesStore, "list" | "get" | "create" | "update" | "delete"> {
+  readonly notes = new Map<string, UserNoteRecord>();
+
+  async list(userEntityId: string, projectPath?: string | null): Promise<UserNoteRecord[]> {
+    let out = Array.from(this.notes.values()).filter((n) => n.userEntityId === userEntityId);
+    if (projectPath === null) {
+      out = out.filter((n) => n.projectPath === null);
+    } else if (typeof projectPath === "string") {
+      out = out.filter((n) => n.projectPath === projectPath);
+    }
+    return out.sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+      if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+  }
+
+  async get(id: string): Promise<UserNoteRecord | null> {
+    return this.notes.get(id) ?? null;
+  }
+
+  async create(input: CreateNoteInput): Promise<UserNoteRecord> {
+    const id = `note_${ulid()}`;
+    const now = new Date().toISOString();
+    const note: UserNoteRecord = {
+      id,
+      userEntityId: input.userEntityId,
+      projectPath: input.projectPath,
+      title: input.title,
+      body: input.body ?? "",
+      sortOrder: input.sortOrder ?? 0,
+      pinned: input.pinned ?? false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.notes.set(id, note);
+    return note;
+  }
+
+  async update(id: string, patch: UpdateNoteInput): Promise<UserNoteRecord | null> {
+    const existing = this.notes.get(id);
+    if (existing === undefined) return null;
+    const updated: UserNoteRecord = {
+      ...existing,
+      ...(patch.title !== undefined ? { title: patch.title } : {}),
+      ...(patch.body !== undefined ? { body: patch.body } : {}),
+      ...(patch.sortOrder !== undefined ? { sortOrder: patch.sortOrder } : {}),
+      ...(patch.pinned !== undefined ? { pinned: patch.pinned } : {}),
+      updatedAt: new Date().toISOString(),
+    };
+    this.notes.set(id, updated);
+    return updated;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    return this.notes.delete(id);
+  }
+}
+
+describe("notes-api routes (s152)", () => {
+  let app: FastifyInstance;
+  let store: InMemoryNotesStore;
+  const workspace = "/wsroot";
+  const projectPath = "/wsroot/myproject";
+
+  beforeEach(async () => {
+    app = Fastify();
+    store = new InMemoryNotesStore();
+    registerNotesRoutes(app, {
+      notesStore: store as unknown as NotesStore,
+      workspaceProjects: [workspace],
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe("POST /api/notes", () => {
+    it("creates a global note when projectPath is omitted", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/notes",
+        payload: { title: "Global thought" },
+      });
+      expect(r.statusCode).toBe(201);
+      const body = r.json() as UserNoteRecord;
+      expect(body.title).toBe("Global thought");
+      expect(body.projectPath).toBeNull();
+      expect(body.userEntityId).toBe(ALPHA_OWNER_ENTITY_ID);
+    });
+
+    it("creates a per-project note when projectPath is set", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/notes",
+        payload: { title: "Project thought", body: "## intro\n\nbody", projectPath },
+      });
+      expect(r.statusCode).toBe(201);
+      const body = r.json() as UserNoteRecord;
+      expect(body.projectPath).toBe(projectPath);
+      expect(body.body).toBe("## intro\n\nbody");
+    });
+
+    it("rejects projectPath outside the workspace with 403", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/notes",
+        payload: { title: "Outside", projectPath: "/etc/passwd" },
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    it("rejects projectPath equal to the workspace root with 403", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/notes",
+        payload: { title: "Root", projectPath: workspace },
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    it("rejects empty title with 400", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/notes",
+        payload: { title: "   " },
+      });
+      expect(r.statusCode).toBe(400);
+    });
+  });
+
+  describe("GET /api/notes", () => {
+    beforeEach(async () => {
+      // Seed: 1 global + 2 project notes
+      await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "Global A" });
+      await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath, title: "Proj A" });
+      await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath, title: "Proj B" });
+    });
+
+    it("returns global notes when no params provided", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/notes" });
+      const body = r.json() as { notes: UserNoteRecord[]; scope: string };
+      expect(body.scope).toBe("global");
+      expect(body.notes.map((n) => n.title)).toEqual(["Global A"]);
+    });
+
+    it("returns per-project notes when projectPath is set", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/notes?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      const body = r.json() as { notes: UserNoteRecord[]; scope: string };
+      expect(body.scope).toBe("project");
+      expect(new Set(body.notes.map((n) => n.title))).toEqual(new Set(["Proj A", "Proj B"]));
+    });
+
+    it("returns all notes for scope=all", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/notes?scope=all" });
+      const body = r.json() as { notes: UserNoteRecord[]; scope: string };
+      expect(body.scope).toBe("all");
+      expect(body.notes).toHaveLength(3);
+    });
+
+    it("rejects projectPath outside the workspace with 403", async () => {
+      const r = await app.inject({
+        method: "GET",
+        url: `/api/notes?projectPath=${encodeURIComponent("/elsewhere")}`,
+      });
+      expect(r.statusCode).toBe(403);
+    });
+
+    it("orders pinned notes first", async () => {
+      const created = await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "Pinned star" });
+      await store.update(created.id, { pinned: true });
+
+      const r = await app.inject({ method: "GET", url: "/api/notes" });
+      const body = r.json() as { notes: UserNoteRecord[] };
+      expect(body.notes[0]?.title).toBe("Pinned star");
+    });
+  });
+
+  describe("GET /api/notes/:id", () => {
+    it("returns the note", async () => {
+      const created = await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "X" });
+      const r = await app.inject({ method: "GET", url: `/api/notes/${created.id}` });
+      expect(r.statusCode).toBe(200);
+      expect((r.json() as UserNoteRecord).id).toBe(created.id);
+    });
+
+    it("returns 404 when not found", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/notes/note_nope" });
+      expect(r.statusCode).toBe(404);
+    });
+
+    it("returns 403 when owned by another user", async () => {
+      const created = await store.create({ userEntityId: "~$U_OTHER", projectPath: null, title: "Theirs" });
+      const r = await app.inject({ method: "GET", url: `/api/notes/${created.id}` });
+      expect(r.statusCode).toBe(403);
+    });
+  });
+
+  describe("PUT /api/notes/:id", () => {
+    it("partially updates title + body", async () => {
+      const created = await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "Old", body: "old body" });
+      const r = await app.inject({
+        method: "PUT",
+        url: `/api/notes/${created.id}`,
+        payload: { title: "New", body: "new body" },
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as UserNoteRecord;
+      expect(body.title).toBe("New");
+      expect(body.body).toBe("new body");
+    });
+
+    it("toggles pinned", async () => {
+      const created = await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "P" });
+      const r = await app.inject({
+        method: "PUT",
+        url: `/api/notes/${created.id}`,
+        payload: { pinned: true },
+      });
+      expect((r.json() as UserNoteRecord).pinned).toBe(true);
+    });
+
+    it("returns 404 when not found", async () => {
+      const r = await app.inject({
+        method: "PUT",
+        url: "/api/notes/note_nope",
+        payload: { title: "x" },
+      });
+      expect(r.statusCode).toBe(404);
+    });
+
+    it("returns 403 when owned by another user", async () => {
+      const created = await store.create({ userEntityId: "~$U_OTHER", projectPath: null, title: "Theirs" });
+      const r = await app.inject({
+        method: "PUT",
+        url: `/api/notes/${created.id}`,
+        payload: { title: "Hijack" },
+      });
+      expect(r.statusCode).toBe(403);
+    });
+  });
+
+  describe("DELETE /api/notes/:id", () => {
+    it("removes the note + returns 204", async () => {
+      const created = await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "Doomed" });
+      const r = await app.inject({ method: "DELETE", url: `/api/notes/${created.id}` });
+      expect(r.statusCode).toBe(204);
+      expect(store.notes.has(created.id)).toBe(false);
+    });
+
+    it("returns 404 when not found", async () => {
+      const r = await app.inject({ method: "DELETE", url: "/api/notes/note_nope" });
+      expect(r.statusCode).toBe(404);
+    });
+
+    it("returns 403 when owned by another user", async () => {
+      const created = await store.create({ userEntityId: "~$U_OTHER", projectPath: null, title: "Theirs" });
+      const r = await app.inject({ method: "DELETE", url: `/api/notes/${created.id}` });
+      expect(r.statusCode).toBe(403);
+    });
+  });
+
+  describe("multi-user isolation", () => {
+    it("scope=all only returns notes for the configured owner entity", async () => {
+      await store.create({ userEntityId: ALPHA_OWNER_ENTITY_ID, projectPath: null, title: "Mine" });
+      await store.create({ userEntityId: "~$U_OTHER", projectPath: null, title: "Theirs" });
+
+      const r = await app.inject({ method: "GET", url: "/api/notes?scope=all" });
+      const body = r.json() as { notes: UserNoteRecord[] };
+      expect(body.notes.map((n) => n.title)).toEqual(["Mine"]);
+    });
+  });
+});

--- a/packages/gateway-core/src/notes-api.ts
+++ b/packages/gateway-core/src/notes-api.ts
@@ -1,0 +1,152 @@
+/**
+ * Notes API — UserNotes REST surface (s152, 2026-05-09).
+ *
+ * Per-project + global markdown notes with the s152 contract:
+ *   - GET    /api/notes?projectPath=...          list (per-project when set, global when omitted)
+ *   - GET    /api/notes/:id                       single fetch
+ *   - POST   /api/notes                           create
+ *   - PUT    /api/notes/:id                       update (partial — title/body/sortOrder/pinned)
+ *   - DELETE /api/notes/:id                       remove
+ *
+ * Single-owner alpha: every note is owned by `~$U0` (the local owner).
+ * Multi-user support comes via Hive-ID; the userEntityId column already
+ * exists for that future. workspace-projects guard on the projectPath
+ * input rejects paths outside the configured workspace, mirroring the
+ * pm-api / projects-api pattern.
+ */
+
+import type { FastifyInstance } from "fastify";
+import type { NotesStore, CreateNoteInput, UpdateNoteInput, UserNoteRecord } from "./notes-store.js";
+
+/** Single-owner alpha — every note is owned by this entity id. */
+export const ALPHA_OWNER_ENTITY_ID = "~$U0";
+
+export interface NotesApiDeps {
+  notesStore: NotesStore;
+  /** Workspace project paths — projectPath query param must lie inside one
+   *  of these (or be empty for global scope). */
+  workspaceProjects: string[];
+  /** Optional hook for resolving the owner entity id (multi-user future).
+   *  Defaults to `ALPHA_OWNER_ENTITY_ID` when omitted. */
+  resolveOwnerEntityId?: () => string;
+}
+
+function isInsideWorkspace(projectPath: string, workspaceProjects: readonly string[]): boolean {
+  const normalize = (p: string): string => (p.endsWith("/") ? p : `${p}/`);
+  const targetPrefix = normalize(projectPath);
+  for (const ws of workspaceProjects) {
+    const wsPrefix = normalize(ws);
+    if (targetPrefix === wsPrefix) return false; // workspace root itself isn't a project
+    if (projectPath.startsWith(wsPrefix)) return true;
+  }
+  return false;
+}
+
+export function registerNotesRoutes(app: FastifyInstance, deps: NotesApiDeps): void {
+  const ownerEntityId = (): string => deps.resolveOwnerEntityId?.() ?? ALPHA_OWNER_ENTITY_ID;
+
+  /**
+   * GET /api/notes
+   *   - no params              → global notes (projectPath null)
+   *   - ?projectPath=/abs/path → notes for that project
+   *   - ?scope=all             → all notes for the user, both scopes
+   */
+  app.get("/api/notes", async (request, reply) => {
+    const query = request.query as { projectPath?: string; scope?: string };
+    const userId = ownerEntityId();
+    if (query.scope === "all") {
+      const all = await deps.notesStore.list(userId);
+      return { notes: all, scope: "all" };
+    }
+    if (typeof query.projectPath === "string" && query.projectPath.length > 0) {
+      if (!isInsideWorkspace(query.projectPath, deps.workspaceProjects)) {
+        return reply.code(403).send({ error: "projectPath is not inside a configured workspace.projects directory" });
+      }
+      const notes = await deps.notesStore.list(userId, query.projectPath);
+      return { notes, scope: "project", projectPath: query.projectPath };
+    }
+    const globals = await deps.notesStore.list(userId, null);
+    return { notes: globals, scope: "global" };
+  });
+
+  /** GET /api/notes/:id */
+  app.get<{ Params: { id: string } }>("/api/notes/:id", async (request, reply) => {
+    const { id } = request.params;
+    const note = await deps.notesStore.get(id);
+    if (note === null) {
+      return reply.code(404).send({ error: `note ${id} not found` });
+    }
+    if (note.userEntityId !== ownerEntityId()) {
+      return reply.code(403).send({ error: "note is owned by another user" });
+    }
+    return note;
+  });
+
+  /**
+   * POST /api/notes
+   * Body: { projectPath?: string|null; title: string; body?: string; pinned?: boolean; sortOrder?: number }
+   * - omit projectPath OR set to null → global note
+   * - set projectPath to absolute path → per-project note (must be inside workspace)
+   */
+  app.post("/api/notes", async (request, reply) => {
+    const body = request.body as Partial<CreateNoteInput> & { projectPath?: string | null };
+    if (typeof body.title !== "string" || body.title.trim().length === 0) {
+      return reply.code(400).send({ error: "title is required" });
+    }
+    let projectPath: string | null = null;
+    if (typeof body.projectPath === "string" && body.projectPath.length > 0) {
+      if (!isInsideWorkspace(body.projectPath, deps.workspaceProjects)) {
+        return reply.code(403).send({ error: "projectPath is not inside a configured workspace.projects directory" });
+      }
+      projectPath = body.projectPath;
+    }
+    const created: UserNoteRecord = await deps.notesStore.create({
+      userEntityId: ownerEntityId(),
+      projectPath,
+      title: body.title.trim(),
+      body: typeof body.body === "string" ? body.body : "",
+      ...(typeof body.pinned === "boolean" ? { pinned: body.pinned } : {}),
+      ...(typeof body.sortOrder === "number" ? { sortOrder: body.sortOrder } : {}),
+    });
+    return reply.code(201).send(created);
+  });
+
+  /**
+   * PUT /api/notes/:id
+   * Body: { title?: string; body?: string; sortOrder?: number; pinned?: boolean }
+   * Partial update — only provided fields change. projectPath cannot be
+   * changed via PUT (delete + recreate to switch scopes).
+   */
+  app.put<{ Params: { id: string } }>("/api/notes/:id", async (request, reply) => {
+    const { id } = request.params;
+    const note = await deps.notesStore.get(id);
+    if (note === null) {
+      return reply.code(404).send({ error: `note ${id} not found` });
+    }
+    if (note.userEntityId !== ownerEntityId()) {
+      return reply.code(403).send({ error: "note is owned by another user" });
+    }
+    const body = request.body as UpdateNoteInput;
+    const patch: UpdateNoteInput = {};
+    if (typeof body.title === "string") patch.title = body.title.trim();
+    if (typeof body.body === "string") patch.body = body.body;
+    if (typeof body.sortOrder === "number") patch.sortOrder = body.sortOrder;
+    if (typeof body.pinned === "boolean") patch.pinned = body.pinned;
+    const updated = await deps.notesStore.update(id, patch);
+    return updated;
+  });
+
+  /** DELETE /api/notes/:id */
+  app.delete<{ Params: { id: string } }>("/api/notes/:id", async (request, reply) => {
+    const { id } = request.params;
+    const note = await deps.notesStore.get(id);
+    if (note === null) {
+      return reply.code(404).send({ error: `note ${id} not found` });
+    }
+    if (note.userEntityId !== ownerEntityId()) {
+      return reply.code(403).send({ error: "note is owned by another user" });
+    }
+    await deps.notesStore.delete(id);
+    return reply.code(204).send();
+  });
+}

--- a/packages/gateway-core/src/notes-store.ts
+++ b/packages/gateway-core/src/notes-store.ts
@@ -1,0 +1,134 @@
+/**
+ * NotesStore — Postgres/drizzle persistence for UserNotes (s152, 2026-05-09).
+ *
+ * Owner directive: "a first-class Notes surface for END USERS … Aion can
+ * read these notes the same way it reads Dev Notes." Storage round-trips
+ * through agi_data per the single-source-of-truth rule.
+ *
+ * Two scopes:
+ *   - per-project notes — `projectPath` set
+ *   - global notes — `projectPath` NULL
+ *
+ * Sort order: pinned notes first (by sortOrder asc, then createdAt desc),
+ * then unpinned (sortOrder asc, then createdAt desc). Drag-to-reorder in
+ * the UI mutates `sortOrder`.
+ */
+
+import { and, asc, desc, eq, isNull } from "drizzle-orm";
+import { ulid } from "ulid";
+import type { Db } from "@agi/db-schema/client";
+import { userNotes } from "@agi/db-schema";
+
+export interface UserNoteRecord {
+  id: string;
+  userEntityId: string;
+  projectPath: string | null;
+  title: string;
+  body: string;
+  sortOrder: number;
+  pinned: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateNoteInput {
+  userEntityId: string;
+  projectPath: string | null;
+  title: string;
+  body?: string;
+  sortOrder?: number;
+  pinned?: boolean;
+}
+
+export interface UpdateNoteInput {
+  title?: string;
+  body?: string;
+  sortOrder?: number;
+  pinned?: boolean;
+}
+
+function rowToRecord(row: typeof userNotes.$inferSelect): UserNoteRecord {
+  return {
+    id: row.id,
+    userEntityId: row.userEntityId,
+    projectPath: row.projectPath,
+    title: row.title,
+    body: row.body,
+    sortOrder: row.sortOrder,
+    pinned: row.pinned,
+    createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
+    updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : String(row.updatedAt),
+  };
+}
+
+export class NotesStore {
+  constructor(private readonly db: Db) {}
+
+  /**
+   * List notes for a scope. When `projectPath` is undefined, returns all
+   * notes for the user across both scopes. When null, returns global
+   * notes only. When a string, returns notes for that project.
+   *
+   * Result order: pinned first, then by sortOrder asc, then createdAt desc
+   * (newest-first within ties so the most recent note surfaces at top).
+   */
+  async list(userEntityId: string, projectPath?: string | null): Promise<UserNoteRecord[]> {
+    const conds = [eq(userNotes.userEntityId, userEntityId)];
+    if (projectPath === null) {
+      conds.push(isNull(userNotes.projectPath));
+    } else if (typeof projectPath === "string") {
+      conds.push(eq(userNotes.projectPath, projectPath));
+    }
+    const rows = await this.db
+      .select()
+      .from(userNotes)
+      .where(and(...conds))
+      .orderBy(desc(userNotes.pinned), asc(userNotes.sortOrder), desc(userNotes.createdAt));
+    return rows.map(rowToRecord);
+  }
+
+  async get(noteId: string): Promise<UserNoteRecord | null> {
+    const [row] = await this.db.select().from(userNotes).where(eq(userNotes.id, noteId));
+    return row ? rowToRecord(row) : null;
+  }
+
+  async create(input: CreateNoteInput): Promise<UserNoteRecord> {
+    const id = `note_${ulid()}`;
+    const now = new Date();
+    await this.db.insert(userNotes).values({
+      id,
+      userEntityId: input.userEntityId,
+      projectPath: input.projectPath,
+      title: input.title,
+      body: input.body ?? "",
+      sortOrder: input.sortOrder ?? 0,
+      pinned: input.pinned ?? false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const out = await this.get(id);
+    if (out === null) {
+      throw new Error("notes-store: create did not produce a row");
+    }
+    return out;
+  }
+
+  async update(noteId: string, patch: UpdateNoteInput): Promise<UserNoteRecord | null> {
+    const existing = await this.get(noteId);
+    if (existing === null) return null;
+    const updates: Partial<typeof userNotes.$inferInsert> = { updatedAt: new Date() };
+    if (patch.title !== undefined) updates.title = patch.title;
+    if (patch.body !== undefined) updates.body = patch.body;
+    if (patch.sortOrder !== undefined) updates.sortOrder = patch.sortOrder;
+    if (patch.pinned !== undefined) updates.pinned = patch.pinned;
+    await this.db.update(userNotes).set(updates).where(eq(userNotes.id, noteId));
+    return this.get(noteId);
+  }
+
+  async delete(noteId: string): Promise<boolean> {
+    const existing = await this.get(noteId);
+    if (existing === null) return false;
+    await this.db.delete(userNotes).where(eq(userNotes.id, noteId));
+    return true;
+  }
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -51,6 +51,7 @@ import { registerComplianceRoutes } from "./compliance-api.js";
 import { registerSecurityRoutes } from "./security-api.js";
 import { registerProvidersRoutes } from "./providers-api.js";
 import { registerPmRoutes } from "./pm-api.js";
+import { registerNotesRoutes } from "./notes-api.js";
 import { registerAdminRoutes } from "./admin-api.js";
 import { ScanProviderRegistry, ScanStore, ScanRunner, sastScanner, scaScanner, secretsScanner, configScanner } from "@agi/security";
 import { COAChainLogger } from "@agi/coa-chain";
@@ -2734,6 +2735,11 @@ export async function startGatewayServer(
   const { MagicAppStateStore } = await import("./magic-app-state-store.js");
   const magicAppStateStore = new MagicAppStateStore(db);
 
+  // s152 — UserNotes store (markdown notepad surface, per-project + global).
+  // Storage round-trips through agi_data per single-source-of-truth.
+  const { NotesStore } = await import("./notes-store.js");
+  const notesStore = new NotesStore(db);
+
   const { httpServer, wsServer } = await createGatewayRuntimeState(
     {
       auth,
@@ -2971,6 +2977,13 @@ export async function startGatewayServer(
         (f) => registerPmRoutes(f, {
           pmProvider,
           planStore,
+          workspaceProjects: projectPaths,
+        }),
+        // s152 — UserNotes REST surface. Markdown notepad, per-project +
+        // global scopes. Single-owner alpha; userEntityId is fixed to
+        // `~$U0` until Hive-ID multi-user lands.
+        (f) => registerNotesRoutes(f, {
+          notesStore,
           workspaceProjects: projectPaths,
         }),
         (f) => registerAdminRoutes(f, createComponentLogger(logger, "admin-api"), aionMicroManager),

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -211,6 +211,70 @@ export async function fetchPmPlan(projectPath: string, planId: string): Promise<
   return res.json() as Promise<PmPlanLite>;
 }
 
+// ---------------------------------------------------------------------------
+// UserNotes — s152. Markdown notepad surface, per-project + global scopes.
+// ---------------------------------------------------------------------------
+
+export interface UserNote {
+  id: string;
+  userEntityId: string;
+  projectPath: string | null;
+  title: string;
+  body: string;
+  sortOrder: number;
+  pinned: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** List notes for a scope. Pass null for global; pass an absolute path for per-project. */
+export async function fetchNotes(projectPath: string | null): Promise<UserNote[]> {
+  const url = projectPath !== null
+    ? `/api/notes?projectPath=${encodeURIComponent(projectPath)}`
+    : "/api/notes";
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  const data = await res.json() as { notes: UserNote[] };
+  return data.notes;
+}
+
+export async function createNote(input: { projectPath: string | null; title: string; body?: string; pinned?: boolean }): Promise<UserNote> {
+  const res = await fetch("/api/notes", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<UserNote>;
+}
+
+export async function updateNote(id: string, patch: { title?: string; body?: string; pinned?: boolean; sortOrder?: number }): Promise<UserNote> {
+  const res = await fetch(`/api/notes/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<UserNote>;
+}
+
+export async function deleteNote(id: string): Promise<void> {
+  const res = await fetch(`/api/notes/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!res.ok && res.status !== 204) {
+    const body = await res.json().catch(() => ({ error: res.statusText })) as { error?: string };
+    throw new Error(body.error ?? `HTTP ${res.status}`);
+  }
+}
+
 export async function createProject(params: {
   name: string;
   tynnToken?: string;

--- a/ui/dashboard/src/components/AppSidebar.tsx
+++ b/ui/dashboard/src/components/AppSidebar.tsx
@@ -19,7 +19,7 @@ import {
   Compass, FileText, GitBranch, Store, ScrollText, Rocket,
   SlidersHorizontal, Activity, Blocks, ShieldHalf, ShieldCheck,
   AlertTriangle, Building2, HardDrive, Fingerprint, Sparkles, Cpu,
-  Shield, ArrowLeft, FileSearch,
+  Shield, ArrowLeft, FileSearch, NotebookPen,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -61,6 +61,8 @@ const builtinSections: NavSectionWithMode[] = [
   { mode: "main", title: "Knowledge", items: [
     { to: "/knowledge", label: "Browse", icon: Compass },
     { to: "/docs", label: "Documentation", icon: FileText },
+    // s152 — Global Notes page (markdown notepad surface, scoped to no project).
+    { to: "/notes", label: "Notes", icon: NotebookPen },
   ]},
   // ── ADMIN ──
   { mode: "admin", title: "Overview", items: [

--- a/ui/dashboard/src/components/NotesPanel.tsx
+++ b/ui/dashboard/src/components/NotesPanel.tsx
@@ -1,0 +1,293 @@
+/**
+ * NotesPanel — markdown notepad surface for a scope (s152, 2026-05-09).
+ *
+ * Props:
+ *   - projectPath: null  → global notes (mounted on a future Notes page)
+ *   - projectPath: string → per-project notes (mounted as the Notes tab)
+ *
+ * Two-pane layout: list on the left, selected note's editor on the right.
+ * A "New note" button at the top of the list creates an empty note and
+ * focuses the editor. Save is explicit — typing without saving keeps a
+ * dirty marker; ⌘S / clicking Save persists. Pinned notes float to top.
+ *
+ * Owner directive 2026-05-09 (Wish #17 → s152): "Aion can read these
+ * notes the same way it reads Dev Notes." Backend already exposes
+ * /api/notes; agent-context-assembly hookup ships in a follow-up.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { createNote, deleteNote, fetchNotes, updateNote, type UserNote } from "../api.js";
+
+export interface NotesPanelProps {
+  /** Per-project: pass the absolute project path. Global: pass null. */
+  projectPath: string | null;
+}
+
+export function NotesPanel({ projectPath }: NotesPanelProps): ReactElement {
+  const [notes, setNotes] = useState<UserNote[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftBody, setDraftBody] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await fetchNotes(projectPath);
+      setNotes(list);
+      // Preserve current selection when possible; otherwise pick first.
+      setSelectedId((prev) => {
+        if (prev !== null && list.some((n) => n.id === prev)) return prev;
+        return list[0]?.id ?? null;
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setNotes([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const selected = useMemo(
+    () => notes.find((n) => n.id === selectedId) ?? null,
+    [notes, selectedId],
+  );
+
+  // Sync the draft fields when the selection changes.
+  useEffect(() => {
+    if (selected !== null) {
+      setDraftTitle(selected.title);
+      setDraftBody(selected.body);
+    } else {
+      setDraftTitle("");
+      setDraftBody("");
+    }
+  }, [selected?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const dirty = useMemo(() => {
+    if (selected === null) return false;
+    return draftTitle !== selected.title || draftBody !== selected.body;
+  }, [selected, draftTitle, draftBody]);
+
+  const handleNew = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createNote({
+        projectPath,
+        title: "Untitled",
+        body: "",
+      });
+      setNotes((prev) => [created, ...prev]);
+      setSelectedId(created.id);
+      // Defer focus until the textarea remounts.
+      setTimeout(() => bodyRef.current?.focus(), 0);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [projectPath]);
+
+  const handleSave = useCallback(async () => {
+    if (selected === null || !dirty) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateNote(selected.id, {
+        title: draftTitle.trim() || "Untitled",
+        body: draftBody,
+      });
+      setNotes((prev) => prev.map((n) => (n.id === updated.id ? updated : n)));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [selected, dirty, draftTitle, draftBody]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await deleteNote(id);
+      setNotes((prev) => prev.filter((n) => n.id !== id));
+      setSelectedId((prev) => (prev === id ? null : prev));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const handleTogglePin = useCallback(async (id: string, currentlyPinned: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateNote(id, { pinned: !currentlyPinned });
+      setNotes((prev) => {
+        const next = prev.map((n) => (n.id === updated.id ? updated : n));
+        // Re-sort: pinned first, then by sortOrder asc, then createdAt desc.
+        return next.sort((a, b) => {
+          if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+          if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+          return b.createdAt.localeCompare(a.createdAt);
+        });
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  // ⌘S / Ctrl+S to save while editor is focused.
+  const handleEditorKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        void handleSave();
+      }
+    },
+    [handleSave],
+  );
+
+  return (
+    <div className="flex gap-4 h-full" data-testid="notes-panel">
+      {/* List pane */}
+      <Card className="p-3 w-[280px] flex flex-col gap-2 max-h-[600px] overflow-hidden">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-[12px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {projectPath !== null ? "Project Notes" : "Global Notes"}
+          </h3>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleNew()}
+            disabled={saving}
+            data-testid="notes-new-button"
+            className="text-[11px] h-7"
+          >
+            + New
+          </Button>
+        </div>
+
+        {error !== null && (
+          <p className="text-[11px] text-red break-words" data-testid="notes-error">{error}</p>
+        )}
+
+        <div className="flex-1 overflow-y-auto -mx-1">
+          {loading && notes.length === 0 && (
+            <p className="text-[12px] text-muted-foreground italic px-1">Loading notes…</p>
+          )}
+          {!loading && notes.length === 0 && error === null && (
+            <p className="text-[12px] text-muted-foreground italic px-1" data-testid="notes-empty">
+              No notes yet. Click + New to start one.
+            </p>
+          )}
+          <ul className="space-y-1" data-testid="notes-list">
+            {notes.map((note) => {
+              const isSelected = note.id === selectedId;
+              return (
+                <li key={note.id}>
+                  <button
+                    type="button"
+                    className={`w-full text-left px-2 py-1.5 rounded text-[13px] flex items-center gap-2 ${
+                      isSelected ? "bg-foreground text-background" : "hover:bg-secondary/40"
+                    }`}
+                    onClick={() => setSelectedId(note.id)}
+                    data-testid="notes-list-item"
+                    data-note-id={note.id}
+                  >
+                    {note.pinned && <span title="Pinned" className="text-yellow text-[10px]">★</span>}
+                    <span className="flex-1 truncate" title={note.title}>{note.title || "Untitled"}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </Card>
+
+      {/* Editor pane */}
+      <Card className="p-4 flex-1 flex flex-col gap-2 max-h-[600px] overflow-hidden">
+        {selected === null && (
+          <p className="text-[12px] text-muted-foreground italic" data-testid="notes-editor-empty">
+            Select a note from the left, or click + New to create one.
+          </p>
+        )}
+        {selected !== null && (
+          <>
+            <div className="flex items-center gap-2">
+              <Input
+                type="text"
+                value={draftTitle}
+                onChange={(e) => setDraftTitle(e.target.value)}
+                onKeyDown={handleEditorKeyDown}
+                placeholder="Untitled"
+                className="text-[14px] flex-1"
+                data-testid="notes-title-input"
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void handleTogglePin(selected.id, selected.pinned)}
+                disabled={saving}
+                className="text-[11px] h-8"
+                data-testid="notes-pin-button"
+              >
+                {selected.pinned ? "Unpin" : "Pin"}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void handleSave()}
+                disabled={!dirty || saving}
+                data-testid="notes-save-button"
+                className="text-[11px] h-8"
+              >
+                {dirty ? "Save" : "Saved"}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void handleDelete(selected.id)}
+                disabled={saving}
+                className="text-[11px] h-8 text-red hover:text-red"
+                data-testid="notes-delete-button"
+              >
+                Delete
+              </Button>
+            </div>
+            <textarea
+              ref={bodyRef}
+              value={draftBody}
+              onChange={(e) => setDraftBody(e.target.value)}
+              onKeyDown={handleEditorKeyDown}
+              placeholder="Markdown body…"
+              className="flex-1 rounded border border-input bg-background px-3 py-2 text-[13px] font-mono leading-relaxed resize-none disabled:opacity-50"
+              data-testid="notes-body-textarea"
+            />
+            <div className="flex items-center justify-between text-[10px] text-muted-foreground/70">
+              <span>{dirty ? "Unsaved changes — ⌘S to save" : `Saved ${new Date(selected.updatedAt).toLocaleString()}`}</span>
+              <span className="font-mono">{String(draftBody.length)} chars</span>
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -24,6 +24,7 @@ import { HostingPanel } from "./HostingPanel.js";
 import { EnvManager } from "./EnvManager.js";
 import { TaskmasterTab } from "./TaskmasterTab.js";
 import { PmLitePanel } from "./PmLitePanel.js";
+import { NotesPanel } from "./NotesPanel.js";
 import { IterativeWorkTab } from "./IterativeWorkTab.js";
 import { MCPTab } from "./MCPTab.js";
 import { ProjectActivityTab } from "./ProjectActivityTab.js";
@@ -87,6 +88,9 @@ const CANVAS_LABELS: Record<string, string> = {
   // Wish #17 / s155 t671 — Plans tab. Always available file-based PM-Lite
   // surface with DONE/CURRENT/NEXT views.
   plans: "Plans",
+  // s152 — Notes tab. Per-project markdown notepad surface; agent reads
+  // these as project context.
+  notes: "Notes",
   security: "Security",
   activity: "Activity",
 };
@@ -206,6 +210,8 @@ export function ProjectDetail({
     "taskmaster": "coordinate",
     // Wish #17 / s155 t671 — Plans tab in coordinate mode (PM workflow).
     "plans": "coordinate",
+    // s152 — Notes tab in coordinate mode (knowledge capture for the project).
+    "notes": "coordinate",
     "security": "insight",
     "activity": "insight",
   };
@@ -222,7 +228,7 @@ export function ProjectDetail({
   useEffect(() => {
     if (!tabBelongsToMode(activeTab)) {
       // Find first tab in current mode (prefer the canonical first one)
-      const candidates = ["details", "files", "repository", "environment", "hosting", "iterative-work", "mcp", "taskmaster", "plans", "security", "activity"];
+      const candidates = ["details", "files", "repository", "environment", "hosting", "iterative-work", "mcp", "taskmaster", "plans", "notes", "security", "activity"];
       const firstInMode = candidates.find((id) => TAB_MODES[id] === currentMode);
       if (firstInMode) setActiveTab(firstInMode);
     }
@@ -700,6 +706,9 @@ export function ProjectDetail({
               // Wish #17 / s155 t671 — Plans entry. Available for every
               // project (no hasCode gate) since PM-Lite is universal.
               if (tabBelongsToMode("plans")) entries.push({ value: "plans", label: "Plans" });
+              // s152 — Notes entry. Available for every project; markdown
+              // notepad surface, agent-readable.
+              if (tabBelongsToMode("notes")) entries.push({ value: "notes", label: "Notes" });
               if (
                 tabBelongsToMode("iterative-work")
                 && (project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible)
@@ -1423,6 +1432,12 @@ export function ProjectDetail({
             file-based plan list straight from <projectPath>/k/plans/. */}
         <TabsContent value="plans" className="mt-4 flex-1 min-h-0 overflow-y-auto">
           <PmLitePanel projectPath={project.path} />
+        </TabsContent>
+
+        {/* s152 — Notes tab. Per-project markdown notepad surface. The
+            global Notes page lands in the next slice (main nav). */}
+        <TabsContent value="notes" className="mt-4 flex-1 min-h-0 overflow-y-auto">
+          <NotesPanel projectPath={project.path} />
         </TabsContent>
 
         {(project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible) && (

--- a/ui/dashboard/src/router.tsx
+++ b/ui/dashboard/src/router.tsx
@@ -23,6 +23,7 @@ import AdminPage from "./routes/admin.js";
 import AdminDashboardPage from "./routes/admin-dashboard.js";
 import KnowledgePage from "./routes/knowledge.js";
 import DocsPage from "./routes/docs.js";
+import NotesPage from "./routes/notes.js";
 import SettingsLayout from "./routes/settings-layout.js";
 import SettingsGatewayPage from "./routes/settings-gateway.js";
 import SettingsDynamicPage from "./routes/settings-dynamic.js";
@@ -79,6 +80,7 @@ export const router = createBrowserRouter([
       { path: "magic-apps/:id", element: <MagicAppDetailPage /> },
       // Knowledge
       { path: "knowledge", element: <KnowledgePage /> },
+      { path: "notes", element: <NotesPage /> },
       // Documentation
       { path: "docs", element: <DocsPage /> },
       // Gateway

--- a/ui/dashboard/src/routes/notes.tsx
+++ b/ui/dashboard/src/routes/notes.tsx
@@ -1,0 +1,27 @@
+/**
+ * Global Notes page (s152, 2026-05-09).
+ *
+ * Reuses the same NotesPanel component used per-project, but scoped to
+ * `projectPath: null` for project-less ideas/todos/context. Owner directive
+ * ("notes for ideas/todos/context that aren't project-bound") shipped here
+ * via the main-nav "Notes" entry.
+ */
+
+import type { ReactElement } from "react";
+import { NotesPanel } from "@/components/NotesPanel.js";
+
+export default function NotesPage(): ReactElement {
+  return (
+    <div className="flex flex-col gap-3 h-full">
+      <header className="flex items-baseline gap-2">
+        <h1 className="text-[16px] font-semibold tracking-tight">Notes</h1>
+        <span className="text-[11px] text-muted-foreground/70">
+          Global scope — ideas + todos + context not bound to any one project
+        </span>
+      </header>
+      <div className="flex-1 min-h-0">
+        <NotesPanel projectPath={null} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Owner-confirmed first slice: markdown notepad surface with DB-backed Notes table, /api/notes REST, NotesPanel component (two-pane list + editor with ⌘S save), per-project Notes tab in ProjectDetail, global Notes page at /notes in main nav. 21 new tests + 124/124 regression. 4 follow-up tasks remain on s152 (agent context wiring, notes tools, passive breadcrumb, whiteboard mode).