### PR TITLE
feat(stack-api): per-repo actions filter via whenRepo predicate (s141 t553)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.560",
+  "version": "0.4.561",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/filter-stack-actions-for-repo.test.ts
+++ b/packages/gateway-core/src/filter-stack-actions-for-repo.test.ts
@@ -1,0 +1,66 @@
+/**
+ * filterStackActionsForRepo — per-repo predicate filtering for stack
+ * install actions (s141 t553). Pure-logic; runs on host.
+ */
+
+import { describe, it, expect } from "vitest";
+import { filterStackActionsForRepo, type StackInstallAction } from "./stack-types.js";
+
+const PROJ = "/home/u/.agi/x/proj";
+
+describe("filterStackActionsForRepo (s141 t553)", () => {
+  it("returns [] for undefined or empty input", () => {
+    expect(filterStackActionsForRepo(undefined, { projectPath: PROJ, repoName: "", repoCount: 0 })).toEqual([]);
+    expect(filterStackActionsForRepo([], { projectPath: PROJ, repoName: "", repoCount: 0 })).toEqual([]);
+  });
+
+  it("includes actions with no whenRepo predicate (backward-compat default)", () => {
+    const actions: StackInstallAction[] = [
+      { id: "a", label: "A", command: "echo A" },
+      { id: "b", label: "B", command: "echo B" },
+    ];
+    const out = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "web", repoCount: 2 });
+    expect(out).toHaveLength(2);
+  });
+
+  it("excludes actions whose whenRepo returns false", () => {
+    const actions: StackInstallAction[] = [
+      { id: "always", label: "Always", command: "echo" },
+      { id: "web-only", label: "Web only", command: "vite", whenRepo: ({ repoName }) => repoName === "web" },
+      { id: "api-only", label: "API only", command: "node", whenRepo: ({ repoName }) => repoName === "api" },
+    ];
+    const onWeb = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "web", repoCount: 2 });
+    expect(onWeb.map((a) => a.id)).toEqual(["always", "web-only"]);
+    const onApi = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "api", repoCount: 2 });
+    expect(onApi.map((a) => a.id)).toEqual(["always", "api-only"]);
+  });
+
+  it("supports the project-level surface (repoName='') predicate", () => {
+    const actions: StackInstallAction[] = [
+      { id: "project-level", label: "PL", command: "x", whenRepo: ({ repoName }) => repoName === "" },
+      { id: "repo-level", label: "RL", command: "y", whenRepo: ({ repoName }) => Boolean(repoName) },
+    ];
+    const projectSurface = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "", repoCount: 3 });
+    expect(projectSurface.map((a) => a.id)).toEqual(["project-level"]);
+    const repoSurface = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "web", repoCount: 3 });
+    expect(repoSurface.map((a) => a.id)).toEqual(["repo-level"]);
+  });
+
+  it("passes repoCount so single-repo projects can short-circuit", () => {
+    const actions: StackInstallAction[] = [
+      { id: "multi-only", label: "MultiOnly", command: "z", whenRepo: ({ repoCount }) => repoCount > 1 },
+    ];
+    expect(filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "web", repoCount: 1 })).toEqual([]);
+    expect(filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "web", repoCount: 2 })).toHaveLength(1);
+  });
+
+  it("preserves action order", () => {
+    const actions: StackInstallAction[] = [
+      { id: "a", label: "A", command: "x", whenRepo: () => true },
+      { id: "b", label: "B", command: "y" },
+      { id: "c", label: "C", command: "z", whenRepo: () => true },
+    ];
+    const out = filterStackActionsForRepo(actions, { projectPath: PROJ, repoName: "r", repoCount: 1 });
+    expect(out.map((a) => a.id)).toEqual(["a", "b", "c"]);
+  });
+});

