### PR TITLE
agi v0.4.553 — s152 notes loop closed (agent reads + writes via notes tool)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.552",
+  "version": "0.4.553",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/agent-invoker.ts
+++ b/packages/gateway-core/src/agent-invoker.ts
@@ -196,6 +196,15 @@ export interface AgentInvokerDeps {
    *  mode + other per-project flags can shape prompt assembly. Null when
    *  invoker is run without project context (e.g. entity-only requests). */
   projectConfigManager?: ProjectConfigManager;
+  /** s152 t651 — UserNotes store. When wired, the invoker reads up to N
+   *  notes for the active project (and global notes) and injects them
+   *  into the system-prompt's project-context section so Aion sees what
+   *  the owner wrote. Null in tests / non-project paths. */
+  notesStore?: import("./notes-store.js").NotesStore;
+  /** s152 t651 — alpha-stage owner entity id used to scope note reads. Defaults
+   *  to `~$U0`; the same constant the notes-api uses. Hive-ID multi-user
+   *  later replaces this with a per-session resolution. */
+  notesOwnerEntityId?: string;
   /** Workspace root path — injected as context when devMode is true. */
   workspaceRoot?: string;
   /** Directories where projects are stored and worked on. */
@@ -542,6 +551,44 @@ export class AgentInvoker extends EventEmitter {
       } catch { /* iterative-work.md missing — proceed without injection */ }
     }
 
