### PR TITLE
feat(mcp): boot-time migration to .mcp.json (s131 t681)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.576",
+  "version": "0.4.577",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/index.ts
+++ b/packages/gateway-core/src/index.ts
@@ -458,6 +458,12 @@ export {
   DotMcpJsonSchema,
 } from "./mcp-config-store.js";
 export type { DotMcpJson, McpServerEntry } from "./mcp-config-store.js";
+export {
+  serverToMcpEntry,
+  migrateProjectMcpConfig,
+  migrateAllProjectMcpConfigs,
+} from "./mcp-config-migration.js";
+export type { McpMigrationResult, McpSweepResult } from "./mcp-config-migration.js";
 
 // Service Manager
 export { ServiceManager } from "./service-manager.js";

--- a/packages/gateway-core/src/mcp-config-migration.test.ts
+++ b/packages/gateway-core/src/mcp-config-migration.test.ts
@@ -1,0 +1,248 @@
+/**
+ * mcp-config-migration tests (s131 t681). Pure-logic; runs on host.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  serverToMcpEntry,
+  migrateProjectMcpConfig,
+  migrateAllProjectMcpConfigs,
+} from "./mcp-config-migration.js";
+import { projectMcpPath } from "./mcp-config-store.js";
+import type { ProjectMcpServer } from "@agi/config";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mcp-mig-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeProjectJson(projectPath: string, content: object): void {
+  mkdirSync(projectPath, { recursive: true });
+  writeFileSync(join(projectPath, "project.json"), JSON.stringify(content, null, 2), "utf-8");
+}
+
+describe("serverToMcpEntry (s131 t681)", () => {
+  it("translates an http server with authToken into Claude Code shape", () => {
+    const server: ProjectMcpServer = {
+      id: "tynn",
+      transport: "http",
+      url: "http://127.0.0.1:7123/mcp",
+      authToken: "$TYNN_API_KEY",
+      autoConnect: true,
+    };
+    expect(serverToMcpEntry(server)).toEqual({
+      type: "http",
+      url: "http://127.0.0.1:7123/mcp",
+      headers: { Authorization: "Bearer $TYNN_API_KEY" },
+      autoConnect: true,
+    });
+  });
+
+  it("translates a stdio server with command + args + env", () => {
+    const server: ProjectMcpServer = {
+      id: "jira",
+      transport: "stdio",
+      command: ["node", "/opt/jira-mcp/bin.js", "--verbose"],
+      env: { JIRA_TOKEN: "$JIRA_TOKEN" },
+      autoConnect: false,
+    };
+    expect(serverToMcpEntry(server)).toEqual({
+      type: "stdio",
+      command: "node",
+      args: ["/opt/jira-mcp/bin.js", "--verbose"],
+      env: { JIRA_TOKEN: "$JIRA_TOKEN" },
+      autoConnect: false,
+    });
+  });
+
+  it("does NOT emit headers for stdio (authToken belongs in env there)", () => {
+    const server: ProjectMcpServer = {
+      id: "x",
+      transport: "stdio",
+      command: ["node"],
+      authToken: "$TOKEN",
+      autoConnect: true,
+    };
+    expect(serverToMcpEntry(server).headers).toBeUndefined();
+  });
+
+  it("preserves the id-less name field when present", () => {
+    const server: ProjectMcpServer = {
+      id: "x",
+      transport: "http",
+      name: "Tynn (production)",
+      url: "http://x",
+      autoConnect: true,
+    };
+    expect(serverToMcpEntry(server).name).toBe("Tynn (production)");
+  });
+
+  it("handles single-element command array (no args emitted)", () => {
+    const server: ProjectMcpServer = {
+      id: "x",
+      transport: "stdio",
+      command: ["binary-only"],
+      autoConnect: true,
+    };
+    const out = serverToMcpEntry(server);
+    expect(out.command).toBe("binary-only");
+    expect(out.args).toBeUndefined();
+  });
+
+  it("round-trips through mcpEntryToServer (read inverse holds)", async () => {
+    const { mcpEntryToServer } = await import("./mcp-config-store.js");
+    const server: ProjectMcpServer = {
+      id: "tynn",
+      transport: "http",
+      url: "http://127.0.0.1:7123/mcp",
+      authToken: "$TYNN_API_KEY",
+      autoConnect: true,
+    };
+    const roundTripped = mcpEntryToServer("tynn", serverToMcpEntry(server));
+    expect(roundTripped).toEqual(server);
+  });
+});
+
+describe("migrateProjectMcpConfig (s131 t681)", () => {
+  it("writes .mcp.json + strips project.json mcp on a populated config", () => {
+    const projectPath = join(tmp, "demo");
+    writeProjectJson(projectPath, {
+      name: "Demo",
+      type: "static-site",
+      mcp: {
+        servers: [
+          { id: "tynn", transport: "http", url: "http://x", authToken: "$T", autoConnect: true },
+          { id: "jira", transport: "stdio", command: ["node", "/x.js"], autoConnect: false },
+        ],
+      },
+    });
+
+    const result = migrateProjectMcpConfig(projectPath);
+    expect(result.dotMcpWritten).toBe(true);
+    expect(result.projectJsonStripped).toBe(true);
+    expect(result.serverCount).toBe(2);
+    expect(existsSync(projectMcpPath(projectPath))).toBe(true);
+
+    // .mcp.json contents are well-formed
+    const parsed = JSON.parse(readFileSync(projectMcpPath(projectPath), "utf-8")) as {
+      mcpServers: Record<string, { type: string }>;
+    };
+    expect(Object.keys(parsed.mcpServers)).toEqual(["tynn", "jira"]);
+    expect(parsed.mcpServers.tynn?.type).toBe("http");
+    expect(parsed.mcpServers.jira?.type).toBe("stdio");
+
+    // project.json mcp field gone
+    const projectJson = JSON.parse(readFileSync(join(projectPath, "project.json"), "utf-8")) as Record<string, unknown>;
+    expect("mcp" in projectJson).toBe(false);
+    expect(projectJson["name"]).toBe("Demo");
+  });
+
+  it("is idempotent — second pass on a migrated project skips silently", () => {
+    const projectPath = join(tmp, "demo");
+    writeProjectJson(projectPath, {
+      name: "Demo",
+      mcp: { servers: [{ id: "x", transport: "http", url: "http://x", autoConnect: true }] },
+    });
+
+    const first = migrateProjectMcpConfig(projectPath);
+    expect(first.dotMcpWritten).toBe(true);
+
+    const second = migrateProjectMcpConfig(projectPath);
+    expect(second.dotMcpWritten).toBe(false);
+    expect(second.skippedReason).toBe("already-migrated");
+  });
+
+  it("strips an empty mcp block from project.json without writing .mcp.json", () => {
+    const projectPath = join(tmp, "demo");
+    writeProjectJson(projectPath, { name: "Demo", mcp: { servers: [] } });
+
+    const result = migrateProjectMcpConfig(projectPath);
+    expect(result.dotMcpWritten).toBe(false);
+    expect(result.projectJsonStripped).toBe(true);
+    expect(result.skippedReason).toBe("no-mcp-block");
+    expect(existsSync(projectMcpPath(projectPath))).toBe(false);
+
+    const projectJson = JSON.parse(readFileSync(join(projectPath, "project.json"), "utf-8")) as Record<string, unknown>;
+    expect("mcp" in projectJson).toBe(false);
+  });
+
+  it("skips when project.json doesn't exist", () => {
+    const projectPath = join(tmp, "missing");
+    mkdirSync(projectPath, { recursive: true });
+    const result = migrateProjectMcpConfig(projectPath);
+    expect(result.skippedReason).toBe("no-project-json");
+    expect(result.dotMcpWritten).toBe(false);
+  });
+
+  it("skips when no mcp block AND no mcp field at all", () => {
+    const projectPath = join(tmp, "no-mcp");
+    writeProjectJson(projectPath, { name: "X" });
+    const result = migrateProjectMcpConfig(projectPath);
+    expect(result.dotMcpWritten).toBe(false);
+    expect(result.projectJsonStripped).toBe(false);
+    expect(result.skippedReason).toBe("no-mcp-block");
+  });
+
+  it("captures error on malformed project.json without throwing", () => {
+    const projectPath = join(tmp, "bad");
+    mkdirSync(projectPath, { recursive: true });
+    writeFileSync(join(projectPath, "project.json"), "not json", "utf-8");
+    const result = migrateProjectMcpConfig(projectPath);
+    expect(result.error).toBeDefined();
+    expect(result.dotMcpWritten).toBe(false);
+  });
+});
+
+describe("migrateAllProjectMcpConfigs (s131 t681)", () => {
+  it("walks each workspace root + migrates each project", () => {
+    const wsRoot = join(tmp, "ws");
+    mkdirSync(wsRoot, { recursive: true });
+
+    // Three projects: one to migrate, one already migrated, one with no mcp.
+    writeProjectJson(join(wsRoot, "alpha"), {
+      name: "Alpha",
+      mcp: { servers: [{ id: "tynn", transport: "http", url: "http://x", autoConnect: true }] },
+    });
+
+    writeProjectJson(join(wsRoot, "beta"), { name: "Beta" });
+    writeFileSync(join(wsRoot, "beta", ".mcp.json"), JSON.stringify({ mcpServers: {} }), "utf-8");
+
+    writeProjectJson(join(wsRoot, "gamma"), { name: "Gamma" }); // no mcp at all
+
+    const out = migrateAllProjectMcpConfigs([wsRoot]);
+    expect(out.scanned).toBe(3);
+    expect(out.migrated).toBe(1); // only alpha
+    expect(out.totalServers).toBe(1);
+    expect(out.errors).toBe(0);
+
+    expect(existsSync(projectMcpPath(join(wsRoot, "alpha")))).toBe(true);
+  });
+
+  it("ignores hidden directories under workspace roots", () => {
+    const wsRoot = join(tmp, "ws");
+    mkdirSync(join(wsRoot, ".hidden"), { recursive: true });
+    writeProjectJson(join(wsRoot, ".hidden"), {
+      name: "Hidden",
+      mcp: { servers: [{ id: "x", transport: "http", url: "http://x", autoConnect: true }] },
+    });
+    const out = migrateAllProjectMcpConfigs([wsRoot]);
+    expect(out.scanned).toBe(0);
+    expect(out.migrated).toBe(0);
+  });
+
+  it("tolerates non-existent workspace roots silently", () => {
+    const out = migrateAllProjectMcpConfigs([join(tmp, "does-not-exist")]);
+    expect(out.scanned).toBe(0);
+    expect(out.errors).toBe(0);
+  });
+});

--- a/packages/gateway-core/src/mcp-config-migration.ts
+++ b/packages/gateway-core/src/mcp-config-migration.ts
@@ -1,0 +1,210 @@
+/**
+ * mcp-config-migration — s131 t681.
+ *
+ * One-shot, idempotent migration: walks each workspace project, and when
+ * `project.json` carries a non-empty `mcp.servers[]` block AND
+ * `<projectPath>/.mcp.json` does NOT exist, writes `.mcp.json` from the
+ * block (Claude Code shape) and removes the `mcp` field from
+ * `project.json`. Already-migrated projects (with `.mcp.json` present)
+ * are left alone.
+ *
+ * Sibling to `project-config-shape-migration.ts` (s150 t632) which
+ * handles the type/category shape pass. Shape vs. mcp-storage are
+ * different axes; keeping them in separate modules keeps the boot
+ * sweep narrow + each axis retirable independently.
+ *
+ * Safe to call repeatedly. Disk is only touched when something
+ * actually changes.
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { isSacredProjectPath } from "./project-config-path.js";
+import { projectMcpPath, type DotMcpJson, type McpServerEntry } from "./mcp-config-store.js";
+import type { ProjectMcpServer } from "@agi/config";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface McpMigrationResult {
+  /** Whether `.mcp.json` was written this pass. */
+  dotMcpWritten: boolean;
+  /** Whether `project.json` had its `mcp` field removed this pass. */
+  projectJsonStripped: boolean;
+  /** Number of servers migrated (mirrors `.mcp.json` server count). */
+  serverCount: number;
+  /** Reason for skipping when neither flag is true. */
+  skippedReason?: "no-project-json" | "no-mcp-block" | "already-migrated" | "sacred-path";
+  /** Captured error message when the migration threw mid-flight. */
+  error?: string;
+}
+
+export interface McpSweepResult {
+  scanned: number;
+  migrated: number;
+  errors: number;
+  totalServers: number;
+  projects: { projectPath: string; result: McpMigrationResult }[];
+}
+
+// ---------------------------------------------------------------------------
+// Adapter (internal ProjectMcpServer → Claude Code .mcp.json shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate one internal ProjectMcpServer back into a Claude-Code-shaped
+ * `.mcp.json` entry. Inverse of `mcp-config-store.ts`'s `mcpEntryToServer`.
+ *
+ * - `transport` → `type` (collapses identically; "http"/"stdio"/"websocket")
+ * - `command: string[]` → split into `{ command, args }` (head + tail)
+ * - `authToken` → `headers: { Authorization: "Bearer <token>" }` for http
+ */
+export function serverToMcpEntry(server: ProjectMcpServer): McpServerEntry {
+  const entry: McpServerEntry = {
+    type: server.transport,
+    autoConnect: server.autoConnect,
+  };
+  if (server.name !== undefined) entry.name = server.name;
+  if (server.url !== undefined) entry.url = server.url;
+  if (server.command !== undefined && server.command.length > 0) {
+    entry.command = server.command[0];
+    if (server.command.length > 1) entry.args = server.command.slice(1);
+  }
+  if (server.env !== undefined) entry.env = server.env;
+  if (server.authToken !== undefined && (server.transport === "http" || server.transport === "websocket")) {
+    entry.headers = { Authorization: `Bearer ${server.authToken}` };
+  }
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Per-project migration
+// ---------------------------------------------------------------------------
+
+const PROJECT_JSON_NAME = "project.json";
+
+/**
+ * Migrate one project's MCP config. Idempotent + side-effect-free when
+ * nothing needs changing.
+ */
+export function migrateProjectMcpConfig(projectPath: string): McpMigrationResult {
+  const result: McpMigrationResult = {
+    dotMcpWritten: false,
+    projectJsonStripped: false,
+    serverCount: 0,
+  };
+
+  if (isSacredProjectPath(projectPath)) {
+    result.skippedReason = "sacred-path";
+    return result;
+  }
+
+  const projectJsonPath = join(projectPath, PROJECT_JSON_NAME);
+  if (!existsSync(projectJsonPath)) {
+    result.skippedReason = "no-project-json";
+    return result;
+  }
+
+  // Already migrated — `.mcp.json` is the source of truth; leave it alone
+  // even if `project.json mcp` somehow still has values (the dual-read
+  // gives `.mcp.json` priority anyway). A future cycle can prune the
+  // stale `mcp` field from project.json on its own pass.
+  const dotMcp = projectMcpPath(projectPath);
+  if (existsSync(dotMcp)) {
+    result.skippedReason = "already-migrated";
+    return result;
+  }
+
+  let raw: string;
+  let parsed: { mcp?: { servers?: ProjectMcpServer[] } } & Record<string, unknown>;
+  try {
+    raw = readFileSync(projectJsonPath, "utf-8");
+    parsed = JSON.parse(raw) as { mcp?: { servers?: ProjectMcpServer[] } } & Record<string, unknown>;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+    return result;
+  }
+
+  const servers = parsed.mcp?.servers ?? [];
+  if (servers.length === 0) {
+    result.skippedReason = "no-mcp-block";
+    // Still null out an empty mcp block so future reads don't trip on
+    // `mcp: { servers: [] }` debris.
+    if (parsed.mcp !== undefined) {
+      const { mcp: _drop, ...rest } = parsed;
+      void _drop;
+      try {
+        writeFileSync(projectJsonPath, JSON.stringify(rest, null, 2) + "\n", "utf-8");
+        result.projectJsonStripped = true;
+      } catch (err) {
+        result.error = err instanceof Error ? err.message : String(err);
+      }
+    }
+    return result;
+  }
+
+  // Build .mcp.json contents.
+  const mcpServers: Record<string, McpServerEntry> = {};
+  for (const server of servers) {
+    mcpServers[server.id] = serverToMcpEntry(server);
+  }
+  const dotMcpContent: DotMcpJson = { mcpServers };
+
+  try {
+    writeFileSync(dotMcp, JSON.stringify(dotMcpContent, null, 2) + "\n", "utf-8");
+    result.dotMcpWritten = true;
+    result.serverCount = servers.length;
+
+    // Strip the `mcp` field from project.json now that the data is
+    // mirrored in `.mcp.json`.
+    const { mcp: _drop, ...rest } = parsed;
+    void _drop;
+    writeFileSync(projectJsonPath, JSON.stringify(rest, null, 2) + "\n", "utf-8");
+    result.projectJsonStripped = true;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk every project directory under each workspace root and migrate
+ * its MCP config. Mirrors `migrateAllProjectConfigShapes` shape so the
+ * boot wiring reads symmetrically.
+ */
+export function migrateAllProjectMcpConfigs(workspaceProjects: readonly string[]): McpSweepResult {
+  const out: McpSweepResult = { scanned: 0, migrated: 0, errors: 0, totalServers: 0, projects: [] };
+
+  for (const dir of workspaceProjects) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+        .map((d) => d.name);
+    } catch {
+      continue;
+    }
+
+    for (const slug of entries) {
+      const projectPath = join(dir, slug);
+      if (isSacredProjectPath(projectPath)) continue;
+      out.scanned++;
+      const result = migrateProjectMcpConfig(projectPath);
+      out.projects.push({ projectPath, result });
+      if (result.dotMcpWritten) {
+        out.migrated++;
+        out.totalServers += result.serverCount;
+      }
+      if (result.error !== undefined) out.errors++;
+    }
+  }
+
+  return out;
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -132,6 +132,7 @@ import { ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-pat
 import { HostingManager } from "./hosting-manager.js";
 import { ProjectConfigManager } from "./project-config-manager.js";
 import { migrateAllProjectConfigShapes } from "./project-config-shape-migration.js";
+import { migrateAllProjectMcpConfigs } from "./mcp-config-migration.js";
 import { IterativeWorkScheduler } from "./iterative-work/scheduler.js";
 import { listProjectsWithConfig } from "./iterative-work/list-projects.js";
 import { projectSlug } from "./project-config-path.js";
@@ -1922,6 +1923,26 @@ export async function startGatewayServer(
     logger.warn(
       "migrate",
       `boot-time s150 shape sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // s131 t681 — MCP config migration. Walk projects and rewrite
+  // `project.json mcp.servers[]` → top-level `.mcp.json` (Claude Code
+  // convention). Idempotent; already-migrated projects are skipped.
+  // Same boot-stage as the s150 shape sweep above so MCP wiring further
+  // down (line 2243+) can rely on either source via the dual-read API.
+  try {
+    const mcpResult = migrateAllProjectMcpConfigs(projectPaths);
+    if (mcpResult.migrated > 0 || mcpResult.errors > 0) {
+      logger.info(
+        "migrate",
+        `boot-time s131 mcp sweep: ${String(mcpResult.scanned)} scanned, ${String(mcpResult.migrated)} migrated (${String(mcpResult.totalServers)} server(s) total), ${String(mcpResult.errors)} error(s)`,
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      "migrate",
+      `boot-time s131 mcp sweep failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Idempotent boot-time sweep converts each project's \`project.json mcp.servers[]\` block into a top-level \`.mcp.json\` (Claude Code shape) and removes the \`mcp\` field from project.json. Mirrors s150's shape-migration pattern.

- \`serverToMcpEntry\` — inverse of t680's \`mcpEntryToServer\`. Splits \`command: string[]\` into head + tail. Translates \`authToken\` → \`Authorization: Bearer <token>\` header for http/websocket; stdio keeps authToken in env.
- \`migrateProjectMcpConfig\` — per-project; sacred-path / no-project-json / already-migrated / empty-block all return early with a reason. Populated → write .mcp.json + strip project.json mcp field.
- \`migrateAllProjectMcpConfigs\` — workspace sweep. Ignores hidden dirs, captures errors per-project, doesn't throw.
- Wired into \`server.ts\` boot at the same stage as the s150 shape sweep.

Bump 0.4.576 → 0.4.577. s131 progress 2/5 (t680 + t681). t682 next flips writes to .mcp.json directly.

## Test plan

- [x] 15 new unit tests covering adapter (http/stdio/no-headers/name-preserve/single-command), round-trip via t680's mcpEntryToServer, idempotency, empty-block stripping, missing project.json, malformed JSON capture, workspace-sweep mixed scenarios, hidden-directory skip, non-existent root tolerance — pass
- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)