### PR TITLE
feat(doctor): git state diagnostic — per-project + sacred repos (s144 t577)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -262,6 +262,141 @@ function repoChecks(config: AionimaConfig): CheckGroup {
   return { title: "Multi-Repo", checks };
 }
 
+// ---------------------------------------------------------------------------
+// Git state — per-project + sacred repos (s144 t577)
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of inspecting a single repo's git state. `null` when the path
+ * isn't a git working tree (or git is unavailable / the call fails).
+ */
+export interface GitRepoState {
+  staged: number;
+  unstaged: number;
+  untracked: number;
+  upstreamSet: boolean;
+  ahead: number;
+  behind: number;
+}
+
+/**
+ * Parse `git status --porcelain=v2 --branch` output into a GitRepoState.
+ * Pure function — pulled out for unit testing without shelling out.
+ */
+export function parseGitPorcelainV2(out: string): GitRepoState {
+  const lines = out.split("\n");
+  let staged = 0;
+  let unstaged = 0;
+  let untracked = 0;
+  let upstreamSet = false;
+  let ahead = 0;
+  let behind = 0;
+
+  for (const line of lines) {
+    if (line.startsWith("# branch.upstream ")) {
+      upstreamSet = true;
+    } else if (line.startsWith("# branch.ab ")) {
+      // Format: "# branch.ab +N -M"
+      const m = /^# branch\.ab \+(\d+) -(\d+)$/.exec(line);
+      if (m) {
+        ahead = Number(m[1]);
+        behind = Number(m[2]);
+      }
+    } else if (line.startsWith("1 ") || line.startsWith("2 ")) {
+      // Tracked-changed entry. Field 2 is the XY status (e.g. ".M", "M.", "MM").
+      const parts = line.split(" ");
+      const xy = parts[1] ?? "..";
+      const indexFlag = xy[0] ?? ".";
+      const worktreeFlag = xy[1] ?? ".";
+      if (indexFlag !== "." && indexFlag !== "?") staged++;
+      if (worktreeFlag !== "." && worktreeFlag !== "?") unstaged++;
+    } else if (line.startsWith("? ")) {
+      untracked++;
+    }
+  }
+
+  return { staged, unstaged, untracked, upstreamSet, ahead, behind };
+}
+
+function readGitState(repoPath: string): GitRepoState | null {
+  try {
+    const out = execFileSync("git", ["status", "--porcelain=v2", "--branch"], {
+      cwd: repoPath,
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    return parseGitPorcelainV2(out);
+  } catch {
+    return null;
+  }
+}
+
+/** Render a one-line summary of a repo's git state (or `null` if not git). */
+function summarizeGitState(state: GitRepoState | null): { ok: boolean; warn: boolean; summary: string } {
+  if (state === null) return { ok: true, warn: false, summary: "not a git repo (skipping)" };
+
+  const parts: string[] = [];
+  const dirty = state.staged > 0 || state.unstaged > 0 || state.untracked > 0;
+  if (state.staged > 0) parts.push(`${String(state.staged)} staged`);
+  if (state.unstaged > 0) parts.push(`${String(state.unstaged)} unstaged`);
+  if (state.untracked > 0) parts.push(`${String(state.untracked)} untracked`);
+  if (!state.upstreamSet) parts.push("no upstream");
+  else if (state.ahead > 0) parts.push(`${String(state.ahead)} unpushed`);
+  if (state.behind > 0) parts.push(`${String(state.behind)} behind`);
+
+  if (parts.length === 0) return { ok: true, warn: false, summary: "clean + in sync" };
+
+  // Mix of staged + unstaged is a warning (looks like a half-finished commit).
+  const stagedMix = state.staged > 0 && state.unstaged > 0;
+  return {
+    ok: !dirty && state.upstreamSet && state.ahead === 0,
+    warn: stagedMix || !state.upstreamSet,
+    summary: parts.join(", "),
+  };
+}
+
+function gitStateChecks(config: AionimaConfig): CheckGroup {
+  const checks: Check[] = [];
+
+  // Sacred repos (mirror the set in repoChecks, which only verifies existence).
+  const mappMarketplaceConfig = (config as Record<string, unknown>).mappMarketplace as Record<string, string> | undefined;
+  const sacred = [
+    { name: "PRIME corpus", path: config.prime?.dir ?? "/opt/agi-prime" },
+    { name: "Plugin Marketplace", path: config.marketplace?.dir ?? "/opt/agi-marketplace" },
+    { name: "MApp Marketplace", path: mappMarketplaceConfig?.dir ?? "/opt/agi-mapp-marketplace" },
+    { name: "ID service", path: config.idService?.dir ?? "/opt/agi-local-id" },
+  ];
+
+  for (const repo of sacred) {
+    if (!dirExists(repo.path)) continue; // existence-warning surfaced by repoChecks
+    const state = readGitState(repo.path);
+    const { ok, warn, summary } = summarizeGitState(state);
+    checks.push({
+      name: `${repo.name} — ${summary}`,
+      ok,
+      warn,
+      fix: ok ? undefined : "Repair actions land with `agi doctor` TUI (s144 t574)",
+    });
+  }
+
+  // Workspace projects.
+  const workspaceProjects = config.workspace?.projects ?? [];
+  for (const projectPath of workspaceProjects) {
+    if (!dirExists(projectPath)) continue;
+    const state = readGitState(projectPath);
+    const { ok, warn, summary } = summarizeGitState(state);
+    checks.push({
+      name: `${projectPath} — ${summary}`,
+      ok,
+      warn,
+      fix: ok ? undefined : "Repair actions land with `agi doctor` TUI (s144 t574)",
+    });
+  }
+
+  return { title: "Git state", checks };
+}
+
 function pluginChecks(): CheckGroup {
   const checks: Check[] = [];
 
@@ -728,6 +863,7 @@ async function runDoctorDump(opts: { config?: string }): Promise<string> {
   if (config && configOk) {
     groups.push(authChecks(config));
     groups.push(repoChecks(config));
+    groups.push(gitStateChecks(config));
     groups.push(pluginChecks());
     const hosting = hostingChecks(config);
     if (hosting) groups.push(hosting);
@@ -835,6 +971,7 @@ export function registerDoctorCommand(program: Command): void {
       if (config && configOk) {
         groups.push(authChecks(config));
         groups.push(repoChecks(config));
+        groups.push(gitStateChecks(config));
         groups.push(pluginChecks());
 
         const hosting = hostingChecks(config);

--- a/cli/src/commands/git-diagnostic.test.ts
+++ b/cli/src/commands/git-diagnostic.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Git-diagnostic parser tests (s144 t577).
+ *
+ * Validates parseGitPorcelainV2 against representative `git status
+ * --porcelain=v2 --branch` outputs. Pure-logic; runs on host.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseGitPorcelainV2 } from "./doctor.js";
+
+describe("parseGitPorcelainV2 (s144 t577)", () => {
+  it("parses a clean, in-sync repo (upstream + 0/0)", () => {
+    const out = [
+      "# branch.oid abc123",
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "",
+    ].join("\n");
+    expect(parseGitPorcelainV2(out)).toEqual({
+      staged: 0,
+      unstaged: 0,
+      untracked: 0,
+      upstreamSet: true,
+      ahead: 0,
+      behind: 0,
+    });
+  });
+
+  it("parses no-upstream (detached or never-pushed branch)", () => {
+    const out = [
+      "# branch.oid abc123",
+      "# branch.head feature/x",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.upstreamSet).toBe(false);
+    expect(r.ahead).toBe(0);
+    expect(r.behind).toBe(0);
+  });
+
+  it("parses ahead/behind counts", () => {
+    const out = [
+      "# branch.oid abc",
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +3 -2",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.ahead).toBe(3);
+    expect(r.behind).toBe(2);
+  });
+
+  it("counts staged-only entries (M.)", () => {
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "1 M. N... 100644 100644 100644 abc def src/foo.ts",
+      "1 A. N... 100644 100644 100644 abc def src/new.ts",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.staged).toBe(2);
+    expect(r.unstaged).toBe(0);
+  });
+
+  it("counts unstaged-only entries (.M)", () => {
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "1 .M N... 100644 100644 100644 abc def src/foo.ts",
+      "1 .D N... 100644 100644 100644 abc def src/bar.ts",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.staged).toBe(0);
+    expect(r.unstaged).toBe(2);
+  });
+
+  it("counts mix as both staged and unstaged (MM)", () => {
+    // A file with staged AND unstaged changes — half-finished commit.
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "1 MM N... 100644 100644 100644 abc def src/foo.ts",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.staged).toBe(1);
+    expect(r.unstaged).toBe(1);
+  });
+
+  it("counts untracked entries (?)", () => {
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "? new-file.ts",
+      "? another.ts",
+      "? src/something.tsx",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.untracked).toBe(3);
+    expect(r.staged).toBe(0);
+    expect(r.unstaged).toBe(0);
+  });
+
+  it("handles renamed entries (line type '2 ')", () => {
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "2 R. N... 100644 100644 100644 abc def R100 src/new.ts\tsrc/old.ts",
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r.staged).toBe(1);
+    expect(r.unstaged).toBe(0);
+  });
+
+  it("ignores lines that don't match any expected prefix (forward-compat)", () => {
+    const out = [
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +0 -0",
+      "# some-future-header value",
+      "u UU N... unmerged",  // unmerged entries — neither staged nor unstaged in our taxonomy
+      "",
+    ].join("\n");
+    const r = parseGitPorcelainV2(out);
+    expect(r).toEqual({
+      staged: 0, unstaged: 0, untracked: 0,
+      upstreamSet: true, ahead: 0, behind: 0,
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.563",
+  "version": "0.4.564",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

New "Git state" check group runs \`git status --porcelain=v2 --branch\` per workspace project + the four sacred repos. Surfaces staged / unstaged / untracked counts, upstream-set, ahead/behind vs upstream, and staged+unstaged mix on the same file (warns — looks like a half-finished commit).

Closes the gap that bit owner during s140 migration: dirty repos blocked operations until manual git intervention. Diagnostic surfaces the state; **repair actions** (commit-and-push, stash, hard-reset, tarball backup) land with the TUI shell in t574.

Auto-included in \`agi doctor\` AND \`agi doctor dump\` (group flows through the existing groups[] pipeline).

Bump 0.4.563 → 0.4.564. s144 progress 3/10.

## Test plan

- [x] 9 new unit tests on \`parseGitPorcelainV2\` (clean / no-upstream / ahead-behind / staged-only / unstaged-only / MM-mix / untracked / renamed / forward-compat) — pass
- [x] Typecheck clean on @agi/cli
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)