+    // s152 t651 — read UserNotes for the active project + global notes,
+    // inject into prompt context so Aion sees what the owner wrote.
+    // Cap at top-N (pinned + most-recently-updated) to keep prompt size
+    // bounded; full search is available via the `notes` agent tool.
+    let projectNotes: SystemPromptContext["projectNotes"];
+    if (
+      this.deps.notesStore !== undefined
+      && request.projectContext !== undefined
+      && request.projectContext.length > 0
+    ) {
+      try {
+        const ownerId = this.deps.notesOwnerEntityId ?? "~$U0";
+        const [perProject, global] = await Promise.all([
+          this.deps.notesStore.list(ownerId, request.projectContext),
+          this.deps.notesStore.list(ownerId, null),
+        ]);
+        const NOTES_INJECTED_CAP = 6;
+        // Order: per-project pinned, per-project recent, global pinned, global recent.
+        const ordered = [
+          ...perProject.filter((n) => n.pinned),
+          ...perProject.filter((n) => !n.pinned),
+          ...global.filter((n) => n.pinned),
+          ...global.filter((n) => !n.pinned),
+        ].slice(0, NOTES_INJECTED_CAP);
+        projectNotes = ordered.map((n) => ({
+          title: n.title,
+          body: n.body,
+          pinned: n.pinned,
+          updatedAt: n.updatedAt,
+          scope: n.projectPath === null ? "global" as const : "project" as const,
+        }));
+      } catch (err) {
+        // Notes injection is best-effort — never block the agent if the DB
+        // hiccups. The notes tool surface still works.
+        this.log.warn(`notes injection failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
     const promptCtx: SystemPromptContext = {
       entity: entityCtx,
       coaFingerprint,
@@ -563,6 +610,7 @@ export class AgentInvoker extends EventEmitter {
       costMode: this.deps.getCostMode?.(),
       toolsAvailable: willOfferTools,
       iterativeWorkPrompt,
+      ...(projectNotes !== undefined ? { projectNotes } : {}),
     };
 
     const { prompt: baseSystemPrompt, breakdown: promptBreakdown } = assembleSystemPromptWithBreakdown(promptCtx);

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -922,6 +922,13 @@ export async function startGatewayServer(
   });
   log.info(`memory adapter initialized (dir: ${memoryDir})`);
 
+  // s152 t651 — UserNotes store. Constructed here (before AgentInvoker)
+  // so the invoker can read notes per project + global on each turn and
+  // inject them into the system-prompt project-context section. Closes
+  // the user-writes-note → Aion-reads-note loop.
+  const { NotesStore } = await import("./notes-store.js");
+  const notesStore = new NotesStore(db);
+
   const agentInvoker = new AgentInvoker({
     stateMachine,
     apiClient: getLLMProvider,
@@ -936,6 +943,7 @@ export async function startGatewayServer(
     userContextStore,
     primeLoader,
     projectConfigManager,
+    notesStore,
     workspaceRoot,
     projectPaths,
     ownerConfig: ownerConfig !== undefined ? {
@@ -2654,6 +2662,89 @@ export async function startGatewayServer(
     },
   );
 
+  // s152 t652 — `notes` agent tool. The owner writes UserNotes via the
+  // dashboard; t651 injects them into the system-prompt on every turn.
+  // This tool lets Aion fetch/search additional notes on demand and
+  // append to existing notes (e.g. when the user says "add this to my
+  // notes for kronos_trader"). All actions are project-scope-gated:
+  // pass projectPath for per-project, omit for global.
+  toolRegistry.register(
+    {
+      name: "notes",
+      description:
+        "User-authored markdown notes — read, search, or append. The owner writes notes via the dashboard's Notes tab (per-project) or the global Notes page; Aion sees them as project context automatically. Actions: 'read' (list notes for a scope), 'get' (fetch a single note by id), 'search' (substring match across title+body), 'append' (add text to an existing note's body). Notes are file-of-record for owner intent + decisions + TODOs that aren't in the code.",
+      requiresState: [],
+      requiresTier: [],
+    },
+    async (input: Record<string, unknown>) => {
+      const action = String(input.action ?? "read");
+      const ownerEntityId = "~$U0"; // single-owner alpha; mirrors notes-api ALPHA_OWNER_ENTITY_ID
+      try {
+        switch (action) {
+          case "read": {
+            // projectPath optional: omitted = global, set = per-project, "all" = both
+            const scope = input.scope as string | undefined;
+            const projectPath = typeof input.projectPath === "string" && input.projectPath.length > 0 ? input.projectPath : null;
+            if (scope === "all") {
+              const all = await notesStore.list(ownerEntityId);
+              return JSON.stringify({ scope: "all", notes: all });
+            }
+            const list = await notesStore.list(ownerEntityId, projectPath);
+            return JSON.stringify({ scope: projectPath === null ? "global" : "project", projectPath, notes: list });
+          }
+          case "get": {
+            const noteId = String(input.noteId ?? "");
+            if (noteId.length === 0) return JSON.stringify({ error: "noteId is required for get" });
+            const note = await notesStore.get(noteId);
+            if (note === null) return JSON.stringify({ error: `note ${noteId} not found` });
+            if (note.userEntityId !== ownerEntityId) return JSON.stringify({ error: "note is owned by another user" });
+            return JSON.stringify(note);
+          }
+          case "search": {
+            const query = String(input.query ?? "").trim().toLowerCase();
+            if (query.length === 0) return JSON.stringify({ error: "query is required for search" });
+            const projectPath = typeof input.projectPath === "string" && input.projectPath.length > 0 ? input.projectPath : undefined;
+            const candidates = await notesStore.list(ownerEntityId, projectPath);
+            const matches = candidates.filter(
+              (n) => n.title.toLowerCase().includes(query) || n.body.toLowerCase().includes(query),
+            );
+            return JSON.stringify({ query, matches: matches.length, notes: matches });
+          }
+          case "append": {
+            const noteId = String(input.noteId ?? "");
+            const text = String(input.text ?? "");
+            if (noteId.length === 0 || text.length === 0) {
+              return JSON.stringify({ error: "noteId and text are required for append" });
+            }
+            const existing = await notesStore.get(noteId);
+            if (existing === null) return JSON.stringify({ error: `note ${noteId} not found` });
+            if (existing.userEntityId !== ownerEntityId) return JSON.stringify({ error: "note is owned by another user" });
+            const separator = existing.body.endsWith("\n\n") ? "" : existing.body.endsWith("\n") ? "\n" : "\n\n";
+            const newBody = `${existing.body}${separator}${text}`;
+            const updated = await notesStore.update(noteId, { body: newBody });
+            return JSON.stringify(updated);
+          }
+          default:
+            return JSON.stringify({ error: `unknown action: ${action}. Valid: read, get, search, append` });
+        }
+      } catch (err) {
+        return JSON.stringify({ error: err instanceof Error ? err.message : String(err) });
+      }
+    },
+    {
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["read", "get", "search", "append"], description: "Notes operation to perform" },
+        projectPath: { type: "string", description: "Absolute project path for per-project scope (omit for global)" },
+        scope: { type: "string", enum: ["all"], description: "Pass 'all' on read to merge per-project + global" },
+        noteId: { type: "string", description: "Note id (required for get / append)" },
+        query: { type: "string", description: "Substring match query (required for search)" },
+        text: { type: "string", description: "Text to append (required for append)" },
+      },
+      required: ["action"],
+    },
+  );
+
   // Register HF model management tool for the agent
   toolRegistry.register(
     {
@@ -2735,10 +2826,10 @@ export async function startGatewayServer(
   const { MagicAppStateStore } = await import("./magic-app-state-store.js");
   const magicAppStateStore = new MagicAppStateStore(db);
 
-  // s152 — UserNotes store (markdown notepad surface, per-project + global).
-  // Storage round-trips through agi_data per single-source-of-truth.
-  const { NotesStore } = await import("./notes-store.js");
-  const notesStore = new NotesStore(db);
+  // s152 — UserNotes store moved earlier in boot (was here, now lives
+  // before AgentInvoker construction so the invoker can inject project
+  // notes into the system prompt — t651). The reference is reused here
+  // by the late dashboard runtime wiring.
 
   const { httpServer, wsServer } = await createGatewayRuntimeState(
     {

--- a/packages/gateway-core/src/system-prompt.ts
+++ b/packages/gateway-core/src/system-prompt.ts
@@ -150,6 +150,14 @@ export interface SystemPromptContext {
   /** Active project path — when set, injects plan workflow instructions. */
   projectPath?: string;
   /**
+   * UserNotes for the active project + global notes (s152 t651, 2026-05-09).
+   * Caller (agent-invoker) reads from NotesStore before assembly. Pinned
+   * notes are included first, then most-recently-updated. The assembler
+   * injects them into the project-context section so Aion sees what the
+   * user wrote — closes the user-writes-note → Aion-reads-note loop.
+   */
+  projectNotes?: Array<{ title: string; body: string; pinned: boolean; updatedAt: string; scope: "project" | "global" }>;
+  /**
    * Active project category — sourced from `project.json`'s `category` field
    * (literature/app/web/media/administration/ops/monorepo). When the category
    * is `"ops"` or `"administration"`, the assembler injects an ops-mode
@@ -617,7 +625,10 @@ function buildOpsModeSection(): string {
  * Reads the project's package.json for name/version/description.
  * Injected before plan workflow instructions when projectPath is set.
  */
-function buildProjectContextSection(projectPath: string): string {
+function buildProjectContextSection(
+  projectPath: string,
+  notes?: Array<{ title: string; body: string; pinned: boolean; updatedAt: string; scope: "project" | "global" }>,
+): string {
   const lines: string[] = ["## Active Project"];
   lines.push(`Path: ${projectPath}`);
 
@@ -639,6 +650,31 @@ function buildProjectContextSection(projectPath: string): string {
 
   lines.push("");
   lines.push("You are scoped to this project. All file operations, analysis, and tool use should be relative to this project path. When answering questions, draw on your knowledge of this project's structure and purpose.");
+
+  // s152 t651 — UserNotes injection. The owner writes free-form notes
+  // (markdown) per-project + global; this section surfaces them to Aion
+  // as project context, the same way Dev Notes are consumed.
+  if (notes !== undefined && notes.length > 0) {
+    lines.push("");
+    lines.push("## Project Notes");
+    lines.push("");
+    lines.push("The following notes were written by the owner. Treat them as authoritative project context — they capture intent, decisions, and TODOs that aren't in the code. Pinned notes are listed first.");
+    lines.push("");
+    for (const note of notes) {
+      const scopeTag = note.scope === "global" ? " [global]" : "";
+      const pinTag = note.pinned ? " ★" : "";
+      lines.push(`### ${note.title}${pinTag}${scopeTag}`);
+      lines.push("");
+      const body = note.body.trim();
+      if (body.length > 0) {
+        lines.push(body);
+      } else {
+        lines.push("*(empty)*");
+      }
+      lines.push("");
+    }
+    lines.push(`Use the \`notes\` tool (action=\`read\`/\`search\`/\`append\`) to fetch additional notes or capture new ones for the owner.`);
+  }
 
   return lines.join("\n");
 }
