### PR TITLE
agi v0.4.554 — s148 agi-test auto-prefers dev tree for spec discovery

### DIFF
--- a/docs/human/testing.md
+++ b/docs/human/testing.md
@@ -167,17 +167,30 @@ When to use which:
 
 Pattern arg matches against spec filename (case-insensitive substring); omit to run all specs.
 
-#### Dev-side spec discovery — `AGI_TEST_DEV_REPO_DIR`
+#### Dev-side spec discovery (auto-prefers `~/temp_core/agi`)
 
-`agi test --e2e <pattern>` resolves specs against `/opt/agi/` by default (where `agi-cli.sh` lives). During /loop sessions where the dev tree at `~/temp_core/agi/` runs ahead of `/opt/agi/` between owner-triggered upgrades, brand-new specs added on dev source are invisible to the wrapper.
+`agi test <pattern>` runs from the deployed install (`/opt/agi/`) but auto-prefers the host dev tree at `~/temp_core/agi/` for spec discovery when that tree exists. This means brand-new specs added on dev source are runnable pre-deploy without any extra ceremony — the wrapper sees them automatically.
 
-Set `AGI_TEST_DEV_REPO_DIR` to point at the dev tree to make `find e2e -iname …` resolve from there:
+The detection order:
+
+1. **`AGI_TEST_DEV_REPO_DIR=<path>`** explicit override — when set + valid (directory containing `package.json`), wins over everything else.
+2. **Auto-prefer `$HOME/temp_core/agi/`** — when the script runs from `/opt/agi*` AND that dev tree exists with a `package.json`, it becomes `REPO_DIR`. This is the default for normal dev workflow on the owner machine. Logged at run time so you can see which tree resolved.
+3. **`/opt/agi/` fallback** — production-only installs (no dev tree) keep the legacy behavior.
+
+Examples:
 
 ```bash
-AGI_TEST_DEV_REPO_DIR=$HOME/temp_core/agi agi test --e2e walk/my-new-spec
+# Default: dev tree auto-preferred when present
+agi test --e2e walk/my-new-spec
+
+# Explicit override (e.g. testing a different dev branch)
+AGI_TEST_DEV_REPO_DIR=$HOME/projects/agi-fork agi test --e2e walk/my-new-spec
+
+# Force production-only discovery (rare)
+AGI_TEST_DEV_REPO_DIR=/opt/agi agi test --e2e walk/my-new-spec
 ```
 
-The wrapper validates the path (must be a directory + contain `package.json`); falls back to the default if invalid. The test VM mounts dev source live, so the runtime target already matches dev — only the spec-discovery path needed the override. Same env var works for unit specs (`--unit`) too.
+The test VM mounts dev source live, so the runtime target already matches dev — only the spec-discovery path needed the override. Same behavior for unit specs (`--unit`) too.
 
 #### Auto-skip when VM > host
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.553",
+  "version": "0.4.554",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/agi-test.sh
+++ b/scripts/agi-test.sh
@@ -46,9 +46,16 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # (typically ~/temp_core/agi). Closes the spec-discovery gap that blocked
 # /loop verification of brand-new specs across cycles 178/179/183/185 —
 # the test VM already mounts dev source live so the runtime target
-# matches; only this script's `find e2e -iname ...` step needed to know
-# about the dev path. Validated below; falls back to default if the
-# override is set but invalid.
+# matches; only this script's `find … -iname …` step needed to know
+# about the dev path.
+#
+# s148 (2026-05-09): when the env var isn't set AND the script is running
+# from /opt/agi (the deployed tree), AUTO-prefer ~/temp_core/agi as
+# REPO_DIR if it looks like a valid dev tree. Owner directive: "agi test
+# should discover specs from host dev source, not /opt/agi production
+# tree" — make this the default behavior so devs don't need to remember
+# the env var. /opt/agi remains the fallback when no dev tree exists
+# (production-only installs).
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 if [ -n "${AGI_TEST_DEV_REPO_DIR:-}" ]; then
   if [ -d "$AGI_TEST_DEV_REPO_DIR" ] && [ -f "$AGI_TEST_DEV_REPO_DIR/package.json" ]; then
@@ -56,6 +63,14 @@ if [ -n "${AGI_TEST_DEV_REPO_DIR:-}" ]; then
     echo "[agi test] AGI_TEST_DEV_REPO_DIR set; resolving specs from $REPO_DIR" >&2
   else
     echo "[agi test] AGI_TEST_DEV_REPO_DIR='$AGI_TEST_DEV_REPO_DIR' invalid (not a dir or missing package.json); using default $REPO_DIR" >&2
+  fi
+elif [[ "$REPO_DIR" == /opt/agi* ]]; then
+  # s148 — auto-prefer the dev tree for spec discovery so brand-new specs
+  # are runnable pre-deploy without extra env-var ceremony.
+  CANDIDATE_DEV="${HOME:-/root}/temp_core/agi"
+  if [ -d "$CANDIDATE_DEV" ] && [ -f "$CANDIDATE_DEV/package.json" ]; then
+    REPO_DIR="$(cd "$CANDIDATE_DEV" && pwd)"
+    echo "[agi test] auto-preferring dev tree for spec discovery: $REPO_DIR (override with AGI_TEST_DEV_REPO_DIR or run from a tree that doesn't have $CANDIDATE_DEV)" >&2
   fi
 fi
 VM_NAME="agi-test"


### PR DESCRIPTION
Owner directive: 'agi test should discover specs from host dev source, not /opt/agi production tree.' s146 t602 shipped AGI_TEST_DEV_REPO_DIR as an explicit env-var override; this cycle makes the dev-tree preference the default behavior. When the script runs from /opt/agi and ~/temp_core/agi exists with a package.json, REPO_DIR auto-flips to dev. Env var override + /opt/agi fallback preserved. Docs updated. Closes s148.