### PR TITLE
feat(doctor): agi doctor config get/set with Zod-validated rollback (s144 t578)

### DIFF
--- a/cli/src/commands/config-edit.test.ts
+++ b/cli/src/commands/config-edit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * agi doctor config get/set helper tests (s144 t578).
+ *
+ * Pure-logic helpers for the safe-edit cycle: getDottedPath / setDottedPath
+ * / coerceValue. The Zod-validated rollback flow is exercised end-to-end
+ * via the CLI command; these tests pin the building blocks.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getDottedPath, setDottedPath, coerceValue } from "./doctor.js";
+
+describe("getDottedPath (s144 t578)", () => {
+  it("reads top-level keys", () => {
+    expect(getDottedPath({ a: 1, b: 2 }, "a")).toBe(1);
+    expect(getDottedPath({ a: 1 }, "b")).toBe(undefined);
+  });
+
+  it("reads nested paths", () => {
+    expect(getDottedPath({ gateway: { port: 3100 } }, "gateway.port")).toBe(3100);
+    expect(getDottedPath({ a: { b: { c: "deep" } } }, "a.b.c")).toBe("deep");
+  });
+
+  it("returns undefined when an intermediate segment is missing", () => {
+    expect(getDottedPath({ gateway: {} }, "gateway.port")).toBe(undefined);
+    expect(getDottedPath({ x: { y: null } }, "x.y.z")).toBe(undefined);
+  });
+
+  it("returns the whole object on empty path", () => {
+    const obj = { a: 1 };
+    expect(getDottedPath(obj, "")).toBe(obj);
+  });
+
+  it("does not crash on null/undefined input", () => {
+    expect(getDottedPath(null, "a")).toBe(undefined);
+    expect(getDottedPath(undefined, "a")).toBe(undefined);
+    expect(getDottedPath(42 as unknown, "a")).toBe(undefined);
+  });
+});
+
+describe("setDottedPath (s144 t578)", () => {
+  it("sets a top-level key on a clone (does not mutate input)", () => {
+    const obj = { a: 1, b: 2 };
+    const out = setDottedPath(obj, "a", 99) as Record<string, unknown>;
+    expect(out).toEqual({ a: 99, b: 2 });
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+
+  it("creates intermediate objects when missing", () => {
+    const obj = {} as Record<string, unknown>;
+    const out = setDottedPath(obj, "gateway.tls.cert", "/etc/cert.pem") as Record<string, unknown>;
+    expect(out).toEqual({ gateway: { tls: { cert: "/etc/cert.pem" } } });
+    expect(obj).toEqual({}); // input untouched
+  });
+
+  it("overwrites a non-object intermediate with an object before descending", () => {
+    const obj = { a: "scalar" };
+    const out = setDottedPath(obj, "a.b.c", 1) as Record<string, unknown>;
+    expect(out).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  it("preserves siblings when setting nested values", () => {
+    const obj = { gateway: { port: 3100, host: "127.0.0.1" } };
+    const out = setDottedPath(obj, "gateway.port", 4100) as Record<string, unknown>;
+    expect(out).toEqual({ gateway: { port: 4100, host: "127.0.0.1" } });
+  });
+
+  it("can replace deep values with arrays/objects", () => {
+    const obj = { workspace: { projects: ["/a"] } };
+    const out = setDottedPath(obj, "workspace.projects", ["/b", "/c"]) as Record<string, unknown>;
+    expect(out).toEqual({ workspace: { projects: ["/b", "/c"] } });
+  });
+
+  it("returns the new value when path is empty", () => {
+    expect(setDottedPath({ a: 1 }, "", { b: 2 })).toEqual({ b: 2 });
+  });
+});
+
+describe("coerceValue (s144 t578)", () => {
+  it("parses booleans and null", () => {
+    expect(coerceValue("true")).toBe(true);
+    expect(coerceValue("false")).toBe(false);
+    expect(coerceValue("null")).toBe(null);
+  });
+
+  it("parses safe-integer strings as numbers", () => {
+    expect(coerceValue("0")).toBe(0);
+    expect(coerceValue("3100")).toBe(3100);
+    expect(coerceValue("-1")).toBe(-1);
+  });
+
+  it("does NOT parse floats as numbers (no decimal regex)", () => {
+    // Float coercion is intentionally excluded — config values are
+    // virtually always integers (ports, counts, timeouts).
+    expect(coerceValue("3.14")).toBe("3.14");
+  });
+
+  it("rejects out-of-range integers, falls back to string", () => {
+    expect(coerceValue("99999999999999999999")).toBe("99999999999999999999");
+  });
+
+  it("parses JSON object/array literals", () => {
+    expect(coerceValue('{"a":1}')).toEqual({ a: 1 });
+    expect(coerceValue("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("returns the raw string when JSON parse fails", () => {
+    expect(coerceValue("{not valid")).toBe("{not valid");
+    expect(coerceValue("[also not")).toBe("[also not");
+  });
+
+  it("treats arbitrary strings verbatim", () => {
+    expect(coerceValue("/etc/cert.pem")).toBe("/etc/cert.pem");
+    expect(coerceValue("aionima")).toBe("aionima");
+    expect(coerceValue("")).toBe("");
+  });
+});

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -11,7 +11,7 @@ import type { Command } from "commander";
 import { loadConfig, validateConfigFile } from "../config-loader.js";
 import { GatewayClient } from "../gateway-client.js";
 import { bold, dim, formatCheck, green, red, yellow } from "../output.js";
-import type { AionimaConfig } from "@agi/config";
+import { AionimaConfigSchema, type AionimaConfig } from "@agi/config";
 
 interface Check {
   name: string;
@@ -1096,6 +1096,71 @@ export function redactConfig(value: unknown): unknown {
 }
 
 // ---------------------------------------------------------------------------
+// `agi doctor config get/set` — Safe edit cycle for gateway.json (s144 t578)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a dotted path out of a nested object. Returns `undefined` on any
+ * missing segment. Pure function for testability.
+ */
+export function getDottedPath(obj: unknown, path: string): unknown {
+  if (path.length === 0) return obj;
+  const parts = path.split(".");
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+/**
+ * Immutably set a dotted path on a deep clone of `obj`. Creates
+ * intermediate objects as needed. Returns the new root. Pure function.
+ */
+export function setDottedPath(obj: unknown, path: string, value: unknown): unknown {
+  if (path.length === 0) return value;
+  // Deep-ish clone via JSON round-trip. Sufficient for plain config
+  // shapes — gateway.json never contains functions, Maps, or Dates.
+  const cloned: Record<string, unknown> = obj && typeof obj === "object"
+    ? JSON.parse(JSON.stringify(obj)) as Record<string, unknown>
+    : {};
+  const parts = path.split(".");
+  let cur: Record<string, unknown> = cloned;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const p = parts[i]!;
+    const next = cur[p];
+    if (next === null || typeof next !== "object" || Array.isArray(next)) {
+      cur[p] = {};
+    }
+    cur = cur[p] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]!] = value;
+  return cloned;
+}
+
+/**
+ * Coerce a raw CLI value to the most useful JSON-typed shape:
+ *   "true"/"false" → boolean; integer string → number; "null" → null;
+ *   "{...}" or "[...]" parses as JSON; anything else → string verbatim.
+ * Operators commonly want `agi doctor config set gateway.port 4100` to
+ * write a number, not the string "4100" — same intuition for booleans.
+ */
+export function coerceValue(raw: string): unknown {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null") return null;
+  if (/^-?\d+$/.test(raw)) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && Number.isSafeInteger(n)) return n;
+  }
+  if (raw.length > 0 && (raw[0] === "{" || raw[0] === "[")) {
+    try { return JSON.parse(raw) as unknown; } catch { /* fallthrough */ }
+  }
+  return raw;
+}
+
+// ---------------------------------------------------------------------------
 // `agi doctor logs` — Tail recent logs and classify by crash pattern (s144 t581)
 // ---------------------------------------------------------------------------
 
@@ -1492,6 +1557,78 @@ export function registerDoctorCommand(program: Command): void {
         }
         console.log(`    ${yellow("→")} ${pattern.repair}`);
         console.log();
+      }
+    });
+
+  // s144 t578 — `agi doctor config get/set` for safe edits to gateway.json
+  // (interactive editor variant lands with t574 TUI). Validates the full
+  // config via Zod before writing; rolls back on validation failure so the
+  // file on disk never enters an invalid state mid-edit.
+  const configSub = doctor
+    .command("config")
+    .description("Inspect or edit gateway.json keys with Zod-validated rollback");
+
+  configSub
+    .command("get <path>")
+    .description("Read a dotted path out of gateway.json (e.g. gateway.port)")
+    .action(async (path: string) => {
+      const opts = program.opts<{ config?: string }>();
+      try {
+        const result = await loadConfig(opts.config);
+        const value = getDottedPath(result.config as unknown, path);
+        if (value === undefined) {
+          console.log(`${dim("(unset)")}`);
+          process.exitCode = 1;
+          return;
+        }
+        // Print primitives raw; objects/arrays as JSON.
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) {
+          console.log(String(value));
+        } else {
+          console.log(JSON.stringify(value, null, 2));
+        }
+      } catch (err) {
+        console.error(`${red("✗")} ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+
+  configSub
+    .command("set <path> <value>")
+    .description("Set a dotted path in gateway.json. Validates against AionimaConfigSchema before writing; rolls back on failure. Coerces 'true'/'false'/'null'/integers/JSON automatically.")
+    .action(async (path: string, value: string) => {
+      const opts = program.opts<{ config?: string }>();
+      try {
+        const result = await loadConfig(opts.config);
+        const previous = getDottedPath(result.config as unknown, path);
+        const coerced = coerceValue(value);
+        const candidate = setDottedPath(result.config as unknown, path, coerced);
+
+        // Validate the FULL candidate config — this catches type
+        // mismatches AND cross-field invariants that single-key
+        // validation would miss.
+        const parsed = AionimaConfigSchema.safeParse(candidate);
+        if (!parsed.success) {
+          console.error(`${red("✗")} Validation failed — gateway.json NOT modified.`);
+          for (const issue of parsed.error.issues) {
+            const where = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+            console.error(`  ${red("•")} ${where}: ${issue.message}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        // Validation passed — atomic write via temp + rename.
+        const tmpPath = `${result.path}.tmp.${String(process.pid)}`;
+        writeFileSync(tmpPath, JSON.stringify(candidate, null, 2) + "\n", "utf-8");
+        execFileSync("mv", [tmpPath, result.path], { stdio: ["ignore", "ignore", "ignore"] });
+
+        console.log(`${green("✓")} ${path} = ${typeof coerced === "string" ? JSON.stringify(coerced) : String(coerced)}`);
+        console.log(`  ${dim(`previous: ${previous === undefined ? "(unset)" : typeof previous === "string" ? JSON.stringify(previous) : String(previous)}`)}`);
+        console.log(`  ${dim(`written: ${result.path}`)}`);
+      } catch (err) {
+        console.error(`${red("✗")} ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
       }
     });
 }

--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -138,6 +138,27 @@ The dump path is printed on stdout; share the file with whoever is helping
 diagnose. Sensitive values are redacted but log tails are not — review the
 bundle before sharing externally.
 
+#### agi doctor config
+
+Safe-edit cycle for `gateway.json` keys: read or write a single dotted-path
+value, with full-config Zod validation before writing. The file on disk
+never enters an invalid state mid-edit — validation failure rolls back
+without touching `gateway.json`.
+
+```bash
+agi doctor config get gateway.port
+agi doctor config set gateway.port 4100
+agi doctor config set workspace.projects '["/srv/proj-a","/srv/proj-b"]'
+```
+
+`set` coerces values automatically: `true`/`false` → boolean, integer
+strings → number, `null` → null, JSON object/array literals are parsed,
+anything else stays a string. Atomic write via temp + rename so an
+interrupted command can't corrupt the file.
+
+The interactive editor variant (open a chosen key in `$EDITOR`) lands
+with the `agi doctor` TUI in s144 t574.
+
 #### agi doctor logs
 
 Tail recent logs and surface known crash patterns. Each match category

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.567",
+  "version": "0.4.568",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Non-interactive safe-edit cycle for \`gateway.json\`:
- \`agi doctor config get gateway.port\` — read dotted path
- \`agi doctor config set gateway.port 4100\` — write with FULL-config Zod validation before commit. Validation failure: per-issue path + message printed, gateway.json untouched. Validation success: atomic write via temp + rename.

Auto-coercion: \`true\`/\`false\` → boolean, \`null\` → null, safe-integer strings → number, \`{...}\`/\`[...]\` → parsed JSON, anything else → string verbatim.

Interactive \`$EDITOR\` variant deferred to t574 TUI shell.

Bump 0.4.567 → 0.4.568. s144 progress 7/10.

## Test plan

- [x] 18 new unit tests on getDottedPath / setDottedPath / coerceValue (top-level / nested / missing / empty-path / non-object input / immutability / sibling preservation / all coercion branches / JSON-fallback-to-string) — pass
- [x] Typecheck clean on @agi/cli
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [ ] Manual: \`set\` with bad value (e.g. \`gateway.port "not a number"\`) leaves gateway.json untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)