@@ -840,7 +876,7 @@ export function assembleSystemPrompt(ctx: SystemPromptContext): string {
   // Project context — for project work. Plan workflow is instruction-heavy
   // and gets dropped in local mode; project path itself is preserved.
   if (rt === "project" && ctx.projectPath !== undefined) {
-    sections.push(buildProjectContextSection(ctx.projectPath));
+    sections.push(buildProjectContextSection(ctx.projectPath, ctx.projectNotes));
     // Ops-mode preamble — sits next to project context so the agent reads
     // "this is project X" + "here's the cross-project authority you have"
     // back-to-back. Gated on category, mirrors requiresProjectCategory tool gate.
@@ -1004,7 +1040,7 @@ export function assembleSystemPromptWithBreakdown(
   }
 
   if (rt === "project" && ctx.projectPath !== undefined) {
-    contextSections.push(buildProjectContextSection(ctx.projectPath));
+    contextSections.push(buildProjectContextSection(ctx.projectPath, ctx.projectNotes));
     if (ctx.projectCategory === "ops" || ctx.projectCategory === "administration") {
       contextSections.push(buildOpsModeSection());
     }


### PR DESCRIPTION
Owner directive: 'continue until you are done and this is actual useful.' Notes feature now end-to-end useful: system-prompt assembler injects up to 6 project+global notes on every turn (t651); new notes agent tool with read/get/search/append actions (t652). Loop closes: user writes note → Aion sees it on next turn → Aion can recall, search, append from chat. 124/124 across regression. Closes s152 t651 + t652. Story stays in_progress with t653/t654 + Wish #18 (PAx refactor of NotesPanel).