### PR TITLE
agi v0.4.556 — s133 t678+t679 CLOSED: MCP cache fresh=1 wiring + status endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.555",
+  "version": "0.4.556",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -2207,6 +2207,14 @@ export async function createGatewayRuntimeState(
   // GET /api/projects/mcp/server/tools|prompts|resources?path=&id= — browse what
   // a connected server provides. Lets the MCPTab UI render the card's expanded
   // inspector. Errors surface as 502 with the underlying SDK message.
+  // s133 t678 (2026-05-09) — `?fresh=1` on any of these GET endpoints
+  // bypasses the mcp-client cache (forces a re-fetch). Refresh button in
+  // MCPTab passes the param so the user always gets a current snapshot
+  // when explicitly refreshing.
+  const isFreshRequested = (q: Record<string, string>): boolean => {
+    const fresh = q["fresh"];
+    return fresh === "1" || fresh === "true";
+  };
   fastify.get("/api/projects/mcp/server/tools", async (request, reply) => {
     const clientIp = getClientIp(request.raw);
     if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
@@ -2216,7 +2224,7 @@ export async function createGatewayRuntimeState(
     if (!pathParam || !idParam) return reply.code(400).send({ error: "path + id required" });
     const nsId = mcpServerNs(resolvePath(pathParam), idParam);
     try {
-      const tools = await deps.mcpClient.listTools(nsId);
+      const tools = await deps.mcpClient.listTools(nsId, { bypassCache: isFreshRequested(query) });
       return reply.send({ ok: true, tools });
     } catch (err) {
       return reply.code(502).send({ ok: false, error: err instanceof Error ? err.message : String(err) });
@@ -2232,7 +2240,7 @@ export async function createGatewayRuntimeState(
     if (!pathParam || !idParam) return reply.code(400).send({ error: "path + id required" });
     const nsId = mcpServerNs(resolvePath(pathParam), idParam);
     try {
-      const prompts = await deps.mcpClient.listPrompts(nsId);
+      const prompts = await deps.mcpClient.listPrompts(nsId, { bypassCache: isFreshRequested(query) });
       return reply.send({ ok: true, prompts });
     } catch (err) {
       return reply.code(502).send({ ok: false, error: err instanceof Error ? err.message : String(err) });
@@ -2248,11 +2256,22 @@ export async function createGatewayRuntimeState(
     if (!pathParam || !idParam) return reply.code(400).send({ error: "path + id required" });
     const nsId = mcpServerNs(resolvePath(pathParam), idParam);
     try {
-      const resources = await deps.mcpClient.listResources(nsId);
+      const resources = await deps.mcpClient.listResources(nsId, { bypassCache: isFreshRequested(query) });
       return reply.send({ ok: true, resources });
     } catch (err) {
       return reply.code(502).send({ ok: false, error: err instanceof Error ? err.message : String(err) });
     }
+  });
+
+  // s133 t679 (2026-05-09) — diagnostic surface for the MCP cache.
+  // Returns per-server hit/miss/bypass/invalidation counts + last-fetch
+  // timestamp; verifies the acceptance criterion "hit ratio > 80% under
+  // normal browsing." Read-only; no UI surface in v1.
+  fastify.get("/api/projects/mcp/server/cache-status", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
+    if (!deps.mcpClient) return reply.code(503).send({ error: "MCP client not available" });
+    return reply.send({ ok: true, servers: deps.mcpClient.getCacheStatus() });
   });
 
   // POST /api/projects/mcp/server/call-tool|read-resource — invoke a tool or
@@ -2277,11 +2296,12 @@ export async function createGatewayRuntimeState(
     const clientIp = getClientIp(request.raw);
     if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
     if (!deps.mcpClient) return reply.code(503).send({ error: "MCP client not available" });
-    const body = request.body as { path?: string; id?: string; uri?: string } | undefined;
+    const body = request.body as { path?: string; id?: string; uri?: string; fresh?: boolean } | undefined;
     if (!body?.path || !body.id || !body.uri) return reply.code(400).send({ error: "path + id + uri required" });
     const nsId = mcpServerNs(resolvePath(body.path), body.id);
     try {
-      const result = await deps.mcpClient.readResource(nsId, body.uri);
+      // s133 t678 — body.fresh=true bypasses the resource-read cache.
+      const result = await deps.mcpClient.readResource(nsId, body.uri, { bypassCache: body.fresh === true });
       return reply.send({ ok: true, result });
     } catch (err) {
       return reply.code(502).send({ ok: false, error: err instanceof Error ? err.message : String(err) });

--- a/ui/dashboard/src/components/MCPTab.tsx
+++ b/ui/dashboard/src/components/MCPTab.tsx
@@ -377,11 +377,16 @@ function McpServerCard({
 
   const isConnected = server.state === "connected";
 
-  const loadTab = async (tab: CardTab): Promise<void> => {
+  // s133 t678 (2026-05-09) — pass `fresh=true` to bypass the gateway-side
+  // mcp-client cache. Tab switches consume cache; the explicit Refresh
+  // button below always force-fetches.
+  const loadTab = async (tab: CardTab, opts: { fresh?: boolean } = {}): Promise<void> => {
     setBrowsing(true);
     setBrowseError(null);
     try {
-      const url = `/api/projects/mcp/server/${tab}?path=${encodeURIComponent(projectPath)}&id=${encodeURIComponent(server.id)}`;
+      const params = new URLSearchParams({ path: projectPath, id: server.id });
+      if (opts.fresh === true) params.set("fresh", "1");
+      const url = `/api/projects/mcp/server/${tab}?${params.toString()}`;
       const res = await fetch(url);
       const body = await res.json() as { ok: boolean; tools?: McpToolDescriptor[]; prompts?: McpPromptDescriptor[]; resources?: McpResourceDescriptor[]; error?: string };
       if (!body.ok) {
@@ -413,6 +418,17 @@ function McpServerCard({
     if (tab === "tools" && tools === null) await loadTab("tools");
     if (tab === "prompts" && prompts === null) await loadTab("prompts");
     if (tab === "resources" && resources === null) await loadTab("resources");
+  };
+
+  // s133 t678 — explicit Refresh button: drop the locally-stashed list +
+  // force-fetch from the gateway with `fresh=1` so the response also
+  // bypasses the mcp-client cache. Without this dual reset, the user's
+  // Refresh would just re-render the same cached data.
+  const onRefreshTab = async (): Promise<void> => {
+    if (activeTab === "tools") setTools(null);
+    else if (activeTab === "prompts") setPrompts(null);
+    else if (activeTab === "resources") setResources(null);
+    await loadTab(activeTab, { fresh: true });
   };
 
   const onCallTool = async (toolName: string): Promise<void> => {
@@ -449,6 +465,10 @@ function McpServerCard({
     setCalling(true);
     setCallResult(null);
     try {
+      // s133 t678 — readResource consumes cache by default; user-driven
+      // resource read is treated as "I want to see this now", but explicit
+      // Refresh of the resources tab already invalidates via fresh=1 list
+      // re-fetch. No fresh flag here in v1.
       const res = await fetch(`/api/projects/mcp/server/read-resource`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -538,9 +558,10 @@ function McpServerCard({
                   </TabsTrigger>
                 </TabsList>
                 <button
-                  onClick={() => { void loadTab(activeTab); }}
+                  onClick={() => { void onRefreshTab(); }}
                   disabled={browsing}
                   className="ml-auto text-[10px] text-muted-foreground hover:text-foreground"
+                  title="Force-fetch from the MCP server (bypass the gateway response cache)"
                 >
                   {browsing ? "Loading…" : "Refresh"}
                 </button>


### PR DESCRIPTION
Closes s133 (MCP response caching). Gateway routes accept ?fresh=1 to bypass mcp-client cache; MCPTab Refresh button force-fetches; new /api/projects/mcp/server/cache-status diagnostic endpoint surfaces per-server hit/miss/bypass/invalidation/hitRatio/lastFetchAt.