### PR TITLE
feat(mcp): flip writes to .mcp.json + dual-read at boot (s131 t682)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.577",
+  "version": "0.4.578",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/mcp-config-migration.ts
+++ b/packages/gateway-core/src/mcp-config-migration.ts
@@ -21,8 +21,13 @@ import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { isSacredProjectPath } from "./project-config-path.js";
-import { projectMcpPath, type DotMcpJson, type McpServerEntry } from "./mcp-config-store.js";
+import { projectMcpPath, serverToMcpEntry, type DotMcpJson, type McpServerEntry } from "./mcp-config-store.js";
 import type { ProjectMcpServer } from "@agi/config";
+
+// Re-export for back-compat — t681 originally landed serverToMcpEntry in
+// this module; t682 moved it to mcp-config-store.ts to avoid a circular
+// import when adding write helpers. Existing callers continue working.
+export { serverToMcpEntry };
 
 // ---------------------------------------------------------------------------
 // Types
@@ -47,36 +52,6 @@ export interface McpSweepResult {
   errors: number;
   totalServers: number;
   projects: { projectPath: string; result: McpMigrationResult }[];
-}
-
-// ---------------------------------------------------------------------------
-// Adapter (internal ProjectMcpServer → Claude Code .mcp.json shape)
-// ---------------------------------------------------------------------------
-
-/**
- * Translate one internal ProjectMcpServer back into a Claude-Code-shaped
- * `.mcp.json` entry. Inverse of `mcp-config-store.ts`'s `mcpEntryToServer`.
- *
- * - `transport` → `type` (collapses identically; "http"/"stdio"/"websocket")
- * - `command: string[]` → split into `{ command, args }` (head + tail)
- * - `authToken` → `headers: { Authorization: "Bearer <token>" }` for http
- */
-export function serverToMcpEntry(server: ProjectMcpServer): McpServerEntry {
-  const entry: McpServerEntry = {
-    type: server.transport,
-    autoConnect: server.autoConnect,
-  };
-  if (server.name !== undefined) entry.name = server.name;
-  if (server.url !== undefined) entry.url = server.url;
-  if (server.command !== undefined && server.command.length > 0) {
-    entry.command = server.command[0];
-    if (server.command.length > 1) entry.args = server.command.slice(1);
-  }
-  if (server.env !== undefined) entry.env = server.env;
-  if (server.authToken !== undefined && (server.transport === "http" || server.transport === "websocket")) {
-    entry.headers = { Authorization: `Bearer ${server.authToken}` };
-  }
-  return entry;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gateway-core/src/mcp-config-store.test.ts
+++ b/packages/gateway-core/src/mcp-config-store.test.ts
@@ -12,9 +12,13 @@ import {
   mcpEntryToServer,
   readDotMcpJson,
   readProjectMcpServers,
+  writeDotMcpJson,
+  setDotMcpServer,
+  removeDotMcpServer,
   DotMcpJsonSchema,
   type McpServerEntry,
 } from "./mcp-config-store.js";
+import { existsSync as existsSyncFs } from "node:fs";
 import type { ProjectMcpServer } from "@agi/config";
 
 let tmp: string;
@@ -165,6 +169,80 @@ describe("readDotMcpJson (s131 t680)", () => {
   it("throws on malformed JSON (loud failure)", () => {
     writeFileSync(join(tmp, ".mcp.json"), "not json", "utf-8");
     expect(() => readDotMcpJson(tmp)).toThrow();
+  });
+});
+
+describe("writeDotMcpJson + setDotMcpServer + removeDotMcpServer (s131 t682)", () => {
+  it("writeDotMcpJson creates .mcp.json with the given servers", () => {
+    const servers: ProjectMcpServer[] = [
+      { id: "tynn", transport: "http", url: "http://x", authToken: "$T", autoConnect: true },
+    ];
+    writeDotMcpJson(tmp, servers);
+    expect(existsSyncFs(projectMcpPath(tmp))).toBe(true);
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(1);
+    expect(round?.[0]?.id).toBe("tynn");
+    expect(round?.[0]?.authToken).toBe("$T");
+  });
+
+  it("writeDotMcpJson overwrites existing file (replace semantics, not append)", () => {
+    writeDotMcpJson(tmp, [
+      { id: "old", transport: "http", url: "http://o", autoConnect: true },
+    ]);
+    writeDotMcpJson(tmp, [
+      { id: "new", transport: "stdio", command: ["node"], autoConnect: true },
+    ]);
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(1);
+    expect(round?.[0]?.id).toBe("new");
+  });
+
+  it("writeDotMcpJson with empty array writes { mcpServers: {} }", () => {
+    writeDotMcpJson(tmp, []);
+    expect(readDotMcpJson(tmp)).toEqual([]);
+  });
+
+  it("setDotMcpServer adds a new server when file is absent", () => {
+    setDotMcpServer(tmp, { id: "x", transport: "http", url: "http://x", autoConnect: true });
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(1);
+    expect(round?.[0]?.id).toBe("x");
+  });
+
+  it("setDotMcpServer upserts (existing id overwritten in place)", () => {
+    setDotMcpServer(tmp, { id: "x", transport: "http", url: "http://v1", autoConnect: true });
+    setDotMcpServer(tmp, { id: "x", transport: "http", url: "http://v2", autoConnect: true });
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(1);
+    expect(round?.[0]?.url).toBe("http://v2");
+  });
+
+  it("setDotMcpServer preserves siblings", () => {
+    setDotMcpServer(tmp, { id: "a", transport: "http", url: "http://a", autoConnect: true });
+    setDotMcpServer(tmp, { id: "b", transport: "http", url: "http://b", autoConnect: true });
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(2);
+    expect(round?.map((s) => s.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("removeDotMcpServer drops the matching id, leaves others", () => {
+    setDotMcpServer(tmp, { id: "a", transport: "http", url: "http://a", autoConnect: true });
+    setDotMcpServer(tmp, { id: "b", transport: "http", url: "http://b", autoConnect: true });
+    removeDotMcpServer(tmp, "a");
+    const round = readDotMcpJson(tmp);
+    expect(round).toHaveLength(1);
+    expect(round?.[0]?.id).toBe("b");
+  });
+
+  it("removeDotMcpServer is a no-op when file is absent", () => {
+    removeDotMcpServer(tmp, "x");
+    expect(readDotMcpJson(tmp)).toBe(null);
+  });
+
+  it("removeDotMcpServer is a no-op when id is absent", () => {
+    setDotMcpServer(tmp, { id: "a", transport: "http", url: "http://a", autoConnect: true });
+    removeDotMcpServer(tmp, "nonexistent");
+    expect(readDotMcpJson(tmp)).toHaveLength(1);
   });
 });
 

--- a/packages/gateway-core/src/mcp-config-store.ts
+++ b/packages/gateway-core/src/mcp-config-store.ts
@@ -41,7 +41,7 @@
  * verbatim.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
 import type { ProjectMcpServer } from "@agi/config";
@@ -166,4 +166,73 @@ export function readProjectMcpServers(
   if (fromDot !== null) return { servers: fromDot, source: "dotmcp" };
   if (legacyServers && legacyServers.length > 0) return { servers: legacyServers, source: "legacy" };
   return { servers: [], source: "none" };
+}
+
+/**
+ * Inverse of `mcpEntryToServer` — translate one internal ProjectMcpServer
+ * into the Claude-Code-shaped `.mcp.json` entry. Lives here (not in the
+ * migration module) so the write helpers below can call it without a
+ * circular import. The migration module re-exports it for back-compat.
+ *
+ * - `transport` → `type`
+ * - `command: string[]` → split into `{ command, args }` (head + tail)
+ * - `authToken` → `headers: { Authorization: "Bearer <token>" }` for
+ *   http/websocket only (stdio keeps authToken in env there)
+ */
+export function serverToMcpEntry(server: ProjectMcpServer): McpServerEntry {
+  const entry: McpServerEntry = {
+    type: server.transport,
+    autoConnect: server.autoConnect,
+  };
+  if (server.name !== undefined) entry.name = server.name;
+  if (server.url !== undefined) entry.url = server.url;
+  if (server.command !== undefined && server.command.length > 0) {
+    entry.command = server.command[0];
+    if (server.command.length > 1) entry.args = server.command.slice(1);
+  }
+  if (server.env !== undefined) entry.env = server.env;
+  if (server.authToken !== undefined && (server.transport === "http" || server.transport === "websocket")) {
+    entry.headers = { Authorization: `Bearer ${server.authToken}` };
+  }
+  return entry;
+}
+
+/**
+ * Write the full set of servers to `.mcp.json`, replacing any existing
+ * file. Atomic via temp + rename so a SIGINT mid-write can't leave a
+ * torn file. Pass an empty array to write `{ mcpServers: {} }` (used
+ * when the last server is removed).
+ */
+export function writeDotMcpJson(projectPath: string, servers: readonly ProjectMcpServer[]): void {
+  const path = projectMcpPath(projectPath);
+  const mcpServers: Record<string, McpServerEntry> = {};
+  for (const server of servers) mcpServers[server.id] = serverToMcpEntry(server);
+  const payload: DotMcpJson = { mcpServers };
+  // Atomic write — temp + rename so a torn file can't surface mid-write.
+  const tmp = `${path}.tmp.${String(process.pid)}`;
+  writeFileSync(tmp, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+  renameSync(tmp, path);
+}
+
+/**
+ * Add or update a single server in `.mcp.json`. Reads existing entries,
+ * upserts by id, writes the merged set. Idempotent on re-add of the
+ * same id with the same payload.
+ */
+export function setDotMcpServer(projectPath: string, server: ProjectMcpServer): void {
+  const existing = readDotMcpJson(projectPath) ?? [];
+  const filtered = existing.filter((s) => s.id !== server.id);
+  filtered.push(server);
+  writeDotMcpJson(projectPath, filtered);
+}
+
+/**
+ * Remove a server from `.mcp.json` by id. No-op when the file or id
+ * doesn't exist (caller doesn't need to check first).
+ */
+export function removeDotMcpServer(projectPath: string, id: string): void {
+  const existing = readDotMcpJson(projectPath);
+  if (existing === null) return;
+  const filtered = existing.filter((s) => s.id !== id);
+  writeDotMcpJson(projectPath, filtered);
 }

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -29,6 +29,7 @@ import type { DashboardApi } from "./dashboard-api.js";
 import type { DashboardQueries } from "./dashboard-queries.js";
 import { GatewayWebSocketServer } from "./ws-server.js";
 import { handlePlanRequest } from "./plan-api.js";
+import { readProjectMcpServers, setDotMcpServer, removeDotMcpServer } from "./mcp-config-store.js";
 import type { EntityStore, CommsLog, NotificationStore } from "@agi/entity-model";
 import { fetchOwnerToken, injectTokenIntoCloneUrl } from "./dev-mode-auth.js";
 import { createComponentLogger } from "./logger.js";
@@ -2030,6 +2031,8 @@ export async function createGatewayRuntimeState(
   };
 
   // GET /api/projects/mcp/list?path= — list MCP servers + connection state.
+  // s131 t682 — reads via the dual-read API: prefers .mcp.json, falls
+  // back to legacy project.json mcp.servers[] for unmigrated installs.
   fastify.get("/api/projects/mcp/list", async (request, reply) => {
     const clientIp = getClientIp(request.raw);
     if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Projects API only allowed from private network" });
@@ -2042,7 +2045,9 @@ export async function createGatewayRuntimeState(
       return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
     }
     const cfg = await deps.projectConfigManager.read(targetPath);
-    const servers = (cfg as { mcp?: { servers?: Array<{ id: string; name?: string; transport: string; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }> } }).mcp?.servers ?? [];
+    const legacy = (cfg as { mcp?: { servers?: Array<{ id: string; name?: string; transport: string; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }> } }).mcp?.servers;
+    const dualResult = readProjectMcpServers(targetPath, legacy as Parameters<typeof readProjectMcpServers>[1]);
+    const servers = dualResult.servers as typeof legacy & object;
     // Augment with live connection state from mcpClient.
     const liveServers = deps.mcpClient?.listServers() ?? [];
     const liveById = new Map(liveServers.map((s: { id: string; state: string }) => [s.id, s.state]));
@@ -2075,10 +2080,18 @@ export async function createGatewayRuntimeState(
     }
     if (!existsSync(projectConfigPath(targetPath))) return reply.code(404).send({ error: "Project has no project.json" });
     try {
+      // s131 t682 — write to .mcp.json (Claude Code convention). Legacy
+      // project.json mcp.servers writes are removed; the boot migration
+      // (t681) brings unmigrated projects forward, and the dual-read in
+      // /list keeps them visible until then. Atomic temp+rename inside
+      // setDotMcpServer.
+      setDotMcpServer(targetPath, body.server as Parameters<typeof setDotMcpServer>[1]);
+      // Re-derive the post-write state for the response so callers see
+      // the same shape that /list returns.
       const cur = await deps.projectConfigManager.read(targetPath);
-      const servers = ((cur as { mcp?: { servers?: typeof body.server[] } }).mcp?.servers ?? []).filter((s) => s.id !== body.server!.id);
-      servers.push(body.server);
-      const updated = await deps.projectConfigManager.update(targetPath, { mcp: { servers } } as Record<string, unknown>);
+      const dualResult = readProjectMcpServers(targetPath, (cur as { mcp?: { servers?: typeof body.server[] } }).mcp?.servers as Parameters<typeof readProjectMcpServers>[1]);
+      const servers = dualResult.servers;
+      const updated = { mcp: { servers } } as { mcp: { servers: typeof servers } };
       // Re-register with mcpClient under namespaced id (best-effort; surfaces error in response).
       let registerError: string | null = null;
       if (deps.mcpClient && (body.server.autoConnect ?? true)) {
@@ -2120,9 +2133,9 @@ export async function createGatewayRuntimeState(
       return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
     }
     try {
-      const cur = await deps.projectConfigManager.read(targetPath);
-      const servers = ((cur as { mcp?: { servers?: Array<{ id: string }> } }).mcp?.servers ?? []).filter((s) => s.id !== idParam);
-      await deps.projectConfigManager.update(targetPath, { mcp: { servers } } as Record<string, unknown>);
+      // s131 t682 — remove from .mcp.json. No-op when neither .mcp.json
+      // nor legacy mcp.servers carries the id.
+      removeDotMcpServer(targetPath, idParam);
       // Best-effort unregister.
       try { await deps.mcpClient?.unregisterServer?.(mcpServerNs(targetPath, idParam)); } catch { /* ignore */ }
       return reply.send({ ok: true });

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -2327,6 +2327,12 @@ export async function startGatewayServer(
   try {
     const { readProjectEnv, resolveDollarVars, resolveDollarVarsObject } = await import("./project-env-store.js");
     const { projectConfigPath: pcp, projectSlug: pslug } = await import("./project-config-path.js");
+    // s131 t682 — read MCP servers via the dual-read API. Prefers
+    // `<projectPath>/.mcp.json` (Claude Code convention) over the legacy
+    // `project.json mcp.servers[]` block. Boot-time migration (t681)
+    // already brings unmigrated projects forward, so by this point most
+    // projects read from .mcp.json directly.
+    const { readProjectMcpServers: readMcpDual } = await import("./mcp-config-store.js");
     for (const projectDir of projectPaths) {
       try {
         const { readdirSync, statSync } = await import("node:fs");
@@ -2336,8 +2342,12 @@ export async function startGatewayServer(
           const cfgPath = pcp(fullPath);
           if (!existsSync(cfgPath)) continue;
           const raw = JSON.parse(readFileSync(cfgPath, "utf-8")) as { mcp?: { servers?: Array<{ id: string; name?: string; transport: "stdio" | "http" | "websocket"; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }> } };
-          const projectServers = raw.mcp?.servers ?? [];
+          const dualResult = readMcpDual(fullPath, raw.mcp?.servers as Parameters<typeof readMcpDual>[1]);
+          const projectServers = dualResult.servers as Array<{ id: string; name?: string; transport: "stdio" | "http" | "websocket"; command?: string[]; env?: Record<string, string>; url?: string; autoConnect?: boolean; authToken?: string }>;
           if (projectServers.length === 0) continue;
+          if (dualResult.source === "legacy") {
+            log.info(`mcp: project ${entry} still using legacy project.json mcp.servers — migration will run on next restart`);
+          }
           const projectEnv = readProjectEnv(fullPath);
           // s128 cycle 86 — per-project secret resolver. $VAR reads from the
           // project's .env (legacy); vault://<id> resolves through VaultResolver


### PR DESCRIPTION
## Summary

Closes the read+write end-to-end loop on s131. After this commit:
- New servers added via the dashboard MCPTab land in **\`.mcp.json\`**
- Boot wiring reads \`.mcp.json\` (with project.json mcp.servers fallback for unmigrated installs)
- DELETE removes from \`.mcp.json\`
- \`/list\` returns the dual-read result

\`mcp-config-store\` gains \`writeDotMcpJson\` / \`setDotMcpServer\` / \`removeDotMcpServer\` (atomic temp+rename). \`serverToMcpEntry\` moved here from migration to break the circular import; migration module re-exports for back-compat.

Bump 0.4.577 → 0.4.578. s131 progress 3/5. Remaining: t683 schema-deprecation, t684 e2e.

## Test plan

- [x] 9 new write-helper tests (create / replace-not-append / empty / upsert / siblings / remove + no-op variants) — pass
- [x] 28 total mcp-config-store + 15 migration tests pass
- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)