### PR TITLE
feat(doctor): agi doctor logs — tail + crash-pattern classifier (s144 t581)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -985,6 +985,73 @@ export function redactConfig(value: unknown): unknown {
   return value;
 }
 
+// ---------------------------------------------------------------------------
+// `agi doctor logs` — Tail recent logs and classify by crash pattern (s144 t581)
+// ---------------------------------------------------------------------------
+
+/**
+ * Known crash patterns surfaced by `agi doctor logs`. The order is
+ * load-bearing: earlier entries win on ambiguous lines (e.g. a ZodError
+ * mention in an unhandledRejection log line classifies as schema-error,
+ * which is the more actionable category).
+ */
+export const LOG_PATTERNS = [
+  {
+    id: "schema-error",
+    label: "Schema validation error",
+    regex: /\bZod(Error|Issue)\b|schema validation (?:rejected|failed)/i,
+    repair: "Run `agi doctor schema` for the offending file. Cycle 150 caught a project.json drift this way.",
+  },
+  {
+    id: "port-conflict",
+    label: "Port already in use",
+    regex: /\bEADDRINUSE\b/i,
+    repair: "Another process is bound to the gateway port (default 3100). `lsof -iTCP:3100 -sTCP:LISTEN` to identify; stop it or change `gateway.port` in gateway.json.",
+  },
+  {
+    id: "segfault",
+    label: "Segfault / SIGSEGV",
+    regex: /\bsegfault\b|signal: SIGSEGV|core dumped/i,
+    repair: "Native crash. Capture `agi doctor dump` and the journalctl tail; likely a node-pty / podman / hf-runtime issue. Open an incident.",
+  },
+  {
+    id: "unhandled-rejection",
+    label: "Unhandled promise rejection",
+    regex: /unhandled\s*(?:promise\s*)?rejection|unhandledrejection/i,
+    repair: "Async error escaped a handler. Capture `agi doctor dump` for the stack; root-cause via the surrounding log lines.",
+  },
+  {
+    id: "container-exit-nonzero",
+    label: "Container exited non-zero",
+    regex: /\bexited (?:with )?(?:status |code )(?:[1-9]|\d{2,})\b|\bcontainer\b[^\n]*?\bexit\s+code\s+(?:[1-9]|\d{2,})\b/i,
+    repair: "A hosted-project or system-service container failed. `agi doctor` repos / hosting groups + `podman logs <name>` for context.",
+  },
+  {
+    id: "restart-loop",
+    label: "Restart loop / fuse popped",
+    regex: /restart\s*(?:count|loop)|fuse popped/i,
+    repair: "podman --restart=always is cycling a broken container. Hosting circuit-breaker (s143) should trip after 3 failures; if not, check the breaker state and reset.",
+  },
+  {
+    id: "oom",
+    label: "Out of memory",
+    regex: /\b(?:out of memory|OOM(?:Killer)?)\b|killed.*(?:memory|by\s+OOM)/i,
+    repair: "OOM killer activated. Check `free -m` and lemonade/HF model RAM ceilings; reduce model concurrency.",
+  },
+] as const;
+
+/**
+ * Classify a single log line by the first matching crash pattern.
+ * Returns `null` when no pattern matches. Pure function — pulled out
+ * for unit testing.
+ */
+export function classifyLogLine(line: string): string | null {
+  for (const p of LOG_PATTERNS) {
+    if (p.regex.test(line)) return p.id;
+  }
+  return null;
+}
+
 /** Read up to N most-recent lines of a file (best-effort). Returns [] on any error. */
 function tailFile(path: string, lines: number): string[] {
   try {
@@ -1240,6 +1307,76 @@ export function registerDoctorCommand(program: Command): void {
       } catch (err) {
         console.error(`${red("✗")} failed to write bundle: ${err instanceof Error ? err.message : String(err)}`);
         process.exitCode = 1;
+      }
+    });
+
+  // s144 t581 — `agi doctor logs` tails recent logs and classifies any
+  // matching crash patterns, with a repair pointer per pattern.
+  doctor
+    .command("logs")
+    .description("Tail recent logs and surface known crash patterns (ZodError, EADDRINUSE, segfault, OOM, container exit, restart loop)")
+    .option("--lines <n>", "Lines to inspect per log file (default 500)", "500")
+    .action((cmdOpts: { lines?: string }) => {
+      const linesPerFile = Math.max(50, Math.min(5000, Number(cmdOpts.lines ?? 500)));
+      const sources: { path: string; lines: string[] }[] = [];
+
+      // Collect from the same locations as `agi doctor dump`.
+      const logsDir = join(homedir(), ".agi", "logs");
+      if (existsSync(logsDir)) {
+        try {
+          const entries = readdirSync(logsDir).filter((f) => f.endsWith(".log") || f.endsWith(".jsonl"));
+          const ranked = entries.map((f) => {
+            const p = join(logsDir, f);
+            try { return { f, mtime: statSync(p).mtimeMs, path: p }; } catch { return { f, mtime: 0, path: p }; }
+          }).sort((a, b) => b.mtime - a.mtime).slice(0, 5);
+          for (const r of ranked) sources.push({ path: r.path, lines: tailFile(r.path, linesPerFile) });
+        } catch {
+          // ignore
+        }
+      }
+      const tmpLog = "/tmp/agi.log";
+      if (existsSync(tmpLog)) sources.push({ path: tmpLog, lines: tailFile(tmpLog, linesPerFile) });
+
+      // Bucket lines by pattern id.
+      const buckets = new Map<string, { count: number; samples: string[]; sources: Set<string> }>();
+      let totalLines = 0;
+      for (const src of sources) {
+        for (const raw of src.lines) {
+          if (raw.length === 0) continue;
+          totalLines++;
+          const id = classifyLogLine(raw);
+          if (!id) continue;
+          let bucket = buckets.get(id);
+          if (!bucket) {
+            bucket = { count: 0, samples: [], sources: new Set() };
+            buckets.set(id, bucket);
+          }
+          bucket.count++;
+          bucket.sources.add(src.path);
+          if (bucket.samples.length < 3) bucket.samples.push(raw.slice(0, 200));
+        }
+      }
+
+      console.log();
+      console.log(bold("  agi doctor logs"));
+      console.log(`  ${dim(`scanned ${String(totalLines)} lines across ${String(sources.length)} log file(s)`)}`);
+      console.log();
+
+      if (buckets.size === 0) {
+        console.log(`  ${green("No known crash patterns found")}`);
+        console.log();
+        return;
+      }
+
+      for (const pattern of LOG_PATTERNS) {
+        const bucket = buckets.get(pattern.id);
+        if (!bucket) continue;
+        console.log(`  ${red("✗")} ${bold(pattern.label)} ${dim(`(${String(bucket.count)} hit${bucket.count === 1 ? "" : "s"} across ${String(bucket.sources.size)} file${bucket.sources.size === 1 ? "" : "s"})`)}`);
+        for (const sample of bucket.samples) {
+          console.log(`    ${dim(sample)}`);
+        }
+        console.log(`    ${yellow("→")} ${pattern.repair}`);
+        console.log();
       }
     });
 }

