### PR TITLE
feat(iw): scheduler fire-rate observability + runaway WARN (s159 t693)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.583",
+  "version": "0.4.584",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/iterative-work/scheduler.test.ts
+++ b/packages/gateway-core/src/iterative-work/scheduler.test.ts
@@ -560,3 +560,45 @@ describe("IterativeWorkScheduler operator kill switch (s159 t692)", () => {
     expect(fires).toHaveLength(2);
   });
 });
+
+describe("IterativeWorkScheduler fire-rate observability (s159 t693)", () => {
+  it("getRecentFireCount returns 0 for a project that has never fired", () => {
+    const scheduler = new IterativeWorkScheduler({
+      projectConfigManager: makeConfigManager({}),
+      listProjectPaths: () => [],
+    });
+    expect(scheduler.getRecentFireCount("/p/never")).toBe(0);
+  });
+
+  it("getRecentFireCount returns 1 after a normal fire", () => {
+    const scheduler = new IterativeWorkScheduler({
+      projectConfigManager: makeConfigManager({
+        "/p/a": { iterativeWork: { enabled: true, cron: "* * * * *" } },
+      }),
+      listProjectPaths: () => ["/p/a"],
+    });
+    scheduler.tick(new Date("2026-04-27T05:30:00.000Z"));
+    expect(scheduler.getRecentFireCount("/p/a", new Date("2026-04-27T05:30:30.000Z"))).toBe(1);
+  });
+
+  it("getRecentFireCount drops timestamps older than the 60s window", () => {
+    const scheduler = new IterativeWorkScheduler({
+      projectConfigManager: makeConfigManager({
+        "/p/a": { iterativeWork: { enabled: true, cron: "* * * * *" } },
+      }),
+      listProjectPaths: () => ["/p/a"],
+    });
+    scheduler.tick(new Date("2026-04-27T05:00:00.000Z"));
+    // 90s later, the recorded fire timestamp is outside the 60s window.
+    expect(scheduler.getRecentFireCount("/p/a", new Date("2026-04-27T05:01:30.000Z"))).toBe(0);
+  });
+
+  // NOTE: testing the "5 fires in 60s → WARN" runaway path against
+  // scheduler.tick directly is tricky because the natural scheduler.tick
+  // path is rate-limited by the cron's next-fire-time gate AND lastFiredAt
+  // tracking. The runaway scenario reported by owner (Wish #20 / s159)
+  // is downstream of scheduler.tick — at the agent-invoker / Taskmaster
+  // worker level. This counter is observability for IF the scheduler
+  // itself ever loops (defense in depth); the actual reported bug needs
+  // tracing in agent-invoker (s159 t693 follow-up) + reproducer (t694).
+});

--- a/packages/gateway-core/src/iterative-work/scheduler.ts
+++ b/packages/gateway-core/src/iterative-work/scheduler.ts
@@ -48,6 +48,21 @@ const DEFAULT_TICK_MS = 30_000;
 const MIN_TICK_MS = 1_000;
 const DEFAULT_LOG_BUFFER = 50;
 
