### PR TITLE
docs(pax): PmLitePanel + tab-trim re-audit (s156 t676 — CLOSES s156)

### DIFF
--- a/docs/agents/pax-audit.md
+++ b/docs/agents/pax-audit.md
@@ -131,6 +131,22 @@ list-shaped UIs route through Table when they need single-column +
 clickable selection. fancy-sheets' Spreadsheet/Sheet are overkill for
 flat lists. Sidebar is for nav-shaped lists.
 
+## 8. PmLitePanel + ProjectDetail tab-trim re-audit (resolved 2026-05-09 cycle 264, s156 t676)
+
+Re-audit per CLAUDE.md § 1.5 mandate after the cycle 263 flat-tabs nuke.
+
+- **PmLitePanel** — Card is PAx-backed via the local
+  `components/ui/card.tsx` adapter. View-pills (NEXT/CURRENT/DONE) are
+  filter-shaped, not navigational tabs — using the PAx Tabs primitive
+  would imply panel-switching semantics that don't apply here. Lists
+  are read-only flat display with semantic `<ul>/<li>` — no selection
+  affordance needed; Table would force header-row semantics for no
+  gain. **Conclusion: acceptable as-is.**
+
+- **ProjectDetail tab-trim** — was the s150 t638 primary/secondary
+  split with a "More…" Select dropdown. Cycle 263 (PR #97) nuked the
+  dropdown entirely; all sub-tabs render flat. Audit moot.
+
 ---
 
 ## Process

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.587",
+  "version": "0.4.588",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Re-audit per CLAUDE.md § 1.5 mandate after cycle 263 flat-tabs nuke. Findings: PmLitePanel is acceptable as-is (Card PAx-backed, filter-pills aren't nav tabs, read-only flat lists are semantic), tab-trim moot.

**s156 CLOSED** end-to-end across 4 tasks (t673-t676).

Bump 0.4.587 → 0.4.588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)