### PR TITLE
refactor(modal): ProjectPickerDialog → PAx Modal (s142 t559 — closes a11y bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.572",
+  "version": "0.4.573",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ProjectPickerDialog.tsx
+++ b/ui/dashboard/src/components/ProjectPickerDialog.tsx
@@ -4,9 +4,16 @@
  *
  * When an `app` is provided, projects are filtered to only show those
  * compatible with the MApp's declared projectTypes/projectCategories.
+ *
+ * s142 t559 — refactored from a hand-rolled `fixed inset-0` overlay to
+ * `@particle-academy/react-fancy` Modal. Gains focus trap, body-scroll
+ * lock, ARIA `role="dialog"` + `aria-modal="true"`, and ESC-to-close
+ * for free. (Replaces the keyboard-tab-out-of-modal bug surface caught
+ * by the t557 audit.)
  */
 
 import { useState } from "react";
+import { Modal } from "@particle-academy/react-fancy";
 import { Button } from "@/components/ui/button.js";
 import type { MagicAppInfo, ProjectInfo } from "@/types.js";
 
@@ -23,8 +30,6 @@ export interface ProjectPickerDialogProps {
 export function ProjectPickerDialog({ open, onSelect, onClose, projects, title, app }: ProjectPickerDialogProps) {
   const [filter, setFilter] = useState("");
 
-  if (!open) return null;
-
   // Filter by MApp compatibility when an app is specified
   let compatible = projects;
   if (app) {
@@ -40,12 +45,9 @@ export function ProjectPickerDialog({ open, onSelect, onClose, projects, title, 
     : compatible;
 
   return (
-    <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50" onClick={onClose}>
-      <div
-        className="bg-card border border-border rounded-xl shadow-2xl w-[420px] max-h-[500px] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="px-4 py-3 border-b border-border">
+    <Modal open={open} onClose={onClose} size="sm">
+      <Modal.Header>
+        <div>
           <h3 className="text-sm font-semibold text-foreground">{title ?? "Select a Project"}</h3>
           <p className="text-[11px] text-muted-foreground mt-0.5">MagicApps are project-anchored — choose which project to open this app for.</p>
           <input
@@ -57,34 +59,34 @@ export function ProjectPickerDialog({ open, onSelect, onClose, projects, title, 
             autoFocus
           />
         </div>
-        <div className="flex-1 overflow-y-auto p-2">
-          {filtered.length === 0 && (
-            <div className="text-center py-6 text-muted-foreground text-xs">
-              {app && compatible.length === 0
-                ? "No compatible projects for this app"
-                : "No projects found"}
+      </Modal.Header>
+      <Modal.Body className="max-h-[400px] overflow-y-auto p-2">
+        {filtered.length === 0 && (
+          <div className="text-center py-6 text-muted-foreground text-xs">
+            {app && compatible.length === 0
+              ? "No compatible projects for this app"
+              : "No projects found"}
+          </div>
+        )}
+        {filtered.map((p) => (
+          <button
+            key={p.path}
+            onClick={() => onSelect(p.path)}
+            className="w-full text-left px-3 py-2 rounded-lg hover:bg-accent/10 transition-colors flex items-center gap-2"
+          >
+            <div className="flex-1">
+              <div className="text-sm font-medium text-foreground">{p.name}</div>
+              <div className="text-[10px] text-muted-foreground font-mono">{p.path}</div>
             </div>
-          )}
-          {filtered.map((p) => (
-            <button
-              key={p.path}
-              onClick={() => onSelect(p.path)}
-              className="w-full text-left px-3 py-2 rounded-lg hover:bg-accent/10 transition-colors flex items-center gap-2"
-            >
-              <div className="flex-1">
-                <div className="text-sm font-medium text-foreground">{p.name}</div>
-                <div className="text-[10px] text-muted-foreground font-mono">{p.path}</div>
-              </div>
-              {p.hosting?.hostname && (
-                <span className="text-[10px] text-blue">{p.hosting.hostname}.ai.on</span>
-              )}
-            </button>
-          ))}
-        </div>
-        <div className="px-4 py-2 border-t border-border flex justify-end">
-          <Button variant="secondary" size="sm" onClick={onClose}>Cancel</Button>
-        </div>
-      </div>
-    </div>
+            {p.hosting?.hostname && (
+              <span className="text-[10px] text-blue">{p.hosting.hostname}.ai.on</span>
+            )}
+          </button>
+        ))}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" size="sm" onClick={onClose}>Cancel</Button>
+      </Modal.Footer>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

First per-modal refactor in the s142 sweep. ProjectPickerDialog drops its hand-rolled \`fixed inset-0\` overlay for PAx \`Modal\` + \`Modal.Header\`/\`Modal.Body\`/\`Modal.Footer\`.

Wins from PAx Modal, no extra code:
- **Focus trap** — keyboard tab cycles within the modal
- **Body scroll lock** — page underneath doesn't scroll
- **ARIA**: \`role="dialog"\` + \`aria-modal="true"\` — screen readers enter dialog mode
- **ESC-to-close**
- **Backdrop click closes** — wired through onClose

The keyboard-tab-out-of-modal a11y bug surfaced in the t557 audit is closed for this modal. Remaining 6 modal surfaces (StackPicker, MagicAppModal, WhoDBFlyout, MAppEditor, flyout-panel adapter, root.tsx chat aside) follow the same template in subsequent cycles.

Behavior preserved: filter input, MApp-compatibility filtering, project list, footer Cancel button.

Bump 0.4.572 → 0.4.573. s142 progress 5/8.

## Test plan

- [x] Typecheck clean on the changed file (other root.tsx errors are pre-existing PAx-WIP)
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [ ] Manual: open the project picker, ESC closes it; tab key cycles within the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)