### PR TITLE
feat(project-schema): per-repo devCommand + custom actions (s141 t551)

### DIFF
--- a/config/src/project-schema.test.ts
+++ b/config/src/project-schema.test.ts
@@ -284,6 +284,92 @@ describe("ProjectConfigSchema", () => {
       expect(ProjectConfigSchema.safeParse(data).success).toBe(true);
     });
 
+    it("accepts a repo with devCommand distinct from startCommand (s141 t551)", () => {
+      const data = {
+        name: "X",
+        repos: [
+          { name: "web", url: "u", port: 5173, startCommand: "node dist/server.js", devCommand: "pnpm dev", isDefault: true },
+        ],
+      };
+      const r = ProjectConfigSchema.safeParse(data);
+      expect(r.success).toBe(true);
+      if (r.success) {
+        expect(r.data.repos?.[0]?.devCommand).toBe("pnpm dev");
+      }
+    });
+
+    it("accepts a repo with custom actions (s141 t551)", () => {
+      const data = {
+        name: "X",
+        repos: [
+          {
+            name: "api",
+            url: "u",
+            port: 8001,
+            startCommand: "node dist",
+            actions: [
+              { label: "Run tests", command: "pnpm test" },
+              { label: "Migrate DB", command: "drizzle-kit push", description: "Pushes the latest schema to the project's hosted Postgres" },
+            ],
+          },
+        ],
+      };
+      const r = ProjectConfigSchema.safeParse(data);
+      expect(r.success).toBe(true);
+      if (r.success) {
+        expect(r.data.repos?.[0]?.actions?.length).toBe(2);
+      }
+    });
+
+    it("rejects duplicate action labels within a repo (s141 t551)", () => {
+      const data = {
+        name: "X",
+        repos: [
+          {
+            name: "api",
+            url: "u",
+            actions: [
+              { label: "Build", command: "pnpm build" },
+              { label: "Build", command: "pnpm build:dashboard" },
+            ],
+          },
+        ],
+      };
+      const r = ProjectConfigSchema.safeParse(data);
+      expect(r.success).toBe(false);
+      if (!r.success) {
+        expect(r.error.issues.some((i) => i.message.includes("action labels must be unique"))).toBe(true);
+      }
+    });
+
+    it("rejects empty action label (s141 t551)", () => {
+      const data = {
+        name: "X",
+        repos: [
+          {
+            name: "api",
+            url: "u",
+            actions: [{ label: "", command: "pnpm build" }],
+          },
+        ],
+      };
+      expect(ProjectConfigSchema.safeParse(data).success).toBe(false);
+    });
+
+    it("rejects empty action command (s141 t551)", () => {
+      const data = {
+        name: "X",
+        repos: [
+          {
+            name: "api",
+            url: "u",
+            actions: [{ label: "Build", command: "" }],
+          },
+        ],
+      };
+      expect(ProjectConfigSchema.safeParse(data).success).toBe(false);
+    });
+
     it("accepts env vars on a repo", () => {
       const data = {
         name: "X",

--- a/config/src/project-schema.ts
+++ b/config/src/project-schema.ts
@@ -259,6 +259,35 @@ export const ProjectRepoSchema = z
      *  Required when `port` is set. */
     startCommand: z.string().optional(),
 
+    /** Optional development-mode command, distinct from startCommand. When
+     *  the dashboard's "Dev" affordance launches the repo, this command
+     *  runs instead — typical examples:
+     *    startCommand: "node dist/server.js" (production-shape)
+     *    devCommand:   "pnpm dev"           (vite, hot reload, source maps)
+     *  When unset, "Dev" falls back to startCommand. (s141 t551) */
+    devCommand: z.string().optional(),
+
+    /** Per-repo custom actions surfaced as buttons in the dashboard's
+     *  hosting card (e.g. "Run tests", "Lint", "Migrate DB"). Each action
+     *  is one shell command run inside the container with cwd = the
+     *  repo's checkout path. Action labels must be unique per repo.
+     *  (s141 t551) */
+    actions: z.array(z.object({
+      /** Display label for the dashboard button. Short — fits in a
+       *  per-repo card row. Example: "Run tests", "Lint", "Build". */
+      label: z.string().min(1).max(40),
+      /** Shell command to execute. Examples:
+       *    "pnpm test"
+       *    "pnpm lint --fix"
+       *    "drizzle-kit push" */
+      command: z.string().min(1),
+      /** Optional one-line description shown as a tooltip / hover hint.
+       *  Useful when the label can't fully describe what the action
+       *  does (e.g. "Migrate DB" → "Runs drizzle-kit push against the
+       *  project's hosted Postgres"). */
+      description: z.string().optional(),
+    }).strict()).optional(),
+
     /** Marks this repo as the default served on `https://<project>.ai.on/`.
      *  At most one repo per project may set this true (enforced via
      *  ProjectConfigSchema.refine). When no repo is marked default, the
@@ -309,6 +338,14 @@ export const ProjectRepoSchema = z
   .refine(
     (r) => r.autoRun === undefined || r.port !== undefined,
     { message: "autoRun only applies to repos with a port set" },
+  )
+  .refine(
+    (r) => {
+      if (!r.actions || r.actions.length === 0) return true;
+      const labels = r.actions.map((a) => a.label);
+      return new Set(labels).size === labels.length;
+    },
+    { message: "action labels must be unique within a repo" },
   );
 
 // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.559",
+  "version": "0.4.560",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Schema-only slice of s141. Adds two optional fields to \`ProjectRepoSchema\`:

- \`devCommand?\` — alternate dev-mode command. Falls back to \`startCommand\` when unset. Lets a repo split production-shape (\`node dist/server.js\`) from dev-shape (\`pnpm dev\`).
- \`actions?\` — array of \`{label, command, description?}\` for per-repo custom buttons. Refine: action labels must be unique within a repo.

Per-repo \`attachedStacks\` was already added in t515. Remaining s141 work is downstream consumers (hosting-manager t552 — already done, t553 stack provider plugin filter, t554 hosting UI, t555 catalog filter, t556 e2e).

Bump 0.4.559 → 0.4.560.

## Test plan

- [x] 34 schema tests pass (5 new): devCommand round-trip, actions accept, duplicate-label reject, empty-label reject, empty-command reject
- [x] Typecheck clean on @agi/config + @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)