+/**
+ * s159 t693 — fire-rate observability constants. The scheduler tracks
+ * timestamps of recent fires per project; if more than
+ * FIRE_RATE_WARN_THRESHOLD fires occur within FIRE_RATE_WINDOW_MS, a
+ * WARN log surfaces the runaway pattern. Pure observability — does not
+ * gate the fire (that's t695 idempotency + t696 cooldown's job).
+ *
+ * Threshold of 5 fires/60s is intentionally permissive — the
+ * scheduler ticks every 30s by default so legitimate per-minute crons
+ * fire 1×/min for one project, well under the threshold. A loop that
+ * trips this is firing every 10-15s (4-6 per minute) — clearly broken.
+ */
+const FIRE_RATE_WINDOW_MS = 60_000;
+const FIRE_RATE_WARN_THRESHOLD = 5;
+
 export class IterativeWorkScheduler extends EventEmitter<IterativeWorkSchedulerEvents> {
   private timer?: ReturnType<typeof setInterval>;
   private readonly inFlight = new Set<string>();
@@ -59,6 +74,11 @@ export class IterativeWorkScheduler extends EventEmitter<IterativeWorkSchedulerE
   private readonly iterationLog = new Map<string, IterativeWorkLogEntry[]>();
   /** Per-project timestamp of the in-flight fire, used to compute durationMs at completion. */
   private readonly inFlightStartedAt = new Map<string, Date>();
+  /**
+   * s159 t693 — sliding window of recent fire timestamps per project,
+   * for the runaway-loop WARN log + future dashboard surface.
+   */
+  private readonly recentFiresByProject = new Map<string, number[]>();
 
   constructor(private readonly deps: IterativeWorkSchedulerDeps) {
     super();
@@ -190,6 +210,24 @@ export class IterativeWorkScheduler extends EventEmitter<IterativeWorkSchedulerE
       this.inFlight.add(projectPath);
       this.inFlightStartedAt.set(projectPath, now);
       this.lastFiredAt.set(projectPath, now);
+
+      // s159 t693 — fire-rate tracking. Push the firedAt timestamp into
+      // a 60s sliding window per project; if the window contains
+      // FIRE_RATE_WARN_THRESHOLD or more entries, emit a WARN log so
+      // the next runaway loop is visible BEFORE it becomes a crisis.
+      // Pure observability — does not gate the fire itself (that's the
+      // job of t695 idempotency + t696 cooldown).
+      const recent = this.recentFiresByProject.get(projectPath) ?? [];
+      const cutoffMs = now.getTime() - FIRE_RATE_WINDOW_MS;
+      const pruned = recent.filter((t) => t >= cutoffMs);
+      pruned.push(now.getTime());
+      this.recentFiresByProject.set(projectPath, pruned);
+      if (pruned.length >= FIRE_RATE_WARN_THRESHOLD) {
+        this.log.warn(
+          `fire-rate: ${projectPath} fired ${String(pruned.length)} times in the last ${String(FIRE_RATE_WINDOW_MS / 1000)}s — possible runaway loop. ` +
+          `Use \`agi iw stop --project ${projectPath}\` to break it without restarting the gateway.`,
+        );
+      }
       // Push a "running" entry to the per-project ring buffer. recordCompletion
       // mutates this head entry when the consumer reports status; until then
       // the log surface shows the in-flight iteration as running.
@@ -212,6 +250,19 @@ export class IterativeWorkScheduler extends EventEmitter<IterativeWorkSchedulerE
   /** Diagnostic: snapshot of current in-flight project paths. */
   getInFlight(): string[] {
     return [...this.inFlight];
+  }
+
+  /**
+   * Diagnostic: how many times this project has fired in the rolling
+   * 60s window. > FIRE_RATE_WARN_THRESHOLD means the scheduler logged
+   * a WARN on the most recent fire. Caller (e.g. dashboard tile, doctor
+   * check) can surface the same data ahead of crisis. (s159 t693)
+   */
+  getRecentFireCount(projectPath: string, now: Date = new Date()): number {
+    const recent = this.recentFiresByProject.get(projectPath);
+    if (!recent) return 0;
+    const cutoffMs = now.getTime() - FIRE_RATE_WINDOW_MS;
+    return recent.filter((t) => t >= cutoffMs).length;
   }
 
   /**


### PR DESCRIPTION
## Summary

Sliding 60s window per project; WARN log when ≥5 fires in 60s with explicit \`agi iw stop\` recovery instruction.

\`getRecentFireCount(projectPath, now?)\` accessor for future dashboard tile + doctor check.

**Scope honest:** catches scheduler.tick-level runaway (defense in depth). The actual Wish #20 runaway is downstream at agent-invoker / Taskmaster worker layer — that needs a reproducer (t694) before the idempotency layer (t695) gets designed correctly.

Bump 0.4.583 → 0.4.584. s159 progress 3/8 (t692 + t693 + this — wait, t693 is THIS one).

## Test plan

- [x] 3 new tests on getRecentFireCount + comment explaining the WARN-test gap
- [x] 37 total scheduler tests pass
- [x] Same-commit guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)