### PR TITLE
feat(mcp): deprecate project.json mcp field + validate .mcp.json (s131 t683)

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -752,6 +752,28 @@ async function projectShapeChecks(config: AionimaConfig): Promise<CheckGroup | n
       const hosting = raw.hosting as Record<string, unknown> | undefined;
       if (hosting && "containerKind" in hosting) findings.push("legacy `hosting.containerKind` field present (s150 t634)");
 
+      // s131 t683 — flag the deprecated mcp field (boot migration writes
+      // `.mcp.json` and strips this on next restart; surface as drift so
+      // operators know what's about to happen).
+      if ("mcp" in raw) findings.push("legacy `mcp` field present (s131 — will migrate to .mcp.json on next boot)");
+
+      // s131 t683 — validate `.mcp.json` if present. Loud-fail so a hand-
+      // edited but malformed file surfaces here rather than at next boot.
+      const dotMcpPath = path.join(projectPath, ".mcp.json");
+      if (fileExists(dotMcpPath)) {
+        try {
+          const mcpRaw = JSON.parse(await readFile(dotMcpPath, "utf-8")) as unknown;
+          const { DotMcpJsonSchema } = await import("@agi/gateway-core");
+          const result = DotMcpJsonSchema.safeParse(mcpRaw);
+          if (!result.success) {
+            const firstIssue = result.error.issues[0];
+            findings.push(`.mcp.json schema error: ${firstIssue?.path.join(".") ?? "(root)"}: ${firstIssue?.message ?? "unknown"}`);
+          }
+        } catch (e) {
+          findings.push(`.mcp.json unparseable (${e instanceof Error ? e.message : String(e)})`);
+        }
+      }
+
       const agiDebris = path.join(projectPath, ".agi", "project.json");
       if (fileExists(agiDebris)) findings.push("`.agi/project.json` debris (s130 → s140 leftover)");
 

--- a/config/src/project-schema.ts
+++ b/config/src/project-schema.ts
@@ -379,7 +379,16 @@ export const ProjectConfigSchema = z
     aiDatasets: z.array(ProjectAiDatasetBindingSchema).optional(),
     /** Iterative-work mode — toggles tynn-workflow prompt injection + cron-nudged scheduling. */
     iterativeWork: ProjectIterativeWorkSchema.optional(),
-    /** Per-project MCP servers (Wish #7) — surfaces on the project's MCP tab. */
+    /**
+     * @deprecated s131 (2026-05-09) — per-project MCP servers moved to a
+     * top-level `<projectPath>/.mcp.json` file (Claude Code convention).
+     * The boot-time migration in `mcp-config-migration.ts` rewrites this
+     * field into `.mcp.json` and strips it from project.json on first
+     * boot after the upgrade. New writes (PUT /api/projects/mcp/server)
+     * land in `.mcp.json` directly. Reads fall through via the dual-read
+     * API in `mcp-config-store.ts`. Kept here as `.optional()` so legacy
+     * project.json files parse without error during the migration window.
+     */
     mcp: ProjectMcpSchema.optional(),
     /** Sub-repos served from this project — s130 phase B (t515).
      *  Each entry clones into `<projectPath>/repos/<name>/`. Used by

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.578",
+  "version": "0.4.579",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Adds @deprecated JSDoc tag to \`ProjectConfigSchema.mcp\` pointing at \`.mcp.json\` (Claude Code convention) + the migration path. Field stays \`.optional()\` so legacy project.json files parse without error during the migration window.

\`agi doctor schema\` (via projectShapeChecks) gains two findings per project:
- **legacy mcp field present** — surfaces what's about to happen so operators see the migration plan up-front instead of being surprised.
- **.mcp.json schema error** — runs \`DotMcpJsonSchema.safeParse\` on every \`.mcp.json\`. Loud-fails on malformed hand-edits BEFORE next boot crashes, with offending path + zod message. doctor layer reports as a finding (not a throw) so multi-project audits don't bail on the first bad file.

Bump 0.4.578 → 0.4.579. s131 progress 4/5. Remaining: t684 e2e.

## Test plan

- [x] Typecheck clean on @agi/cli + @agi/config
- [x] Same-commit guards (route-check / docs-check / staged-check) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)