### PR TITLE
feat(doctor): container diagnostic — agi-* podman containers (s144 t576)

### DIFF
--- a/cli/src/commands/container-diagnostic.test.ts
+++ b/cli/src/commands/container-diagnostic.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Container diagnostic — normalizePodmanEntry + classifyContainer (s144 t576).
+ * Pure logic; runs on host.
+ */
+
+import { describe, it, expect } from "vitest";
+import { normalizePodmanEntry, classifyContainer, type ContainerSummary } from "./doctor.js";
+
+describe("normalizePodmanEntry (s144 t576)", () => {
+  it("parses canonical podman 4.x shape", () => {
+    const entry = {
+      Names: ["agi-postgres"],
+      State: "running",
+      Status: "Up 2 hours",
+      ExitCode: 0,
+      RestartCount: 0,
+      StartedAt: "2026-05-09T01:00:00Z",
+    };
+    expect(normalizePodmanEntry(entry)).toEqual({
+      name: "agi-postgres",
+      status: "Up 2 hours",
+      state: "running",
+      exitCode: 0,
+      restartCount: 0,
+      startedAt: "2026-05-09T01:00:00Z",
+    });
+  });
+
+  it("accepts lowercased keys (older podman versions)", () => {
+    const entry = {
+      names: "agi-caddy",
+      state: "exited",
+      status: "Exited (1) 5m ago",
+      exitcode: 1,
+      restartcount: 5,
+      startedat: "2026-05-09T00:00:00Z",
+    };
+    const r = normalizePodmanEntry(entry);
+    expect(r.name).toBe("agi-caddy");
+    expect(r.exitCode).toBe(1);
+    expect(r.restartCount).toBe(5);
+  });
+
+  it("falls back to safe defaults on missing fields", () => {
+    const r = normalizePodmanEntry({});
+    expect(r).toEqual({
+      name: "(unknown)",
+      status: "",
+      state: "",
+      exitCode: 0,
+      restartCount: 0,
+      startedAt: "",
+    });
+  });
+
+  it("coerces string-shaped numeric fields", () => {
+    const entry = { Names: ["x"], ExitCode: "137", RestartCount: "12" };
+    const r = normalizePodmanEntry(entry);
+    expect(r.exitCode).toBe(137);
+    expect(r.restartCount).toBe(12);
+  });
+});
+
+describe("classifyContainer (s144 t576)", () => {
+  const base: ContainerSummary = {
+    name: "agi-x",
+    status: "Up 1h",
+    state: "running",
+    exitCode: 0,
+    restartCount: 0,
+    startedAt: "2026-05-09T00:00:00Z",
+  };
+
+  it("running + clean restarts → ok", () => {
+    expect(classifyContainer(base)).toEqual({ ok: true, warn: false, reason: "running" });
+  });
+
+  it("stopped with non-zero exit → failing (not warn)", () => {
+    const c = { ...base, state: "exited", status: "Exited (137) 3m ago", exitCode: 137 };
+    const r = classifyContainer(c);
+    expect(r.ok).toBe(false);
+    expect(r.warn).toBe(false);
+    expect(r.reason).toContain("exit 137");
+  });
+
+  it("stopped with exit 0 → ok (intentional shutdown)", () => {
+    const c = { ...base, state: "exited", status: "Exited (0) 10m ago", exitCode: 0 };
+    expect(classifyContainer(c).ok).toBe(true);
+  });
+
+  it("running but restart count > 3 → warn (flapping)", () => {
+    const c = { ...base, restartCount: 5 };
+    const r = classifyContainer(c);
+    expect(r.ok).toBe(false);
+    expect(r.warn).toBe(true);
+    expect(r.reason).toContain("flapping");
+    expect(r.reason).toContain("5 restarts");
+  });
+
+  it("running with restartCount === 3 → still ok (boundary)", () => {
+    expect(classifyContainer({ ...base, restartCount: 3 }).ok).toBe(true);
+  });
+
+  it("treats Status='Up …' as running even when state field is missing", () => {
+    const c = { ...base, state: "", status: "Up 5 minutes" };
+    expect(classifyContainer(c).ok).toBe(true);
+  });
+
+  it("running + non-zero exitCode counted historical → still warn-by-flapping if restarts >3", () => {
+    // Containers can be "running" again after a non-zero exit was recorded
+    // before the restart. We don't penalize the historical exit if the
+    // container is back up with low restart count.
+    const c = { ...base, exitCode: 1, restartCount: 1 };
+    expect(classifyContainer(c).ok).toBe(true);
+  });
+});

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -471,6 +471,116 @@ function inspectCertFile(path: string): { subject: string; daysUntilExpiry: numb
   }
 }
 
