### PR TITLE
feat(circuit-breaker): force-trip e2e + Services page UX fixes (s143 t573 — CLOSES s143)

### DIFF
--- a/e2e/circuit-breaker-force-trip-reset.spec.ts
+++ b/e2e/circuit-breaker-force-trip-reset.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * Circuit-breaker — force-trip + reset via Services page UI (s143 t573).
+ *
+ * Closes the s143 story by proving the full round-trip:
+ *   1. Force a synthetic service id into "open" via the test-VM-only
+ *      `/api/services/circuit-breakers/force-trip` endpoint.
+ *   2. Navigate to the Services page (the Aion docs link path is
+ *      `/services`; the dashboard internal route is `/system/services` —
+ *      both render the CircuitBreakerSection from the same component).
+ *   3. Assert the synthetic id's row + status pill + Reset button render.
+ *   4. Click Reset.
+ *   5. Verify via API that the breaker no longer exists in state.
+ *
+ * The synthetic id uses the prefix `service:e2e-cb-test-` so it can never
+ * be confused with a real channel/plugin/hosting/mcp breaker on the test
+ * VM. The force-trip endpoint is gated on AIONIMA_TEST_VM=1 — production
+ * never has this surface.
+ *
+ * Run via: `agi test --e2e circuit-breaker-force-trip-reset`
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Circuit breaker — force-trip + reset (s143 t573)", () => {
+  test("force a synthetic breaker open, see it render on /system/services, reset via UI, verify cleared", async ({ page, request }) => {
+    // Unique id per run so concurrent runs / leftover state can't clash.
+    const syntheticId = `service:e2e-cb-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+    // ---- Step 1: force the breaker open via the test-VM endpoint --------
+    const forceTripRes = await request.post("/api/services/circuit-breakers/force-trip", {
+      data: { serviceId: syntheticId, failures: 3 },
+      headers: { "Content-Type": "application/json" },
+    });
+    if (forceTripRes.status() === 404) {
+      test.skip(true, "force-trip endpoint disabled — set AIONIMA_TEST_VM=1 on the gateway to enable");
+      return;
+    }
+    expect(forceTripRes.status(), "force-trip should return 2xx").toBeLessThan(300);
+    const forceTripBody = await forceTripRes.json() as {
+      ok: boolean;
+      serviceId: string;
+      state: { status: string; failures: number } | null;
+    };
+    expect(forceTripBody.ok).toBe(true);
+    expect(forceTripBody.state?.status, "synthetic breaker should be open after 3 failures").toBe("open");
+    expect(forceTripBody.state?.failures).toBe(3);
+
+    // ---- Step 2: API confirms the breaker is in listStates --------------
+    const apiBefore = await request.get("/api/services/circuit-breakers");
+    expect(apiBefore.status()).toBeLessThan(300);
+    const apiBeforeBody = await apiBefore.json() as {
+      states: Record<string, { status: string }>;
+    };
+    expect(apiBeforeBody.states[syntheticId]?.status).toBe("open");
+
+    try {
+      // ---- Step 3: render the Services page, see the row ----------------
+      await page.goto("/system/services");
+      await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+
+      // Section visible — there's at least one tracked breaker (ours).
+      const section = page.getByTestId("circuit-breakers-section");
+      await expect(section, "section must render when at least one breaker is tracked").toBeVisible({ timeout: 10_000 });
+
+      // Row for our synthetic id.
+      const rowTestId = `circuit-breaker-${syntheticId}`;
+      const resetTestId = `circuit-breaker-reset-${syntheticId}`;
+      await expect(
+        page.getByTestId(rowTestId),
+        `row for synthetic id ${syntheticId} should render`,
+      ).toBeVisible();
+
+      const resetBtn = page.getByTestId(resetTestId);
+      await expect(resetBtn, "reset button visible").toBeVisible();
+      await expect(resetBtn, "reset button enabled").toBeEnabled();
+
+      // ---- Step 4: click Reset ----------------------------------------
+      await resetBtn.click();
+
+      // The row should disappear from the section (CircuitBreakerSection
+      // refetches on reset and re-renders). Allow a short wait for the
+      // refetch + re-render cycle to settle.
+      await expect(
+        page.getByTestId(rowTestId),
+        "row should disappear after reset",
+      ).toHaveCount(0, { timeout: 10_000 });
+
+      // ---- Step 5: API confirms the breaker is cleared ----------------
+      const apiAfter = await request.get("/api/services/circuit-breakers");
+      const apiAfterBody = await apiAfter.json() as {
+        states: Record<string, { status: string; failures: number }>;
+      };
+      const after = apiAfterBody.states[syntheticId];
+      // Reset writes a state with failures=0, status=closed (with
+      // lastResetAt). The breaker isn't deleted — that's intentional so
+      // operators can see "this was reset at <time>". Either undefined OR
+      // closed/0 is acceptable; assert the latter.
+      if (after !== undefined) {
+        expect(after.status).toBe("closed");
+        expect(after.failures).toBe(0);
+      }
+    } finally {
+      // Cleanup: ensure no leftover synthetic state regardless of test
+      // outcome. A failed assertion above shouldn't pollute future runs.
+      await request.post(`/api/services/circuit-breakers/${encodeURIComponent(syntheticId)}/reset`).catch(() => {});
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.558",
+  "version": "0.4.559",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -6030,6 +6030,37 @@ export async function createGatewayRuntimeState(
     return reply.send({ ok: true, count });
   });
 
+  // s143 t573 — test-VM-only endpoint that synthesizes an "open" breaker
+  // for an arbitrary service id so the e2e can prove force-trip → render
+  // → reset → cleared without breaking a real service. Gated on
+  // AIONIMA_TEST_VM=1 (the same gate FilesystemSecretsBackend uses) so
+  // production cannot reach this surface even from a private network.
+  // The expected service-id prefix is `service:e2e-` — but the endpoint
+  // doesn't enforce a prefix so other tests (channel/plugin/hosting)
+  // can synthesize their own breakers consistently.
+  fastify.post("/api/services/circuit-breakers/force-trip", async (request, reply) => {
+    if (process.env["AIONIMA_TEST_VM"] !== "1") {
+      return reply.code(404).send({ error: "Not Found" });
+    }
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) {
+      return reply.code(403).send({ error: "Services API only allowed from private network" });
+    }
+    if (!deps.circuitBreaker) {
+      return reply.code(503).send({ error: "Circuit breaker tracker not wired" });
+    }
+    const body = (request.body ?? {}) as { serviceId?: string; failures?: number };
+    if (typeof body.serviceId !== "string" || body.serviceId.length === 0) {
+      return reply.code(400).send({ error: "serviceId (string) required" });
+    }
+    // Default 3 failures = threshold (matches CircuitBreakerTracker default).
+    const target = Math.max(1, Math.min(20, body.failures ?? 3));
+    for (let i = 0; i < target; i++) {
+      deps.circuitBreaker.recordFailure(body.serviceId, new Error(`e2e force-trip failure ${String(i + 1)}/${String(target)}`));
+    }
+    return reply.send({ ok: true, serviceId: body.serviceId, state: deps.circuitBreaker.getState(body.serviceId) ?? null });
+  });
+
   // -----------------------------------------------------------------------
   // Federation & Identity routes
   // -----------------------------------------------------------------------

--- a/scripts/test-vm.sh
+++ b/scripts/test-vm.sh
@@ -511,9 +511,13 @@ EOF
   '
 
   echo "==> Starting AGI gateway..."
+  # AIONIMA_TEST_VM=1 marks this gateway process as "running inside the test
+  # VM" — gates test-only endpoints (e.g. /api/services/circuit-breakers/
+  # force-trip from s143 t573) so production gateways never expose them
+  # even on a private network.
   multipass exec "$VM_NAME" -- bash -c '
     cd /mnt/agi
-    nohup node cli/dist/index.js run > /tmp/agi.log 2>&1 &
+    nohup env AIONIMA_TEST_VM=1 node cli/dist/index.js run > /tmp/agi.log 2>&1 &
     echo $! > /tmp/agi.pid
     sleep 3
     echo "  AGI PID: $(cat /tmp/agi.pid)"

--- a/ui/dashboard/src/routes/services.tsx
+++ b/ui/dashboard/src/routes/services.tsx
@@ -55,8 +55,15 @@ export default function ServicesPage() {
   const visibleServices = services.filter((svc) => svc.imageAvailable !== false);
 
   if (visibleServices.length === 0) {
+    // s143 t573 — render the CircuitBreakerSection BEFORE the empty-state
+    // early-return so circuit-broken services are visible even when no
+    // service plugin is registered. Previously, breakers were hidden
+    // behind this branch — a real UX gap caught while wiring the e2e.
+    // CircuitBreakerSection internally returns null when totalCount === 0,
+    // so the empty-state stays clean for the actually-empty case.
     return (
       <PageScroll>
+      <CircuitBreakerSection />
       <div className="text-center py-12">
         <div className="text-[13px] text-muted-foreground mb-2">No services registered</div>
         <div className="text-[11px] text-muted-foreground">
@@ -183,7 +190,20 @@ function CircuitBreakerSection(): React.ReactElement | null {
     return null;
   }
 
-  const entries = Object.entries(data.states);
+  // s143 t573 — section title is "Circuit-broken services". Only render
+  // rows whose breaker is open or half-open. Reset writes status=closed
+  // but does NOT delete the entry (intentional — operators see when each
+  // breaker was last reset), so closed entries leak into the list
+  // otherwise. Hiding closed ones makes the UI self-clearing after Reset
+  // is clicked, and keeps the count summary honest ("N open · M
+  // half-open"). The full state map is still available via API for any
+  // diagnostic surface that wants the full history.
+  const entries = Object.entries(data.states).filter(
+    ([, state]) => state.status === "open" || state.status === "half-open",
+  );
+  if (entries.length === 0) {
+    return null;
+  }
 
   async function handleReset(serviceId: string): Promise<void> {
     setBusy(serviceId);


### PR DESCRIPTION
## Summary

Closes **s143** by proving the full force-trip → render → reset → cleared loop end-to-end. Surfaced + fixed three real UX gaps along the way.

- **New test-VM-only endpoint** \`POST /api/services/circuit-breakers/force-trip\`, gated on \`AIONIMA_TEST_VM=1\` (404 otherwise) + private-network. Records N failures (default 3 = threshold) so the synthetic id transitions to open. Production never has the env set, so the surface is invisible there.
- **\`scripts/test-vm.sh\`**: pass \`AIONIMA_TEST_VM=1\` into the gateway process env at \`services-start\`. Production gateways never see this env.
- **\`services.tsx\`** (two real bugs caught while wiring the e2e):
  1. Render \`CircuitBreakerSection\` BEFORE the "No services registered" empty-state. Previously breakers were invisible whenever no service plugin was installed.
  2. Filter "Circuit-broken services" rows to only \`open\` + \`half-open\` status. Reset writes \`status=closed\` (with \`lastResetAt\`) and does NOT delete the entry, so closed entries were leaking into the section. Filtering makes Reset self-clearing in the UI.
- **New e2e spec**: synthesizes \`service:e2e-cb-test-<rand>\` per run, force-trips, navigates to \`/system/services\`, asserts row + status pill + Reset button render, clicks Reset, asserts row disappears + API confirms cleared.

s143 closes — 10/10 tasks done across cycles 153-238.

Bump 0.4.558 → 0.4.559.

## Test plan

- [x] e2e \`circuit-breaker-force-trip-reset\` passes against test VM (1.3s)
- [x] Existing 33 breaker tests still green
- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (staged-check / route-check / docs-check) — clean
- [x] Production gateway returns 404 for force-trip (gated by \`AIONIMA_TEST_VM\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)