### PR TITLE
feat(help): page-context resolver for help-mode chat agent (s137 t530)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.569",
+  "version": "0.4.570",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/lib/help-context.test.ts
+++ b/ui/dashboard/src/lib/help-context.test.ts
@@ -1,0 +1,66 @@
+/**
+ * resolveHelpContext tests (s137 t530). Pure-logic; runs on host.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveHelpContext } from "./help-context.js";
+
+describe("resolveHelpContext (s137 t530)", () => {
+  it("maps known top-level routes to descriptive strings", () => {
+    expect(resolveHelpContext("/")).toBe("dashboard overview");
+    expect(resolveHelpContext("/projects")).toBe("projects browser");
+    expect(resolveHelpContext("/settings/providers")).toBe("providers + models management");
+    expect(resolveHelpContext("/system/services")).toBe("system services + circuit breakers");
+    expect(resolveHelpContext("/marketplace")).toBe("Plugin Marketplace catalog");
+  });
+
+  it("normalizes trailing slashes (except for root)", () => {
+    expect(resolveHelpContext("/projects/")).toBe("projects browser");
+    expect(resolveHelpContext("/")).toBe("dashboard overview");
+  });
+
+  it("flattens /projects/:slug to a project workspace string", () => {
+    expect(resolveHelpContext("/projects/my-app")).toBe('workspace for project "my-app"');
+    expect(resolveHelpContext("/projects/scope%2Fsub")).toBe('workspace for project "scope/sub"');
+  });
+
+  it("flattens /projects/:slug/:tab to a per-tab string", () => {
+    expect(resolveHelpContext("/projects/my-app/files")).toBe('files tab in workspace "my-app"');
+    expect(resolveHelpContext("/projects/my-app/hosting/manage")).toBe('hosting/manage tab in workspace "my-app"');
+  });
+
+  it("flattens marketplace detail routes", () => {
+    expect(resolveHelpContext("/marketplace/plugins/postgres-stack")).toBe('plugin "postgres-stack" detail');
+    expect(resolveHelpContext("/marketplace/mapps/whodb")).toBe('MApp "whodb" detail');
+  });
+
+  it("flattens entity / comms / knowledge / docs detail routes", () => {
+    expect(resolveHelpContext("/entity/E0")).toBe('entity "E0" detail');
+    expect(resolveHelpContext("/comms/slack")).toBe("comms — slack channel");
+    expect(resolveHelpContext("/knowledge/aion-prime")).toBe('knowledge namespace "aion-prime"');
+    expect(resolveHelpContext("/docs/getting-started")).toBe("docs reader: getting-started");
+    expect(resolveHelpContext("/docs/agents/system-prompt-assembly.md")).toBe("docs reader: agents/system-prompt-assembly.md");
+  });
+
+  it("flattens MApp editor route", () => {
+    expect(resolveHelpContext("/mapp-editor/sample-app")).toBe('MApp editor for "sample-app"');
+  });
+
+  it("falls back to 'unknown route <path>' for routes not yet listed", () => {
+    expect(resolveHelpContext("/some/new/page")).toBe("unknown route /some/new/page");
+    expect(resolveHelpContext("/x")).toBe("unknown route /x");
+  });
+
+  it("handles empty / non-string input safely", () => {
+    expect(resolveHelpContext("")).toBe("unknown route");
+    expect(resolveHelpContext(undefined as unknown as string)).toBe("unknown route");
+    expect(resolveHelpContext(null as unknown as string)).toBe("unknown route");
+  });
+
+  it("static-route match wins over pattern-route match (for routes that look ambiguous)", () => {
+    // /knowledge is a static route ("knowledge namespaces"). /knowledge/foo
+    // matches the pattern. Verifying both render correctly.
+    expect(resolveHelpContext("/knowledge")).toBe("knowledge namespaces");
+    expect(resolveHelpContext("/knowledge/aion-prime")).toBe('knowledge namespace "aion-prime"');
+  });
+});

--- a/ui/dashboard/src/lib/help-context.ts
+++ b/ui/dashboard/src/lib/help-context.ts
@@ -1,0 +1,87 @@
+/**
+ * resolveHelpContext — map a dashboard route to a human-readable context
+ * string for the help-mode chat agent (s137 t530).
+ *
+ * The help button passes this string (prefixed with "help:") into the chat
+ * context so Aion knows what page the user is looking at without us having
+ * to hard-code per-page help strings. Dynamic segments (e.g. `:slug`,
+ * `:id`) are flattened so the help agent gets a stable context.
+ *
+ * Pure function — no React imports, no DOM access. Unit-testable on host.
+ */
+
+const STATIC_ROUTES: Record<string, string> = {
+  "/": "dashboard overview",
+  "/dashboard": "dashboard overview",
+  "/overview": "dashboard overview",
+  "/projects": "projects browser",
+  "/marketplace": "Plugin Marketplace catalog",
+  "/marketplace/plugins": "Plugin Marketplace catalog",
+  "/mapp-marketplace": "MApp Marketplace catalog",
+  "/marketplace/mapps": "MApp Marketplace catalog",
+  "/aionima": "Aionima collection (core repos + PRIME)",
+  "/pax": "particle-academy packages",
+  "/comms": "comms (channels) overview",
+  "/workflows": "workflow definitions",
+  "/logs": "logs viewer",
+  "/onboarding": "gateway onboarding",
+  "/notifications": "notifications inbox",
+  "/skills": "skills catalog",
+  "/knowledge": "knowledge namespaces",
+  "/docs": "documentation reader",
+  "/coa": "Chain of Accountability ledger",
+  "/sandbox": "sandbox (experimentation surface)",
+  "/incidents": "incidents log",
+  "/system/services": "system services + circuit breakers",
+  "/system/agents": "system agents",
+  "/system/incidents": "system incidents",
+  "/system/identity": "identity + federation",
+  "/system/changelog": "changelog",
+  "/system/security": "security posture",
+  "/system/backups": "backup status",
+  "/system/vendors": "vendor registry",
+  "/settings": "settings overview",
+  "/settings/gateway": "gateway settings",
+  "/settings/providers": "providers + models management",
+  "/settings/scheduled-jobs": "scheduled jobs",
+  "/settings/themes": "theme settings",
+  "/settings/user": "user settings",
+  "/admin": "admin dashboard",
+  "/admin/dashboard": "admin dashboard",
+  "/prompt-inspector": "prompt inspector (Aion's prompt assembly)",
+};
+
+/**
+ * Pattern-based routes — checked in order. First match wins. Dynamic
+ * segments are flattened to readable strings via the label function.
+ */
+const PATTERN_ROUTES: Array<{ regex: RegExp; label: (m: RegExpMatchArray) => string }> = [
+  // /projects/<slug or path>
+  { regex: /^\/projects\/([^/]+)$/, label: (m) => `workspace for project "${decodeURIComponent(m[1] ?? "")}"` },
+  { regex: /^\/projects\/([^/]+)\/(.+)$/, label: (m) => `${decodeURIComponent(m[2] ?? "")} tab in workspace "${decodeURIComponent(m[1] ?? "")}"` },
+  { regex: /^\/marketplace\/plugins\/([^/]+)$/, label: (m) => `plugin "${decodeURIComponent(m[1] ?? "")}" detail` },
+  { regex: /^\/marketplace\/mapps\/([^/]+)$/, label: (m) => `MApp "${decodeURIComponent(m[1] ?? "")}" detail` },
+  { regex: /^\/mapp-editor\/([^/]+)$/, label: (m) => `MApp editor for "${decodeURIComponent(m[1] ?? "")}"` },
+  { regex: /^\/entity\/([^/]+)$/, label: (m) => `entity "${decodeURIComponent(m[1] ?? "")}" detail` },
+  { regex: /^\/comms\/([^/]+)$/, label: (m) => `comms — ${decodeURIComponent(m[1] ?? "")} channel` },
+  { regex: /^\/knowledge\/([^/]+)$/, label: (m) => `knowledge namespace "${decodeURIComponent(m[1] ?? "")}"` },
+  { regex: /^\/docs\/(.+)$/, label: (m) => `docs reader: ${decodeURIComponent(m[1] ?? "")}` },
+];
+
+/**
+ * Map a pathname to a help-context string. Falls back to `unknown route
+ * <pathname>` so the help agent always gets something rather than nothing.
+ */
+export function resolveHelpContext(pathname: string): string {
+  if (typeof pathname !== "string" || pathname.length === 0) return "unknown route";
+  // Trim trailing slashes for normalization (except for "/").
+  const normalized = pathname.length > 1 && pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+  if (normalized in STATIC_ROUTES) return STATIC_ROUTES[normalized] as string;
+  for (const entry of PATTERN_ROUTES) {
+    const m = normalized.match(entry.regex);
+    if (m) return entry.label(m);
+  }
+  return `unknown route ${normalized}`;
+}

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -37,6 +37,7 @@ import { checkForUpdates, startUpgrade, fetchUpgradeLog, fetchNotifications, mar
 import type { ProviderBalance } from "@/api.js";
 import { LoginPage } from "@/components/LoginPage.js";
 import type { ActivityEntry, DashboardEvent, Notification, ProjectActivity, TimeBucket, UpdateCheck } from "@/types.js";
+import { resolveHelpContext } from "@/lib/help-context.js";
 
 export type View = "overview" | "entity" | "coa" | "settings" | "logs" | "projects" | "system";
 
@@ -757,7 +758,11 @@ export default function RootLayout() {
                 as the agent can read it. */}
             <button
               onClick={() => {
-                setChatContext(`help:${location.pathname}`);
+                // s137 t530 — resolve route → human-readable help context
+                // string instead of the raw pathname. The help agent gets
+                // a stable description (e.g. "providers + models
+                // management") regardless of dynamic segments in the URL.
+                setChatContext(`help:${resolveHelpContext(location.pathname)}`);
                 setChatOpen(true);
               }}
               className="p-2 rounded-lg transition-colors text-subtext0 hover:bg-surface0 hover:text-text"


### PR DESCRIPTION
## Summary

Replaces raw-pathname forwarding in the header help button with a proper route → human-readable context-string mapping. The help agent receives "providers + models management" instead of the raw URL — stable context across dynamic segments.

- **STATIC_ROUTES** (40 entries) for known top-level + nested surfaces.
- **PATTERN_ROUTES** (9 entries) for dynamic-segment routes (\`/projects/:slug\`, marketplace detail, \`/entity/:id\`, \`/comms/:channel\`, etc.).
- **Fallback** \`unknown route <pathname>\` so the agent always gets context.

Pure module — no React imports, no DOM access. Wired into the existing help button. The chat-context plumbing on the agent side (interpreting the \`help:\` prefix) lands with t532 (help-mode chat agent).

Bump 0.4.569 → 0.4.570. s137 progress 2/5.

## Test plan

- [x] 10 new unit tests on \`resolveHelpContext\` (static / trailing slash / dynamic flatten / nested tabs / URL-decoded slugs / marketplace + entity + comms + knowledge + docs + mapp-editor patterns / fallback / null-input safety / static-vs-pattern precedence) — pass
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [ ] Manual: click help button on /settings/providers, observe context "providers + models management"

🤖 Generated with [Claude Code](https://claude.com/claude-code)