--- a/cli/src/commands/log-classifier.test.ts
+++ b/cli/src/commands/log-classifier.test.ts
@@ -1,0 +1,83 @@
+/**
+ * classifyLogLine — crash-pattern classifier (s144 t581).
+ *
+ * The classifier maps a log line to a known pattern id (or null). Order
+ * matters: earlier patterns win on ambiguous lines (e.g. a ZodError mention
+ * inside an unhandled rejection log line classifies as `schema-error`,
+ * which is the more actionable category).
+ */
+
+import { describe, it, expect } from "vitest";
+import { classifyLogLine, LOG_PATTERNS } from "./doctor.js";
+
+describe("classifyLogLine (s144 t581)", () => {
+  it("returns null for non-matching lines", () => {
+    expect(classifyLogLine("[INFO] gateway listening on 127.0.0.1:3100")).toBe(null);
+    expect(classifyLogLine("")).toBe(null);
+    expect(classifyLogLine("regular debug output")).toBe(null);
+  });
+
+  it("classifies ZodError as schema-error", () => {
+    expect(classifyLogLine("ZodError: [{...}]")).toBe("schema-error");
+    expect(classifyLogLine("Error: ZodError at validateConfig")).toBe("schema-error");
+  });
+
+  it("classifies ZodIssue as schema-error", () => {
+    expect(classifyLogLine("Failed: ZodIssue: invalid_type")).toBe("schema-error");
+  });
+
+  it("classifies 'schema validation rejected' as schema-error", () => {
+    expect(classifyLogLine("project.json schema validation rejected")).toBe("schema-error");
+  });
+
+  it("classifies EADDRINUSE as port-conflict", () => {
+    expect(classifyLogLine("Error: listen EADDRINUSE: address already in use 127.0.0.1:3100")).toBe("port-conflict");
+  });
+
+  it("classifies segfault / SIGSEGV as segfault", () => {
+    expect(classifyLogLine("node[123]: segfault at 0x0")).toBe("segfault");
+    expect(classifyLogLine("Process killed with signal: SIGSEGV (core dumped)")).toBe("segfault");
+  });
+
+  it("classifies unhandled rejection in multiple shapes", () => {
+    expect(classifyLogLine("(node:123) UnhandledPromiseRejectionWarning: Error: ...")).toBe("unhandled-rejection");
+    expect(classifyLogLine("unhandledRejection at line 42")).toBe("unhandled-rejection");
+    expect(classifyLogLine("unhandled rejection: TypeError")).toBe("unhandled-rejection");
+  });
+
+  it("classifies non-zero container exit codes", () => {
+    expect(classifyLogLine("container 'agi-postgres' exited with code 137")).toBe("container-exit-nonzero");
+    expect(classifyLogLine("podman: container exit code 1")).toBe("container-exit-nonzero");
+  });
+
+  it("does NOT classify exit code 0 as container-exit-nonzero", () => {
+    expect(classifyLogLine("container 'foo' exited with code 0")).not.toBe("container-exit-nonzero");
+  });
+
+  it("classifies restart loop / fuse popped", () => {
+    expect(classifyLogLine("[hosting] restart loop detected for project 'web'")).toBe("restart-loop");
+    expect(classifyLogLine("podman: fuse popped after 5 restarts")).toBe("restart-loop");
+    expect(classifyLogLine("Container has restart count: 12 (threshold 3)")).toBe("restart-loop");
+  });
+
+  it("classifies OOM signals", () => {
+    expect(classifyLogLine("Out of memory: Killed process 12345")).toBe("oom");
+    expect(classifyLogLine("OOMKiller: terminated agi-gateway")).toBe("oom");
+    expect(classifyLogLine("ERROR: killed by OOM at runtime")).toBe("oom");
+  });
+
+  it("schema-error wins when both schema + unhandled-rejection match (load-bearing order)", () => {
+    // First-match-wins by LOG_PATTERNS order. schema-error is listed first.
+    const line = "UnhandledPromiseRejectionWarning: ZodError: invalid input";
+    expect(classifyLogLine(line)).toBe("schema-error");
+  });
+
+  it("each pattern in LOG_PATTERNS has a repair pointer", () => {
+    // Diagnostic patterns without repair pointers leave the operator
+    // stranded. Lock in the contract: every pattern must have one.
+    for (const p of LOG_PATTERNS) {
+      expect(p.repair, `pattern ${p.id} should have a repair pointer`).toMatch(/.+/);
+      expect(p.label.length, `pattern ${p.id} should have a label`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -138,6 +138,22 @@ The dump path is printed on stdout; share the file with whoever is helping
 diagnose. Sensitive values are redacted but log tails are not — review the
 bundle before sharing externally.
 
+#### agi doctor logs
+
+Tail recent logs and surface known crash patterns. Each match category
+includes a count, sample lines, and a pointer to the relevant repair
+surface. Categories: schema-error (ZodError / ZodIssue), port-conflict
+(EADDRINUSE), segfault, unhandled-rejection, container-exit-nonzero,
+restart-loop / fuse-popped, OOM.
+
+```bash
+agi doctor logs                # default 500 lines per file
+agi doctor logs --lines 2000   # cap is 5000 per file
+```
+
+Reads from `~/.agi/logs/` (top 5 most-recent .log/.jsonl files) and
+`/tmp/agi.log`. Pure pattern matching — no journalctl shell-out yet.
+
 ---
 
 ### agi config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.565",
+  "version": "0.4.566",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

New \`agi doctor logs\` reads recent logs (\`~/.agi/logs/\` top 5 + \`/tmp/agi.log\`, default 500 lines per file) and surfaces known crash patterns with per-category counts + sample lines + repair pointer.

Categories (first-match-wins): schema-error (ZodError/ZodIssue), port-conflict (EADDRINUSE), segfault, unhandled-rejection, container-exit-nonzero, restart-loop, oom. Each entry in \`LOG_PATTERNS\` has a label + regex + repair string; a contract test enforces all three are non-empty so the diagnostic never strands the operator.

The cycle-150 ZodError would surface here as **schema-error** → "Run \`agi doctor schema\` for the offending file."

Bump 0.4.565 → 0.4.566. s144 progress 5/10.

## Test plan

- [x] 13 new unit tests on \`classifyLogLine\` (null cases, each pattern, exit-code-0 negative, multi-shape rejection, ordering, LOG_PATTERNS contract) — pass
- [x] Typecheck clean on @agi/cli
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)