### PR TITLE
fix(systemd): Restart=always so dashboard restart button actually restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.584",
+  "version": "0.4.585",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/agi.service
+++ b/scripts/agi.service
@@ -18,7 +18,14 @@ Environment=NODE_EXTRA_CA_CERTS=/var/lib/caddy/.local/share/caddy/pki/authoritie
 # --- END CREDENTIALS ---
 
 ExecStart=/usr/bin/node /opt/agi/cli/dist/index.js run
-Restart=on-failure
+# Restart=always (not on-failure) — the dashboard's Gateway Restart button
+# (POST /api/gateway/restart) and `agi restart` both send SIGTERM to the
+# process, which the gateway handles as a clean shutdown (exit 0). With
+# Restart=on-failure, systemd treats clean exits as success and does NOT
+# bring the service back up — meaning Restart became Stop in practice.
+# Restart=always brings it back regardless of exit code; `systemctl stop
+# agi` still stops it (state transition, not exit-code-driven).
+Restart=always
 RestartSec=5
 TimeoutStopSec=10
 KillMode=mixed


### PR DESCRIPTION
## Summary

Owner-reported: clicking the Settings → Gateway → **Restart** button shuts the service down but doesn't bring it back up.

**Root cause**: \`scripts/agi.service\` had \`Restart=on-failure\`. The restart endpoint sends SIGTERM, gateway handles it as a clean shutdown (exit 0). systemd treats clean exits as success and does NOT restart — so **Restart became Stop in practice**.

The comment in \`server-runtime-state.ts:677\` already documented the intent (\`Restart=always\`); the unit file had drifted to \`on-failure\`. This commit realigns the unit with the documented intent.

Trade-off: \`Restart=always\` brings the service back even on clean exits. \`systemctl stop agi\` still stops the unit (state transition, not exit-code-driven), so no runaway risk.

**Auto-applied on next upgrade**: \`scripts/upgrade.sh:562-580\` diffs + replaces \`/etc/systemd/system/agi.service\` + \`daemon-reload\` on every upgrade. No manual operator action needed.

Bump 0.4.584 → 0.4.585.

## Test plan

- [x] Same-commit guards (route-check / docs-check / staged-check) — clean
- [ ] Manual after upgrade: click Settings → Gateway → Restart; verify service comes back up within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)