### PR TITLE
docs(pm-tool): make plans + always-on PM-Lite explicit (s155 t666)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.568",
+  "version": "0.4.569",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -2500,19 +2500,23 @@ export async function startGatewayServer(
     {
       name: "pm",
       description:
-        "The single project-management entryway with many functions. " +
-        "Always works — the file-based PM-Lite floor handles every read/write when no remote PM provider " +
-        "(tynn / linear / jira / …) is configured or reachable. " +
+        "The single project-management entryway. ALWAYS available — no flag, no fallback to invent your own tracking. " +
+        "PM-Lite (file-based, per-project k/pm/) is wired as a permanent floor on top of which the configured remote provider " +
+        "(tynn / linear / jira / GitHub Projects / …) layers when reachable; reads fall through to PM-Lite on remote failure, " +
+        "writes always land in PM-Lite (and propagate to remote when configured). PM-Lite is part of the contract, not a fallback. " +
         "Tasks/stories/comments: 'next' (active version + top story + tasks), 'task'/'story' (lookup by id or number), " +
         "'find-tasks' (filtered list), 'comments' (entity audit trail), " +
         "'start-task'/'testing'/'finished'/'block' (status transitions), " +
-        "'update-task' (modify fields), 'create-task'/'comment'/'iwish' (create entities), " +
+        "'update-task' (modify fields), 'create-task'/'comment' (create entities), " +
+        "'iwish' (declare an outcome the agent doesn't know how to action yet — captures intent for later triage), " +
         "'progress' (race-to-DONE counts for active focus). " +
-        "Plans (file-based, per-project k/plans/, ALWAYS available regardless of remote provider): " +
+        "Plans (file-based, per-project k/plans/, ALWAYS available regardless of remote provider's capabilities — " +
+        "remote PM tools rarely model plans, so plans live in PM-Lite by definition): " +
         "'plan-list' (list all plans for a projectPath), 'plan-get' (fetch by planId), " +
         "'plan-create' (new plan), 'plan-update' (status/steps/body). " +
         "Use this tool whenever you need to query or update the project's tracked work or recall a plan — " +
-        "never invent your own task tracking, and never assume tynn is the only PM provider.",
+        "never invent your own task tracking, never assume tynn (or any single backend) is the only provider, " +
+        "never wait for a remote PM to be reachable before recording state — PM-Lite always accepts the write.",
       requiresState: [],
       requiresTier: [],
     },


### PR DESCRIPTION
## Summary

Pure description change to the \`pm\` agent tool registration. Makes the contract explicit so the agent sees:

- **ALWAYS available** — no flag, no fallback to inventing your own tracking.
- **PM-Lite is part of the contract, not a fallback** — wired permanently as the file-based floor.
- **Layered semantics** — reads fall through on remote failure; writes always land in PM-Lite (and propagate to remote when configured).
- **Plans live in PM-Lite by definition** — remote PM tools rarely model plans.
- **\`iwish\`** — declare an outcome the agent doesn't know how to action yet.

Pure-description change. No schema, code path, or test surface modified. Bump 0.4.568 → 0.4.569. s155 progress: t666 closes.

## Test plan

- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)