--- a/packages/gateway-core/src/index.ts
+++ b/packages/gateway-core/src/index.ts
@@ -408,6 +408,7 @@ export type { ProjectTypeDefinition, ProjectTypeTool, ContainerConfig, ProjectCa
 
 // Stacks
 export { StackRegistry } from "./stack-registry.js";
+export { filterStackActionsForRepo } from "./stack-types.js";
 export type {
   StackCategory, StackRequirement, StackGuide,
   StackContainerContext, StackContainerConfig, StackDatabaseConfig,

--- a/packages/gateway-core/src/stack-api.ts
+++ b/packages/gateway-core/src/stack-api.ts
@@ -10,6 +10,7 @@ import type { StackRegistry } from "./stack-registry.js";
 import type { SharedContainerManager } from "./shared-container-manager.js";
 import type { HostingManager } from "./hosting-manager.js";
 import type { ProjectCategory } from "./project-types.js";
+import { filterStackActionsForRepo } from "./stack-types.js";
 import type { StackCategory } from "./stack-types.js";
 import type { ComponentLogger } from "./logger.js";
 import type { RuntimeDefinition } from "@agi/plugins";
@@ -145,6 +146,43 @@ export function registerStackRoutes(app: FastifyInstance, deps: StackApiDeps): v
 
     const stacks = hostingManager.getProjectStacks(query.path);
     reply.send({ stacks });
+  });
+
+  // GET /api/hosting/stacks/actions — list stack install actions visible to a
+  // specific repo within a project (s141 t553). Filters each stack's
+  // installActions through `whenRepo({projectPath, repoName, repoCount})`.
+  // When `repo` is omitted, returns the project-level surface
+  // (`repoName: ""`) — preserves the legacy stack-card actions list.
+  app.get("/api/hosting/stacks/actions", async (request, reply) => {
+    const query = request.query as { path?: string; repo?: string };
+    if (!query.path) {
+      reply.code(400).send({ error: "path query parameter required" });
+      return;
+    }
+
+    const projectPath = query.path;
+    const repoName = query.repo ?? "";
+    const instances = hostingManager.getProjectStacks(projectPath);
+    // Count repos via the existing config-manager accessor (no new method
+    // on HostingManager). projectConfigManager isn't directly on
+    // StackApiDeps, so route through hostingManager which holds it.
+    const repoCount = (hostingManager as unknown as {
+      configMgr: { getRepos(p: string): unknown[] } | undefined;
+    }).configMgr?.getRepos(projectPath).length ?? 0;
+    const ctx = { projectPath, repoName, repoCount };
+
+    const result = instances.map((instance) => {
+      const def = stackRegistry.get(instance.stackId);
+      const actions = def ? filterStackActionsForRepo(def.installActions, ctx) : [];
+      return {
+        stackId: instance.stackId,
+        actions: actions.map(({ id, label, description, optional }) => ({
+          id, label, description, optional,
+        })),
+      };
+    });
+
+    reply.send({ stacks: result, repoCount });
   });
 
   // GET /api/stacks/compatible-runtimes — runtimes filtered by installed stacks' compatibleLanguages

--- a/packages/gateway-core/src/stack-types.ts
+++ b/packages/gateway-core/src/stack-types.ts
@@ -95,6 +95,27 @@ export interface StackInstallAction {
   command: string;
   /** If true, skip on error and continue with next action. */
   optional?: boolean;
+  /**
+   * Per-repo visibility filter (s141 t553). When set, the action only
+   * surfaces for repos where `whenRepo(ctx)` returns true. When unset,
+   * the action shows on every repo with the stack attached (backward
+   * compat — covers the project-level intent).
+   *
+   * Plugin authors decide whether their actions are project-level or
+   * repo-level. Examples:
+   *   - "Run migrations" on a `database` stack: project-level (one DB,
+   *     one set of migrations) — leave whenRepo unset.
+   *   - "Restart vite dev server" on a framework stack: repo-level
+   *     (each repo has its own dev server) — `whenRepo: ({ repoName })
+   *     => Boolean(repoName)` shows it only when called with a real
+   *     repo context.
+   *
+   * `repoName` is empty string when the caller is a project-level
+   * surface (the legacy stack-card actions list); `repoCount` is the
+   * total number of repos on the project so plugin authors can short-
+   * circuit single-repo projects with `repoCount === 1`.
+   */
+  whenRepo?: (ctx: { projectPath: string; repoName: string; repoCount: number }) => boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -120,6 +141,25 @@ export interface StackScaffoldingConfig {
   description?: string;
   command: string[];
   expectedOutput?: string[];
+}
+
+/**
+ * Filter a stack's install actions by per-repo predicate (s141 t553).
+ *
+ * Default (no `whenRepo`): action shows on every repo with the stack —
+ * preserves the project-level legacy semantics.
+ *
+ * @param actions     The stack's `installActions` (or undefined).
+ * @param ctx         Repo context: `repoName` is empty string for
+ *                    project-level surfaces; `repoCount` is the total
+ *                    number of repos on the project.
+ */
+export function filterStackActionsForRepo(
+  actions: StackInstallAction[] | undefined,
+  ctx: { projectPath: string; repoName: string; repoCount: number },
+): StackInstallAction[] {
+  if (!actions || actions.length === 0) return [];
+  return actions.filter((a) => (a.whenRepo === undefined ? true : a.whenRepo(ctx)));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- \`StackInstallAction\` gains optional \`whenRepo({projectPath, repoName, repoCount}) => boolean\` predicate. Default (unset): action shows on every repo with the stack — preserves legacy project-level behavior.
- New helper \`filterStackActionsForRepo(actions, ctx)\` exported from \`@agi/gateway-core\`.
- New API \`GET /api/hosting/stacks/actions?path=...&repo=...\` returns per-stack action lists filtered through the predicate. When \`repo\` is omitted, returns the project-level surface (\`repoName: ""\`).
- \`defineStack().installAction()\` passes \`whenRepo\` through automatically (no builder change — the type widens).

Plugin author examples:
- "Run migrations" on a database stack → project-level, leave whenRepo unset.
- "Restart vite dev server" on a framework stack → \`whenRepo: ({ repoName }) => Boolean(repoName)\`.
- Multi-repo-only action → \`whenRepo: ({ repoCount }) => repoCount > 1\`.

Bump 0.4.560 → 0.4.561. s141 progress 3/6.

## Test plan

- [x] 6 new unit tests in \`filter-stack-actions-for-repo.test.ts\` (empty/undefined, default backward-compat, predicate true/false, project-level surface, single-repo short-circuit, order preservation) — pass
- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)