### PR TITLE
feat(mcp): foundational .mcp.json reader + dual-read fallback (s131 t680)

### DIFF
--- a/config/src/index.ts
+++ b/config/src/index.ts
@@ -41,6 +41,8 @@ export {
   ProjectAiDatasetBindingSchema,
   ProjectIterativeWorkSchema,
   ProjectRepoSchema,
+  ProjectMcpServerSchema,
+  ProjectMcpSchema,
   type ProjectConfig,
   type ProjectHosting,
   type ProjectStackInstance,
@@ -49,6 +51,8 @@ export {
   type ProjectAiDatasetBinding,
   type ProjectIterativeWork,
   type ProjectRepo,
+  type ProjectMcpServer,
+  type ProjectMcp,
 } from "./project-schema.js";
 
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.575",
+  "version": "0.4.576",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/index.ts
+++ b/packages/gateway-core/src/index.ts
@@ -449,6 +449,16 @@ export type { MagicAppInstanceRecord, CreateInstanceParams } from "./magic-app-s
 export { HostingManager } from "./hosting-manager.js";
 export type { HostingConfig, ProjectHostingMeta, HostedProject, InfraStatus, HostingManagerDeps, InstallActionResult, DetectedProjectConfig } from "./hosting-manager.js";
 
+// MCP project config (s131)
+export {
+  projectMcpPath,
+  mcpEntryToServer,
+  readDotMcpJson,
+  readProjectMcpServers,
+  DotMcpJsonSchema,
+} from "./mcp-config-store.js";
+export type { DotMcpJson, McpServerEntry } from "./mcp-config-store.js";
+
 // Service Manager
 export { ServiceManager } from "./service-manager.js";
 export type { ServiceStatus, ServiceManagerDeps } from "./service-manager.js";

--- a/packages/gateway-core/src/mcp-config-store.test.ts
+++ b/packages/gateway-core/src/mcp-config-store.test.ts
@@ -1,0 +1,207 @@
+/**
+ * mcp-config-store tests (s131 t680). Pure-logic; runs on host.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  projectMcpPath,
+  mcpEntryToServer,
+  readDotMcpJson,
+  readProjectMcpServers,
+  DotMcpJsonSchema,
+  type McpServerEntry,
+} from "./mcp-config-store.js";
+import type { ProjectMcpServer } from "@agi/config";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mcp-store-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("projectMcpPath (s131 t680)", () => {
+  it("appends .mcp.json to the project path", () => {
+    expect(projectMcpPath("/srv/proj")).toBe("/srv/proj/.mcp.json");
+    expect(projectMcpPath("/home/u/work/x")).toBe("/home/u/work/x/.mcp.json");
+  });
+});
+
+describe("DotMcpJsonSchema (s131 t680)", () => {
+  it("accepts the canonical Claude Code shape", () => {
+    const r = DotMcpJsonSchema.safeParse({
+      mcpServers: {
+        tynn: {
+          type: "http",
+          url: "http://127.0.0.1:7123/mcp",
+          headers: { Authorization: "Bearer $TYNN_API_KEY" },
+        },
+      },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("defaults autoConnect to true and type to stdio", () => {
+    const r = DotMcpJsonSchema.parse({ mcpServers: { foo: {} } });
+    expect(r.mcpServers.foo?.autoConnect).toBe(true);
+    expect(r.mcpServers.foo?.type).toBe("stdio");
+  });
+
+  it("accepts empty mcpServers", () => {
+    const r = DotMcpJsonSchema.parse({ mcpServers: {} });
+    expect(Object.keys(r.mcpServers)).toEqual([]);
+  });
+
+  it("accepts a missing mcpServers key (defaults to empty)", () => {
+    const r = DotMcpJsonSchema.parse({});
+    expect(r.mcpServers).toEqual({});
+  });
+
+  it("passes-through unknown top-level keys (forward-compat)", () => {
+    const r = DotMcpJsonSchema.parse({ mcpServers: {}, _futureField: "ok" });
+    expect((r as Record<string, unknown>)._futureField).toBe("ok");
+  });
+});
+
+describe("mcpEntryToServer (s131 t680)", () => {
+  it("translates an http server with bearer header to authToken", () => {
+    const entry: McpServerEntry = {
+      type: "http",
+      url: "http://127.0.0.1:7123/mcp",
+      headers: { Authorization: "Bearer $TYNN_API_KEY" },
+      autoConnect: true,
+    };
+    const out = mcpEntryToServer("tynn", entry);
+    expect(out).toEqual<ProjectMcpServer>({
+      id: "tynn",
+      transport: "http",
+      url: "http://127.0.0.1:7123/mcp",
+      authToken: "$TYNN_API_KEY",
+      autoConnect: true,
+    });
+  });
+
+  it("translates a stdio server with command + args + env", () => {
+    const entry: McpServerEntry = {
+      type: "stdio",
+      command: "node",
+      args: ["/opt/jira-mcp/bin.js", "--verbose"],
+      env: { JIRA_TOKEN: "$JIRA_TOKEN" },
+      autoConnect: false,
+    };
+    const out = mcpEntryToServer("jira", entry);
+    expect(out).toEqual<ProjectMcpServer>({
+      id: "jira",
+      transport: "stdio",
+      command: ["node", "/opt/jira-mcp/bin.js", "--verbose"],
+      env: { JIRA_TOKEN: "$JIRA_TOKEN" },
+      autoConnect: false,
+    });
+  });
+
+  it("collapses sse to http transport", () => {
+    const entry: McpServerEntry = {
+      type: "sse",
+      url: "http://example.com/sse",
+      autoConnect: true,
+    };
+    const out = mcpEntryToServer("legacy-sse", entry);
+    expect(out.transport).toBe("http");
+    expect(out.url).toBe("http://example.com/sse");
+  });
+
+  it("preserves Authorization without 'Bearer ' prefix", () => {
+    const entry: McpServerEntry = {
+      type: "http",
+      url: "http://x",
+      headers: { Authorization: "$RAW_TOKEN" },
+      autoConnect: true,
+    };
+    expect(mcpEntryToServer("x", entry).authToken).toBe("$RAW_TOKEN");
+  });
+
+  it("accepts lowercase 'authorization' header", () => {
+    const entry: McpServerEntry = {
+      type: "http",
+      url: "http://x",
+      headers: { authorization: "Bearer $TOKEN" },
+      autoConnect: true,
+    };
+    expect(mcpEntryToServer("x", entry).authToken).toBe("$TOKEN");
+  });
+});
+
+describe("readDotMcpJson (s131 t680)", () => {
+  it("returns null when .mcp.json does not exist", () => {
+    expect(readDotMcpJson(tmp)).toBe(null);
+  });
+
+  it("returns [] when .mcp.json has no servers", () => {
+    writeFileSync(join(tmp, ".mcp.json"), JSON.stringify({ mcpServers: {} }), "utf-8");
+    expect(readDotMcpJson(tmp)).toEqual([]);
+  });
+
+  it("returns servers in internal shape, sorted by file order", () => {
+    writeFileSync(join(tmp, ".mcp.json"), JSON.stringify({
+      mcpServers: {
+        tynn: { type: "http", url: "http://127.0.0.1:7123/mcp", headers: { Authorization: "Bearer $TYNN_API_KEY" } },
+        local: { type: "stdio", command: "node", args: ["/x/y.js"] },
+      },
+    }), "utf-8");
+    const servers = readDotMcpJson(tmp);
+    expect(servers).toHaveLength(2);
+    expect(servers?.[0]?.id).toBe("tynn");
+    expect(servers?.[1]?.id).toBe("local");
+  });
+
+  it("throws on malformed JSON (loud failure)", () => {
+    writeFileSync(join(tmp, ".mcp.json"), "not json", "utf-8");
+    expect(() => readDotMcpJson(tmp)).toThrow();
+  });
+});
+
+describe("readProjectMcpServers (s131 t680)", () => {
+  it("returns dotmcp source when .mcp.json exists", () => {
+    writeFileSync(join(tmp, ".mcp.json"), JSON.stringify({
+      mcpServers: { tynn: { type: "http", url: "http://x" } },
+    }), "utf-8");
+    const r = readProjectMcpServers(tmp, undefined);
+    expect(r.source).toBe("dotmcp");
+    expect(r.servers).toHaveLength(1);
+    expect(r.servers[0]?.id).toBe("tynn");
+  });
+
+  it("falls back to legacy servers when .mcp.json is absent", () => {
+    const legacy: ProjectMcpServer[] = [
+      { id: "tynn", transport: "http", url: "http://x", autoConnect: true },
+    ];
+    const r = readProjectMcpServers(tmp, legacy);
+    expect(r.source).toBe("legacy");
+    expect(r.servers).toBe(legacy);
+  });
+
+  it("prefers .mcp.json over legacy when both exist (.mcp.json wins migration)", () => {
+    writeFileSync(join(tmp, ".mcp.json"), JSON.stringify({
+      mcpServers: { fromdot: { type: "http", url: "http://dot" } },
+    }), "utf-8");
+    const legacy: ProjectMcpServer[] = [
+      { id: "fromlegacy", transport: "http", url: "http://legacy", autoConnect: true },
+    ];
+    const r = readProjectMcpServers(tmp, legacy);
+    expect(r.source).toBe("dotmcp");
+    expect(r.servers[0]?.id).toBe("fromdot");
+  });
+
+  it("returns empty + source 'none' when neither populated", () => {
+    expect(readProjectMcpServers(tmp, undefined)).toEqual({ servers: [], source: "none" });
+    expect(readProjectMcpServers(tmp, [])).toEqual({ servers: [], source: "none" });
+  });
+});

--- a/packages/gateway-core/src/mcp-config-store.ts
+++ b/packages/gateway-core/src/mcp-config-store.ts
@@ -1,0 +1,169 @@
+/**
+ * MCP project config — `.mcp.json` reader (s131 t680).
+ *
+ * Owner directive (cycle 68): per-project MCP servers live in a top-level
+ * `.mcp.json` at the project root, matching Claude Code's convention. This
+ * module is the single read entry-point during the migration window:
+ * prefers `.mcp.json` if present, falls back to the legacy
+ * `project.json mcp.servers[]` block for unmigrated installs.
+ *
+ * Write path is intentionally NOT in this module yet — t682 flips writes
+ * to `.mcp.json` after the dual-read landing zone is solid. Until then,
+ * existing API endpoints continue writing to project.json AND the
+ * one-shot migration (t681) brings unmigrated projects forward at boot.
+ *
+ * ## Disk shape
+ *
+ * Claude Code's `.mcp.json` uses `mcpServers: { <id>: { ... } }` keyed by
+ * id. Our internal model is `ProjectMcpServer[]` keyed by `id` field.
+ * Adapt at the boundary.
+ *
+ * ```jsonc
+ * {
+ *   "mcpServers": {
+ *     "tynn": {
+ *       "type": "http",
+ *       "url": "http://127.0.0.1:7123/mcp",
+ *       "headers": { "Authorization": "Bearer $TYNN_API_KEY" }
+ *     },
+ *     "jira-stdio": {
+ *       "type": "stdio",
+ *       "command": "node",
+ *       "args": ["/opt/jira-mcp/bin.js"],
+ *       "env": { "JIRA_TOKEN": "$JIRA_TOKEN" }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * `$VAR` resolution against `<projectPath>/.env` happens later via the
+ * existing `resolveDollarVars` helper; this module returns config
+ * verbatim.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import type { ProjectMcpServer } from "@agi/config";
+
+// ---------------------------------------------------------------------------
+// .mcp.json schema (Claude Code shape)
+// ---------------------------------------------------------------------------
+
+const McpServerEntrySchema = z
+  .object({
+    /** Transport tag matching Claude Code's `type` field. */
+    type: z.enum(["stdio", "http", "websocket", "sse"]).default("stdio"),
+    name: z.string().optional(),
+    /** http/websocket/sse: server URL. */
+    url: z.string().optional(),
+    /** stdio: executable to spawn. */
+    command: z.string().optional(),
+    /** stdio: argv after command. */
+    args: z.array(z.string()).optional(),
+    /** stdio: env-var injections. Values may use `$VAR` for .env resolution. */
+    env: z.record(z.string(), z.string()).optional(),
+    /** http: header map. Values may use `$VAR`. Authorization is the
+     *  conventional auth-token slot per Claude Code. */
+    headers: z.record(z.string(), z.string()).optional(),
+    /** Whether to connect at boot (default true) or lazily. */
+    autoConnect: z.boolean().default(true),
+  })
+  .passthrough();
+
+export const DotMcpJsonSchema = z
+  .object({
+    mcpServers: z.record(z.string(), McpServerEntrySchema).default({}),
+  })
+  .passthrough();
+
+export type DotMcpJson = z.infer<typeof DotMcpJsonSchema>;
+export type McpServerEntry = z.infer<typeof McpServerEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// Path + readers
+// ---------------------------------------------------------------------------
+
+/**
+ * Where the project's `.mcp.json` lives. Always at the project root
+ * regardless of the s130 universal-monorepo `k/` folder layout — Claude
+ * Code expects this exact name + location and our gateway should respect
+ * the convention so a project can be opened by either tool without copying
+ * configuration around.
+ */
+export function projectMcpPath(projectPath: string): string {
+  return join(projectPath, ".mcp.json");
+}
+
+/**
+ * Adapt a single `.mcp.json` entry (Claude Code shape) into our internal
+ * `ProjectMcpServer` shape.
+ *
+ * `type: "sse"` collapses to "http" (we don't model SSE separately yet —
+ * the McpClient handles SSE-over-HTTP transparently). Authorization is
+ * extracted from `headers` to populate `authToken` so existing wiring
+ * keeps working without refactoring the consumer.
+ */
+export function mcpEntryToServer(id: string, entry: McpServerEntry): ProjectMcpServer {
+  const transport = entry.type === "sse" ? "http" : entry.type;
+  const authHeader = entry.headers?.Authorization ?? entry.headers?.authorization;
+  const authToken = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length)
+    : authHeader;
+
+  // Combine `command` + `args` into the single `command: string[]` array
+  // our internal schema uses.
+  let command: string[] | undefined;
+  if (entry.command !== undefined) {
+    command = entry.args !== undefined ? [entry.command, ...entry.args] : [entry.command];
+  }
+
+  return {
+    id,
+    transport,
+    autoConnect: entry.autoConnect,
+    ...(entry.name !== undefined ? { name: entry.name } : {}),
+    ...(command !== undefined ? { command } : {}),
+    ...(entry.env !== undefined ? { env: entry.env } : {}),
+    ...(entry.url !== undefined ? { url: entry.url } : {}),
+    ...(authToken !== undefined ? { authToken } : {}),
+  } as ProjectMcpServer;
+}
+
+/**
+ * Read `.mcp.json` for a project and return its servers in the internal
+ * shape. Returns `null` when the file doesn't exist (caller should fall
+ * back to project.json for unmigrated installs). Returns `[]` when the
+ * file is present but parses to `mcpServers: {}`.
+ *
+ * Throws on parse / schema error (loud failure preferred over silent
+ * fallback — a malformed `.mcp.json` should surface in `agi doctor
+ * schema`, not be silently ignored).
+ */
+export function readDotMcpJson(projectPath: string): ProjectMcpServer[] | null {
+  const path = projectMcpPath(projectPath);
+  if (!existsSync(path)) return null;
+  const raw = readFileSync(path, "utf-8");
+  const parsed = JSON.parse(raw) as unknown;
+  const result = DotMcpJsonSchema.parse(parsed);
+  return Object.entries(result.mcpServers).map(([id, entry]) => mcpEntryToServer(id, entry));
+}
+
+/**
+ * The dual-read entry-point. Prefers `.mcp.json` when present; otherwise
+ * falls back to `legacyServers` (typically the `project.json mcp.servers`
+ * block). Pass both even when only one is expected to be populated — the
+ * caller doesn't need to know which migration era this project is in.
+ *
+ * Returns an empty array when neither is populated (project never
+ * configured any MCP servers).
+ */
+export function readProjectMcpServers(
+  projectPath: string,
+  legacyServers: ProjectMcpServer[] | undefined,
+): { servers: ProjectMcpServer[]; source: "dotmcp" | "legacy" | "none" } {
+  const fromDot = readDotMcpJson(projectPath);
+  if (fromDot !== null) return { servers: fromDot, source: "dotmcp" };
+  if (legacyServers && legacyServers.length > 0) return { servers: legacyServers, source: "legacy" };
+  return { servers: [], source: "none" };
+}


