### PR TITLE
docs(pax): audit findings for s156 — MarkdownEditor upstream + Table for lists

### DIFF
--- a/docs/agents/pax-audit.md
+++ b/docs/agents/pax-audit.md
@@ -108,6 +108,11 @@ These files already pull from PAx — use as reference for refactor shape:
 
 Items where the right PAx primitive may not exist yet:
 
+- **Markdown editor**: fancy-code exports `CodeEditor` (syntax-highlighted
+  code) but no MarkdownEditor with optional preview. NotesPanel currently
+  uses a hand-rolled `<textarea>`. **Filed upstream:**
+  [Particle-Academy/fancy-code#2](https://github.com/Particle-Academy/fancy-code/issues/2).
+  Tracked Aionima-side under tynn s156 t673.
 - **Toast/notification stack**: `NotificationBell.tsx` shows a list; the
   permanent toast surface (cycle 162 spec) needs PAx Toast. **File
   upstream issue against react-fancy if no Toast primitive is present.**
@@ -117,6 +122,14 @@ Items where the right PAx primitive may not exist yet:
 - **Universal help Support Canvas** (s137 t531): doc-tree + reader
   primitives exist in fancy-code; combining them into a Support Canvas
   shape is a local component, not a missing PAx primitive.
+
+## 7. List-with-selection primitive (resolved 2026-05-09 cycle 260)
+
+react-fancy's **Table** primitive (with `onRowClick`) is the right fit
+for selectable lists; no upstream issue needed. NotesPanel + future
+list-shaped UIs route through Table when they need single-column +
+clickable selection. fancy-sheets' Spreadsheet/Sheet are overkill for
+flat lists. Sidebar is for nav-shaped lists.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.580",
+  "version": "0.4.581",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Audit conclusions for the s156 NotesPanel refactor:

- **Markdown editor (t673)**: fancy-code has \`CodeEditor\` (syntax-highlighted) but no \`MarkdownEditor\` with preview. **Filed upstream as [Particle-Academy/fancy-code#2](https://github.com/Particle-Academy/fancy-code/issues/2)** with cross-references to Aionima consumers (NotesPanel, future Support Canvas, future PM-Lite kanban descriptions).
- **List with selection (t674)**: \`react-fancy Table\` with \`onRowClick\` is the right fit. fancy-sheets Spreadsheet/Sheet is overkill. Sidebar is for nav-shaped lists. No upstream issue needed.

\`pax-audit.md\` updated with both findings + the upstream link.

t675 (NotesPanel internals refactor) accepts the temporary \`<textarea>\` pinned to issue #2 and switches the list to Table. t676 re-verifies PmLitePanel + ProjectDetail tab trim against the same primitives.

Bump 0.4.580 → 0.4.581. s156 progress 2/4.

## Test plan

- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [x] Upstream issue filed: Particle-Academy/fancy-code#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)