### PR TITLE
feat(types): aionima-system project type (s119 t700)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.588",
+  "version": "0.4.589",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/project-types.ts
+++ b/packages/gateway-core/src/project-types.ts
@@ -141,6 +141,11 @@ export const CODE_SERVED_TYPES: ReadonlySet<string> = new Set([
   "static-site",
   "api-service",
   "php-app",
+  // s119 t700 (2026-05-09) — `aionima-system` is the always-present
+  // meta-project for the Aionima system itself; its repos contain code
+  // (forks of agi/prime/id/PAx/etc.), so it routes via code-served paths.
+  // Hosting is still false (Aionima isn't hosted as an app by itself).
+  "aionima-system",
   // s150 t640 (2026-05-07) — "monorepo" REMOVED. Every project is a monorepo
   // per the universal-monorepo directive; a sibling "monorepo" type as a
   // peer of web-app/static-site/etc. contradicts the model. The s150 t632
@@ -196,6 +201,10 @@ export const ITERATIVE_WORK_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
   "static-site",
   "php-app",
   "ops",
+  // s119 t700 (2026-05-09) — Aionima system project gets iterative-work
+  // so the owner can run Aion in autonomous-mode against the system
+  // itself (e.g. "drive remaining VIP 0.7.1 to done").
+  "aionima-system",
 ]);
 
 export const TESTING_UX_ELIGIBLE_TYPE_IDS: ReadonlySet<string> = new Set([
@@ -361,6 +370,34 @@ export function createProjectTypeRegistry(): ProjectTypeRegistry {
     hasCode: false,
     defaultMeta: {
       type: "aionima",
+      mode: "production",
+      internalPort: null,
+    },
+    tools: [],
+  });
+
+  // Aionima System — the always-present meta-project that holds Aionima
+  // itself. The dashboard's `_aionima` project (s119 t700) — repos folder
+  // contains every fork (agi, prime, id, marketplace, mapp-marketplace,
+  // react-fancy, fancy-code, fancy-sheets, fancy-echarts, fancy-3d,
+  // fancy-screens). k/ holds Aion's memory + user-generated system
+  // knowledge. Aion chat on this project lets the owner work on the
+  // Aionima system itself the same way they work on any other project.
+  // hasCode=true — repos contain real code consumers can edit / inspect /
+  // run via standard project tooling. hostable=false — Aionima isn't
+  // hosted as an app by itself (it IS the gateway). servesDesktop=false —
+  // not a Desktop-served project; the project's value is the repos +
+  // memory, not a hostname-routed surface.
+  registry.register({
+    id: "aionima-system",
+    label: "Aionima System",
+    category: "monorepo",
+    hostable: false,
+    hasCode: true,
+    servesDesktop: false,
+    iterativeWorkEligible: true,
+    defaultMeta: {
+      type: "aionima-system",
       mode: "production",
       internalPort: null,
     },


### PR DESCRIPTION
## Summary

First slice of the s119 _aionima-as-real-project work. Owner directive 2026-05-09: Aion chat needs to talk about Aionima itself.

This commit registers the new \`aionima-system\` builtin type:
- hostable=false, hasCode=true, servesDesktop=false, iterativeWorkEligible=true
- Indexed in CODE_SERVED_TYPES + ITERATIVE_WORK_ELIGIBLE_TYPE_IDS

Subsequent slices in s119: t701 scaffold layout, t702 always-present injection, t703 hard-move + symlink rewrite, t704 memory migration, t705 route consolidation, t706 e2e.

Bump 0.4.588 → 0.4.589.

## Test plan

- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)