### PR DESCRIPTION
## Summary

Lays the groundwork for moving project MCP config from \`project.json mcp.servers[]\` to a top-level \`.mcp.json\` file (Claude Code convention). This commit ships only the **read path** — writes still flow through project.json until t682 flips them.

New module: \`packages/gateway-core/src/mcp-config-store.ts\`

- \`projectMcpPath(projectPath)\` — \`<projectPath>/.mcp.json\`
- \`DotMcpJsonSchema\` — Zod schema matching Claude Code's \`mcpServers: { <id>: { type, url, command, args, env, headers, autoConnect } }\` shape. Forward-compat passthrough.
- \`mcpEntryToServer(id, entry)\` — adapter from Claude-Code-shape → internal \`ProjectMcpServer\`. Combines command+args, extracts \`Authorization: Bearer <token>\` → authToken, collapses \`sse\` → http transport.
- \`readDotMcpJson(projectPath)\` — returns servers or null. Throws on malformed JSON (loud failure preferred — surfaces in \`agi doctor schema\`).
- \`readProjectMcpServers(projectPath, legacyServers)\` — dual-read entry-point. Returns \`{servers, source: "dotmcp" | "legacy" | "none"}\`.

\`ProjectMcpServer\` / \`ProjectMcpServerSchema\` / \`ProjectMcp\` / \`ProjectMcpSchema\` now exported from \`@agi/config\`.

Bump 0.4.575 → 0.4.576. s131 in_progress (1/5; t681-t684 filed for migration + write-flip + schema-deprecation + e2e).

## Test plan

- [x] 19 new unit tests covering schema acceptance + defaults + forward-compat + adapter (http/stdio/sse, Bearer-strip, lowercase authorization) + file-missing returns null + malformed JSON throws + dual-read source ordering — pass
- [x] Typecheck clean on @agi/gateway-core + @agi/config
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)