+// ---------------------------------------------------------------------------
+// Container diagnostics — agi-* podman containers (s144 t576)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-container summary derived from `podman ps -a --format json`.
+ * Pulled out as a typed shape so the parser can be unit-tested without
+ * a real podman call.
+ */
+export interface ContainerSummary {
+  name: string;
+  status: string;
+  state: string;
+  exitCode: number;
+  restartCount: number;
+  startedAt: string;
+}
+
+/**
+ * Normalize a single entry from `podman ps -a --format json` into the
+ * fields we surface. podman's JSON output has historically varied across
+ * versions in casing (Names vs names, ExitCode vs exitcode); this
+ * accepts the union shapes and falls back to safe defaults.
+ */
+export function normalizePodmanEntry(entry: Record<string, unknown>): ContainerSummary {
+  const namesField = (entry["Names"] ?? entry["names"]) as unknown;
+  const name = Array.isArray(namesField)
+    ? (namesField[0] as string | undefined) ?? "(unknown)"
+    : typeof namesField === "string" ? namesField : "(unknown)";
+  const status = String(entry["Status"] ?? entry["status"] ?? "");
+  const state = String(entry["State"] ?? entry["state"] ?? "");
+  const exitCodeRaw = entry["ExitCode"] ?? entry["exitcode"] ?? entry["exitCode"] ?? 0;
+  const exitCode = typeof exitCodeRaw === "number" ? exitCodeRaw : Number(exitCodeRaw) || 0;
+  const restartRaw = entry["RestartCount"] ?? entry["restartcount"] ?? entry["restartCount"] ?? 0;
+  const restartCount = typeof restartRaw === "number" ? restartRaw : Number(restartRaw) || 0;
+  const startedAt = String(entry["StartedAt"] ?? entry["startedat"] ?? entry["startedAt"] ?? "");
+  return { name, status, state, exitCode, restartCount, startedAt };
+}
+
+/**
+ * Classify a container as healthy / warn / failing for the diagnostic.
+ *   - failing: state !== running AND exitCode !== 0 (truly broken)
+ *   - warn:    running but restartCount > 3 (flapping under --restart=always)
+ *   - ok:      everything else
+ */
+export function classifyContainer(c: ContainerSummary): { ok: boolean; warn: boolean; reason: string } {
+  const stateLower = c.state.toLowerCase();
+  const isRunning = stateLower === "running" || c.status.toLowerCase().startsWith("up");
+  if (!isRunning && c.exitCode !== 0) {
+    return {
+      ok: false,
+      warn: false,
+      reason: `${c.state || "stopped"} (exit ${String(c.exitCode)})`,
+    };
+  }
+  if (isRunning && c.restartCount > 3) {
+    return {
+      ok: false,
+      warn: true,
+      reason: `running but flapping (${String(c.restartCount)} restarts)`,
+    };
+  }
+  return {
+    ok: true,
+    warn: false,
+    reason: isRunning ? "running" : c.state || c.status || "stopped",
+  };
+}
+
+function containerChecks(): CheckGroup | null {
+  let raw = "";
+  try {
+    raw = execFileSync("podman", ["ps", "-a", "--filter", "name=agi-", "--format", "json"], {
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+  } catch {
+    return null; // podman not installed or not reachable — surfaced by core checks
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+
+  const containers = parsed.map((e) => normalizePodmanEntry(e as Record<string, unknown>));
+  if (containers.length === 0) {
+    // No agi-* containers — fresh install or all stopped + removed. Don't
+    // emit an empty group; surface only when there's something material.
+    return null;
+  }
+
+  const checks: Check[] = [];
+  for (const c of containers) {
+    const verdict = classifyContainer(c);
+    checks.push({
+      name: `${c.name} — ${verdict.reason}`,
+      ok: verdict.ok,
+      warn: verdict.warn,
+      fix: verdict.ok ? undefined : "Repair: force-remove / recreate / podman logs <name> via `agi doctor` TUI (s144 t574)",
+    });
+  }
+
+  return { title: "Containers (agi-*)", checks };
+}
+
 function networkChecks(): CheckGroup | null {
   const checks: Check[] = [];
 
@@ -1082,6 +1192,8 @@ async function runDoctorDump(opts: { config?: string }): Promise<string> {
     groups.push(pluginChecks());
     const network = networkChecks();
     if (network) groups.push(network);
+    const containers = containerChecks();
+    if (containers) groups.push(containers);
     const hosting = hostingChecks(config);
     if (hosting) groups.push(hosting);
     const shape = await projectShapeChecks(config);
@@ -1193,6 +1305,9 @@ export function registerDoctorCommand(program: Command): void {
 
         const network = networkChecks();
         if (network) groups.push(network);
+
+        const containers = containerChecks();
+        if (containers) groups.push(containers);
 
         const hosting = hostingChecks(config);
         if (hosting) groups.push(hosting);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.566",
+  "version": "0.4.567",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

New "Containers (agi-*)" check group in \`agi doctor\` runs \`podman ps -a --filter name=agi- --format json\` and classifies each per-container:

- **failing**: stopped + non-zero exit code
- **warn**: running but restartCount > 3 (flapping)
- **ok**: everything else (including stopped with exit 0 — intentional)

\`normalizePodmanEntry\` tolerates podman key-casing variation across versions and coerces string-numeric fields. Empty agi-* set returns null (no noisy yellow on fresh installs). Repair actions (force-remove / recreate / podman logs / exec shell) deferred to t574 TUI. Auto-included in \`agi doctor\` AND \`agi doctor dump\`.

Bump 0.4.566 → 0.4.567. s144 progress 6/10.

## Test plan

- [x] 11 new unit tests on normalizer + classifier (canonical / lowercase / missing / coerced / running-clean / stopped-failing / stopped-clean-exit-0 / flapping / boundary at restartCount=3 / Status-fallback / recovered) — pass
- [x] Typecheck clean on @agi/cli
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)