### PR TITLE
refactor(notes-panel): list → PAx Table (s156 t675)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.586",
+  "version": "0.4.587",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/NotesPanel.tsx
+++ b/ui/dashboard/src/components/NotesPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
+import { Table } from "@particle-academy/react-fancy";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -196,27 +197,37 @@ export function NotesPanel({ projectPath }: NotesPanelProps): ReactElement {
               No notes yet. Click + New to start one.
             </p>
           )}
-          <ul className="space-y-1" data-testid="notes-list">
-            {notes.map((note) => {
-              const isSelected = note.id === selectedId;
-              return (
-                <li key={note.id}>
-                  <button
-                    type="button"
-                    className={`w-full text-left px-2 py-1.5 rounded text-[13px] flex items-center gap-2 ${
+          {/* s156 t675 — list rendered via PAx Table for selection
+              affordance + a11y. Each row's onClick selects the note;
+              the row className highlights the selected one. Pin
+              indicator is the leading cell. */}
+          <Table className="border-0" data-testid="notes-list">
+            <Table.Body>
+              {notes.map((note) => {
+                const isSelected = note.id === selectedId;
+                return (
+                  <Table.Row
+                    key={note.id}
+                    onClick={() => setSelectedId(note.id)}
+                    className={`cursor-pointer text-[13px] ${
                       isSelected ? "bg-foreground text-background" : "hover:bg-secondary/40"
                     }`}
-                    onClick={() => setSelectedId(note.id)}
                     data-testid="notes-list-item"
                     data-note-id={note.id}
                   >
-                    {note.pinned && <span title="Pinned" className="text-yellow text-[10px]">★</span>}
-                    <span className="flex-1 truncate" title={note.title}>{note.title || "Untitled"}</span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+                    <Table.Cell className="w-4 px-1.5 py-1.5">
+                      {note.pinned ? (
+                        <span title="Pinned" className="text-yellow text-[10px]">★</span>
+                      ) : null}
+                    </Table.Cell>
+                    <Table.Cell className="px-1 py-1.5">
+                      <span className="truncate block" title={note.title}>{note.title || "Untitled"}</span>
+                    </Table.Cell>
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
         </div>
       </Card>
 
@@ -272,6 +283,12 @@ export function NotesPanel({ projectPath }: NotesPanelProps): ReactElement {
                 Delete
               </Button>
             </div>
+            {/* s156 t675 — body editor stays as raw <textarea> until
+                Particle-Academy/fancy-code ships a MarkdownEditor
+                primitive. Tracked at:
+                https://github.com/Particle-Academy/fancy-code/issues/2
+                When that primitive lands, swap this for
+                <MarkdownEditor value={draftBody} onValueChange={...}>. */}
             <textarea
               ref={bodyRef}
               value={draftBody}


### PR DESCRIPTION
## Summary

Swaps NotesPanel's hand-rolled \`<ul>/<li>/<button>\` list for PAx \`Table.Body / Row / Cell\` with onClick selection. Selected-row visual treatment preserved.

Body editor stays as raw \`<textarea>\` with TODO comment linking [Particle-Academy/fancy-code#2](https://github.com/Particle-Academy/fancy-code/issues/2) — no MarkdownEditor primitive in fancy-code yet (filed during s156 t673 audit). Swap when upstream lands.

All affordances preserved: ⌘S save, pin/unpin, delete, dirty-state label, char count.

Bump 0.4.586 → 0.4.587. s156 progress 3/4 — only t676 (PmLitePanel verification) left.

## Test plan

- [x] Typecheck clean on the changed file
- [x] Same-commit guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)