### PR TITLE
feat(stack-api): /api/stacks/for-repo catalog filter (s141 t555)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.561",
+  "version": "0.4.562",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/stack-api.ts
+++ b/packages/gateway-core/src/stack-api.ts
@@ -40,6 +40,43 @@ export function registerStackRoutes(app: FastifyInstance, deps: StackApiDeps): v
     reply.send({ stacks });
   });
 
+  // GET /api/stacks/for-repo — catalog filtered by the repo's effective
+  // project category (s141 t555). When attaching a stack to a specific
+  // repo, the dashboard hits this to cut menu noise — only stacks
+  // compatible with the project's classification surface. The "all"
+  // toggle on the dashboard side just falls back to /api/stacks
+  // (unfiltered).
+  //
+  // Response includes `inferredCategory` so the dashboard can label the
+  // filter ("Showing for App — view all") without a second call. When
+  // the project type can't be resolved (no projectTypeRegistry, project
+  // type unset, registry doesn't know the type), returns the full
+  // catalog + `inferredCategory: null` — caller fall-through is the
+  // same code path as the toggle-off case.
+  app.get("/api/stacks/for-repo", async (request, reply) => {
+    const query = request.query as { path?: string; repo?: string };
+    if (!query.path) {
+      reply.code(400).send({ error: "path query parameter required" });
+      return;
+    }
+
+    let inferredCategory: ProjectCategory | null = null;
+    const cfg = (hostingManager as unknown as {
+      configMgr: { read(p: string): { type?: string } | null } | undefined;
+    }).configMgr?.read(query.path);
+    const typeId = cfg?.type;
+    const projectTypeRegistry = hostingManager.getProjectTypeRegistry();
+    if (typeId && projectTypeRegistry) {
+      const def = projectTypeRegistry.get(typeId);
+      if (def?.category) inferredCategory = def.category;
+    }
+
+    const stacks = stackRegistry.toJSON({
+      projectCategory: inferredCategory ?? undefined,
+    });
+    reply.send({ stacks, inferredCategory, projectType: typeId ?? null });
+  });
+
   // GET /api/stacks/:id — single stack detail
   app.get("/api/stacks/:id", async (request, reply) => {
     const { id } = request.params as { id: string };


### PR DESCRIPTION
## Summary

New \`GET /api/stacks/for-repo?path=...&repo=...\` returns the stack catalog filtered by the project's effective category. Cuts menu noise when attaching a stack to a specific repo.

- Resolves \`project.type\` → looks up type def in \`hostingManager.getProjectTypeRegistry()\` → derives \`ProjectCategory\` → passes to \`stackRegistry.toJSON({projectCategory})\`.
- Response: \`{stacks, inferredCategory, projectType}\` — dashboard can label the filter ("Showing for {category} — view all") without a second call.
- Graceful fallback: unresolvable type returns full catalog + \`inferredCategory: null\`.
- "All" toggle on the dashboard side falls back to existing \`/api/stacks\` (unfiltered).

Bump 0.4.561 → 0.4.562. s141 progress 4/6.

## Test plan

- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [ ] Manual: dashboard renders filtered catalog when attaching to a repo, full catalog with toggle off

🤖 Generated with [Claude Code](https://claude.com/claude-code)