### PR TITLE
feat(circuit-breaker): wire channels + plugins through tracker (s143 t569)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.557",
+  "version": "0.4.558",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/channel-registry.ts
+++ b/packages/gateway-core/src/channel-registry.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 
 import type { AionimaChannelPlugin } from "@agi/channel-sdk";
 import { assertValidAdapter } from "@agi/channel-sdk";
+import type { CircuitBreakerTracker } from "./circuit-breaker.js";
 import { createComponentLogger } from "./logger.js";
 import type { Logger, ComponentLogger } from "./logger.js";
 
@@ -61,10 +62,21 @@ export class ChannelRegistry extends EventEmitter {
   private readonly channels: Map<string, ChannelEntry> = new Map();
   private readonly health: Map<string, ChannelHealth> = new Map();
   private readonly log: ComponentLogger;
+  private circuitBreaker: CircuitBreakerTracker | null = null;
 
   constructor(logger?: Logger) {
     super();
     this.log = createComponentLogger(logger, "channel-registry");
+  }
+
+  /**
+   * Wire the circuit-breaker tracker after construction. Channels are
+   * registered before the system-config service exists during boot, so the
+   * tracker can't be passed via the constructor — server.ts calls this once
+   * the tracker is built. Service-id format: `channel:<channelId>`. (s143 t569)
+   */
+  setCircuitBreaker(tracker: CircuitBreakerTracker): void {
+    this.circuitBreaker = tracker;
   }
 
   // ---------------------------------------------------------------------------
@@ -150,17 +162,43 @@ export class ChannelRegistry extends EventEmitter {
       throw new Error(`Channel "${channelId}" is not registered`);
     }
 
+    // s143 t569 — circuit-breaker gate. If this channel has tripped the
+    // breaker on previous boots, skip the start attempt entirely so a
+    // permanently broken adapter (bad token, missing secret, dead webhook)
+    // can't burn budget on every gateway boot. The Services page Reset
+    // button (or a fix to the underlying failure) re-arms it.
+    const serviceId = `channel:${channelId}`;
+    if (this.circuitBreaker) {
+      const decision = this.circuitBreaker.shouldSkip(serviceId);
+      if (decision.skip) {
+        const reason = decision.reason ?? "circuit open";
+        entry.status = "error";
+        entry.error = reason;
+        this.log.warn(`[${channelId}] circuit-open — skipping start (${reason})`);
+        this.emit("channel_error", channelId, reason);
+        // Preserve the original throw-on-failure contract so startAll's
+        // Promise.allSettled and any direct callers see a consistent
+        // failure shape regardless of breaker vs runtime cause.
+        throw new Error(reason);
+      }
+      if (decision.transitionedTo) {
+        this.log.info(`[${channelId}] breaker transitioned to ${decision.transitionedTo} — attempting start`);
+      }
+    }
+
     entry.status = "starting";
 
     try {
       await entry.plugin.gateway.start();
       entry.status = "running";
       entry.error = undefined;
+      this.circuitBreaker?.recordSuccess(serviceId);
       this.emit("channel_started", channelId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       entry.status = "error";
       entry.error = message;
+      this.circuitBreaker?.recordFailure(serviceId, err);
       this.emit("channel_error", channelId, message);
       throw err;
     }

--- a/packages/gateway-core/src/circuit-breaker-integration.test.ts
+++ b/packages/gateway-core/src/circuit-breaker-integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Circuit-breaker integration tests — s143 t569
+ *
+ * Verifies that ChannelRegistry.startChannel and the plugin-loader path both
+ * gate on shouldSkip and record success/failure, mirroring the hosting-manager
+ * wiring shipped in t568. Pure-logic — runs on host.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ChannelRegistry } from "./channel-registry.js";
+import { CircuitBreakerTracker } from "./circuit-breaker.js";
+import { SystemConfigService } from "./system-config-service.js";
+import type { AionimaChannelPlugin } from "@agi/channel-sdk";
+
+function makeTmpConfig(): { path: string; cleanup: () => void } {
+  const dir = join(tmpdir(), `cb-integration-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "gateway.json");
+  writeFileSync(path, "{}", "utf-8");
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function makePlugin(id: string, opts?: { startShouldFail?: boolean }): AionimaChannelPlugin {
+  let running = false;
+  return {
+    id: id as AionimaChannelPlugin["id"],
+    meta: { name: id, version: "0.0.1" },
+    capabilities: {
+      text: true,
+      media: false,
+      voice: false,
+      reactions: false,
+      threads: false,
+      ephemeral: false,
+    },
+    config: { validate: () => true, getDefaults: () => ({}) },
+    gateway: {
+      start: vi.fn(async () => {
+        if (opts?.startShouldFail) throw new Error(`${id} start failed`);
+        running = true;
+      }),
+      stop: vi.fn(async () => { running = false; }),
+      isRunning: () => running,
+    },
+    outbound: { send: vi.fn(async () => {}) },
+    messaging: { onMessage: vi.fn() },
+  };
+}
+
+describe("ChannelRegistry × CircuitBreakerTracker (s143 t569)", () => {
+  let cfg: ReturnType<typeof makeTmpConfig>;
+  let svc: SystemConfigService;
+  let tracker: CircuitBreakerTracker;
+  let registry: ChannelRegistry;
+  const clock = { current: new Date("2026-05-09T06:00:00Z") };
+
+  beforeEach(() => {
+    cfg = makeTmpConfig();
+    svc = new SystemConfigService({ configPath: cfg.path });
+    clock.current = new Date("2026-05-09T06:00:00Z");
+    tracker = new CircuitBreakerTracker({ configService: svc, now: () => clock.current });
+    registry = new ChannelRegistry();
+    registry.setCircuitBreaker(tracker);
+  });
+
+  it("records success on a clean start", async () => {
+    const plugin = makePlugin("slack");
+    registry.register(plugin);
+    await registry.startChannel("slack");
+    // No failure ever recorded — tracker has no state for this serviceId.
+    expect(tracker.getState("channel:slack")).toBeUndefined();
+  });
+
+  it("records failure when the adapter's start throws", async () => {
+    const plugin = makePlugin("discord", { startShouldFail: true });
+    registry.register(plugin);
+    await expect(registry.startChannel("discord")).rejects.toThrow("discord start failed");
+    expect(tracker.getState("channel:discord")).toMatchObject({ failures: 1, status: "closed" });
+  });
+
+  it("trips the breaker after threshold, then skips subsequent starts without invoking adapter.start", async () => {
+    const plugin = makePlugin("telegram", { startShouldFail: true });
+    registry.register(plugin);
+    // 3 failures = threshold (default).
+    await expect(registry.startChannel("telegram")).rejects.toThrow("telegram start failed");
+    await expect(registry.startChannel("telegram")).rejects.toThrow("telegram start failed");
+    await expect(registry.startChannel("telegram")).rejects.toThrow("telegram start failed");
+    expect(tracker.getState("channel:telegram")?.status).toBe("open");
+    expect(plugin.gateway.start).toHaveBeenCalledTimes(3);
+
+    // 4th attempt: should be skipped by breaker — adapter.start MUST NOT be invoked.
+    await expect(registry.startChannel("telegram")).rejects.toThrow(/circuit open/);
+    expect(plugin.gateway.start).toHaveBeenCalledTimes(3);
+    // Failures counter doesn't increment when the breaker pre-empts the call.
+    expect(tracker.getState("channel:telegram")?.failures).toBe(3);
+  });
+
+  it("clears state on success after prior failures", async () => {
+    const plugin = makePlugin("matrix", { startShouldFail: true });
+    registry.register(plugin);
+    await expect(registry.startChannel("matrix")).rejects.toThrow();
+    expect(tracker.getState("channel:matrix")?.failures).toBe(1);
+
+    // Swap in a healthy start — same plugin id, fresh start fn.
+    plugin.gateway.start = vi.fn(async () => {});
+    await registry.startChannel("matrix");
+    expect(tracker.getState("channel:matrix")).toMatchObject({ failures: 0, status: "closed" });
+  });
+
+  it("works when no breaker is wired (fallback path)", async () => {
+    const bareRegistry = new ChannelRegistry();
+    const plugin = makePlugin("twilio", { startShouldFail: true });
+    bareRegistry.register(plugin);
+    // Throws as before; no NPE despite no breaker.
+    await expect(bareRegistry.startChannel("twilio")).rejects.toThrow("twilio start failed");
+  });
+});

--- a/packages/gateway-core/src/index.ts
+++ b/packages/gateway-core/src/index.ts
@@ -452,6 +452,10 @@ export type { HostingConfig, ProjectHostingMeta, HostedProject, InfraStatus, Hos
 export { ServiceManager } from "./service-manager.js";
 export type { ServiceStatus, ServiceManagerDeps } from "./service-manager.js";
 
+// Circuit breaker (s143)
+export { CircuitBreakerTracker } from "./circuit-breaker.js";
+export type { CircuitBreakerDeps, ShouldSkipResult } from "./circuit-breaker.js";
+
 // Terminal
 export { TerminalManager } from "./terminal-manager.js";
 export type { TerminalSession } from "./terminal-manager.js";

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -798,6 +798,20 @@ export async function startGatewayServer(
     ? new SystemConfigService({ configPath: opts.configPath, logger })
     : null;
 
+  // s143 t567/t568/t569 — persistent circuit-breaker tracker for boot-time
+  // service failures. Constructed early (right after SystemConfigService)
+  // so it can be wired into ChannelRegistry, plugin-loader, and
+  // hosting-manager — all of which start before/at boot. The v0.4.431
+  // try/catch fallback in hosting still applies when systemConfigService is
+  // null (no persistence available). Service-id prefix conventions live in
+  // circuit-breaker.ts: hosting:/channel:/plugin:/service:/mcp:.
+  const circuitBreakerTracker = systemConfigService
+    ? new CircuitBreakerTracker({ configService: systemConfigService, logger })
+    : undefined;
+  if (circuitBreakerTracker) {
+    channelRegistry.setCircuitBreaker(circuitBreakerTracker);
+  }
+
   // Iterative-work scheduler — walks workspace projects each tick, decides
   // who's due based on their iterativeWork.cron config, emits fire events.
   // The fire→AgentInvoker handler is installed below (after agentInvoker
@@ -1597,6 +1611,7 @@ export async function startGatewayServer(
         pluginPriorities,
         channelRegistry,
         channelConfigs: config.channels as Array<{ id: string; enabled: boolean; config?: Record<string, unknown> }>,
+        circuitBreaker: circuitBreakerTracker,
       });
       log.info(`plugins: ${String(result.loaded.length)} loaded, ${String(result.failed.length)} failed`);
       if (discovered.plugins.length > enabledPlugins.length) {
@@ -1655,6 +1670,7 @@ export async function startGatewayServer(
                       ),
                       channelRegistry,
                       channelConfigs: config.channels as Array<{ id: string; enabled: boolean; config?: Record<string, unknown> }>,
+                      circuitBreaker: circuitBreakerTracker,
                     });
                     bridgePluginCapabilities({ pluginRegistry, toolRegistry, skillRegistry, logger });
                     // Retry provider creation now that the plugin is loaded
@@ -1751,14 +1767,8 @@ export async function startGatewayServer(
     }
   }
 
-  // s143 t567/t568 — persistent circuit-breaker tracker for boot-time service
-  // failures. Wired in only when SystemConfigService is available (i.e. we
-  // know where gateway.json lives); otherwise the v0.4.431 try/catch fallback
-  // path keeps the gateway from hanging on a broken project even without
-  // persistence.
-  const circuitBreakerTracker = systemConfigService
-    ? new CircuitBreakerTracker({ configService: systemConfigService, logger })
-    : undefined;
+  // (s143 circuitBreakerTracker constructed earlier — see § "s143 t567/t568/t569"
+  // right after systemConfigService.)
 
   const hostingManager = new HostingManager({
     config: {
@@ -2912,6 +2922,7 @@ export async function startGatewayServer(
             ),
             channelRegistry,
             channelConfigs: config.channels as Array<{ id: string; enabled: boolean; config?: Record<string, unknown> }>,
+            circuitBreaker: circuitBreakerTracker,
           });
           if (result.loaded.length > 0) {
             // Bridge newly registered capabilities and sync stacks to the registry
@@ -2955,6 +2966,7 @@ export async function startGatewayServer(
             ),
             channelRegistry,
             channelConfigs: config.channels as Array<{ id: string; enabled: boolean; config?: Record<string, unknown> }>,
+            circuitBreaker: circuitBreakerTracker,
           }, { bustCache: true });
           if (result.loaded.length > 0) {
             bridgePluginCapabilities({ pluginRegistry, toolRegistry, skillRegistry, logger });

--- a/packages/plugins/src/loader.ts
+++ b/packages/plugins/src/loader.ts
@@ -7,7 +7,7 @@ import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { createComponentLogger } from "@agi/gateway-core";
 import { scanPluginSource } from "./scanner.js";
-import type { Logger, ComponentLogger, ProjectTypeRegistry, ProjectTypeDefinition, ProjectTypeTool } from "@agi/gateway-core";
+import type { Logger, ComponentLogger, ProjectTypeRegistry, ProjectTypeDefinition, ProjectTypeTool, CircuitBreakerTracker } from "@agi/gateway-core";
 import type { AionimaChannelPlugin } from "@agi/channel-sdk";
 import type { DiscoveredPlugin } from "./discovery.js";
 import { HookBus } from "./hooks.js";
@@ -41,6 +41,13 @@ export interface PluginLoaderDeps {
   projectConfigReader?: (projectPath: string) => Record<string, unknown> | null;
   /** Read project stacks (for plugin getProjectStacks API). */
   projectStacksReader?: (projectPath: string) => Array<{ stackId: string; addedAt: string }>;
+  /**
+   * Optional circuit-breaker. When wired (s143 t569), each plugin load runs
+   * through `shouldSkip(plugin:<id>)` first; failed activations are recorded
+   * so a chronically broken plugin won't burn boot time forever. Without
+   * this, plugin loads fall back to the bare try/catch behavior unchanged.
+   */
+  circuitBreaker?: CircuitBreakerTracker;
 }
 
 export interface LoadResult {
@@ -63,6 +70,26 @@ export async function loadPlugins(
     if (deps.pluginRegistry.has(manifest.id)) {
       log.warn(`plugin "${manifest.id}" already loaded — skipping duplicate`);
       continue;
+    }
+
+    // s143 t569 — circuit-breaker gate. If a plugin has tripped the breaker
+    // on previous boots, skip the dynamic-import + activate() entirely so a
+    // chronically broken plugin (bad entry, throws on activate, missing
+    // peer dep) can't burn budget every restart. Failed loads still record
+    // through the catch block below regardless of whether the breaker is
+    // wired — falling back to bare try/catch when not.
+    const serviceId = `plugin:${manifest.id}`;
+    if (deps.circuitBreaker) {
+      const decision = deps.circuitBreaker.shouldSkip(serviceId);
+      if (decision.skip) {
+        const reason = decision.reason ?? "circuit open";
+        log.warn(`[${manifest.id}] circuit-open — skipping plugin load (${reason})`);
+        failed.push({ id: manifest.id, error: reason });
+        continue;
+      }
+      if (decision.transitionedTo) {
+        log.info(`[${manifest.id}] breaker transitioned to ${decision.transitionedTo} — attempting load`);
+      }
     }
 
     // Scan plugin source for suspicious patterns (warn-only)
@@ -117,10 +144,12 @@ export async function loadPlugins(
       }
 
       loaded.push(manifest.id);
+      deps.circuitBreaker?.recordSuccess(serviceId);
       log.info(`loaded plugin: ${manifest.name} v${manifest.version}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       failed.push({ id: manifest.id, error: message });
+      deps.circuitBreaker?.recordFailure(serviceId, err);
       log.error(`failed to load plugin "${manifest.id}": ${message}`);
     }
   }


### PR DESCRIPTION
## Summary

- Channel adapters: \`ChannelRegistry.startChannel\` now gates on \`shouldSkip(channel:<id>)\` before \`adapter.start\`; records success/failure around the lifecycle. Skip path throws "circuit open" preserving the \`Promise.allSettled\` contract for \`startAll()\` callers.
- Plugin loader: \`PluginLoaderDeps.circuitBreaker\` (optional) gates each plugin on \`shouldSkip(plugin:<id>)\` before dynamic-import + activate; records success/failure around the existing per-plugin try/catch.
- \`server.ts\`: \`CircuitBreakerTracker\` construction moved up to right after \`SystemConfigService\` so it can be wired into \`ChannelRegistry\` (via setter — channels are constructed pre-config) AND threaded into all 4 \`loadPlugins\` call sites.
- Bump 0.4.557 → 0.4.558.

Runtime startup intentionally **not** split into a separate prefix: \`RuntimeDefinition\` is plugin-contributed (no independent boot lifecycle), so plugin-load failures cascade to runtime-availability automatically. \`SystemServiceManager\` only queries status (systemd/exec); the gateway never starts those services itself.

Closes **s143 t569**. Remaining: t573 (Playwright e2e — force circuit-open + reset via UI).

## Test plan

- [x] 5 new integration tests in \`circuit-breaker-integration.test.ts\` (clean start / single failure / threshold trip + skip / recovery-clears-state / no-breaker fallback) — pass
- [x] Existing 33 tests (channel-resilience + circuit-breaker) — pass
- [x] Typecheck clean on @agi/gateway-core + @agi/plugins
- [x] Same-commit guards (staged-check / route-check / docs-check) — clean
- [ ] Manual: bring up gateway with a deliberately-failing channel adapter; observe 3 failure entries → "OPENED" log → 4th boot logs "circuit-open — skipping start"

🤖 Generated with [Claude Code](https://claude.com/claude-code)