### PR TITLE
refactor(chrome): NotesPage heading → PAx Heading (s142 t560)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.574",
+  "version": "0.4.575",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/routes/notes.tsx
+++ b/ui/dashboard/src/routes/notes.tsx
@@ -8,13 +8,18 @@
  */
 
 import type { ReactElement } from "react";
+import { Heading } from "@particle-academy/react-fancy";
 import { NotesPanel } from "@/components/NotesPanel.js";
 
 export default function NotesPage(): ReactElement {
   return (
     <div className="flex flex-col gap-3 h-full">
       <header className="flex items-baseline gap-2">
-        <h1 className="text-[16px] font-semibold tracking-tight">Notes</h1>
+        {/* s142 t560 — PAx Heading anchors typography on design tokens
+            instead of an ad-hoc text size + weight class. Same visual
+            output (size="md" + weight="semibold" matches the prior
+            text-[16px] font-semibold). */}
+        <Heading as="h1" size="md" weight="semibold" className="tracking-tight">Notes</Heading>
         <span className="text-[11px] text-muted-foreground/70">
           Global scope — ideas + todos + context not bound to any one project
         </span>


### PR DESCRIPTION
## Summary

NotesPage \`<h1 className="text-[16px] font-semibold tracking-tight">\` swaps to \`<Heading as="h1" size="md" weight="semibold">\`. Anchors typography on PAx design tokens.

Verified local Card adapter (\`components/ui/card.tsx\`) already wraps PAx Card via the \`data-react-fancy-card\` attribute selector for global theming. Card refactors land opportunistically when consumers adopt the local adapter.

Per same scope-call as t559/t561: audit IS the find, local adapters ARE PAx-backed, first refactor is the template.

Bump 0.4.574 → 0.4.575. s142 progress 7/8 — only t563 (fancy-3d when first consumer exists) remains, reactive.

## Test plan

- [x] Typecheck clean on the changed file (root.tsx errors are pre-existing PAx-WIP, count unchanged)
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)