### PR TITLE
refactor(form-input): ProjectPickerDialog search input → PAx Input (s142 t561)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.573",
+  "version": "0.4.574",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ProjectPickerDialog.tsx
+++ b/ui/dashboard/src/components/ProjectPickerDialog.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useState } from "react";
-import { Modal } from "@particle-academy/react-fancy";
+import { Modal, Input } from "@particle-academy/react-fancy";
 import { Button } from "@/components/ui/button.js";
 import type { MagicAppInfo, ProjectInfo } from "@/types.js";
 
@@ -50,12 +50,15 @@ export function ProjectPickerDialog({ open, onSelect, onClose, projects, title, 
         <div>
           <h3 className="text-sm font-semibold text-foreground">{title ?? "Select a Project"}</h3>
           <p className="text-[11px] text-muted-foreground mt-0.5">MagicApps are project-anchored — choose which project to open this app for.</p>
-          <input
-            type="text"
+          {/* s142 t561 — PAx Input. Brings consistent focus styles +
+              affix-slot scaffolding (leading/trailing) for free + a
+              proper onValueChange callback shape. */}
+          <Input
+            type="search"
             placeholder="Search projects..."
             value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            className="mt-2 w-full px-2.5 py-1.5 rounded-md border border-border bg-background text-foreground text-xs"
+            onValueChange={setFilter}
+            className="mt-2 w-full"
             autoFocus
           />
         </div>


### PR DESCRIPTION
## Summary

First per-component refactor in the form-input sweep. Verifies the local adapters (\`components/ui/input.tsx\` + \`select.tsx\`) already re-export from \`@particle-academy/react-fancy\`. ProjectPickerDialog's search input drops \`<input type="text">\` for \`<Input type="search" onValueChange={setFilter}>\` — wins consistent focus styles, leading/trailing affix slots, and a proper onValueChange callback shape.

Per the same scope-call as t559: audit IS the find; local adapters ARE PAx-backed; first refactor is the template; remaining call sites refactor opportunistically.

Bump 0.4.573 → 0.4.574. s142 progress 6/8.

## Test plan

- [x] Typecheck clean on the changed file (existing root.tsx errors are pre-existing PAx-WIP, count unchanged)
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)