### PR TITLE
feat(_aionima): boot-time scaffolder for the always-present meta-project (s119 t701)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.589",
+  "version": "0.4.590",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/project-config-path.ts
+++ b/packages/gateway-core/src/project-config-path.ts
@@ -323,6 +323,85 @@ export function scaffoldProjectFolders(projectPath: string): { created: string[]
 }
 
 /**
+ * Resolve the always-present `_aionima` system project path beneath a
+ * workspace root. The folder is reserved (per SACRED_PROJECT_NAMES) so
+ * the regular project-enumeration paths skip it; this helper hands the
+ * path to callers that explicitly want to address it (boot-time
+ * scaffolder + always-present injection in t702).
+ */
+export function aionimaSystemProjectPath(workspaceRoot: string): string {
+  return resolvePath(workspaceRoot, "_aionima");
+}
+
+export interface EnsureAionimaSystemResult {
+  /** Resolved `<workspaceRoot>/_aionima` path. */
+  projectPath: string;
+  /** Whether project.json was created this call. */
+  projectJsonCreated: boolean;
+  /** New folders created beneath the project (relative to projectPath). */
+  scaffoldedFolders: string[];
+}
+
+/**
+ * Idempotent boot-time scaffolder for the always-present `_aionima/`
+ * meta-project (s119 t701). Creates the universal monorepo layout
+ * (k/{plans,knowledge,pm,memory,chat}, repos/, sandbox/, .trash/) and
+ * a starter project.json declaring `type: aionima-system`,
+ * `name: "Aionima"` if missing.
+ *
+ * Non-destructive: existing files (including the legacy 9 forks
+ * currently at `_aionima/{agi,prime,...}` pre-t703-migration) are
+ * left alone. Once t703 runs, the forks live under `_aionima/repos/`
+ * and the new layout is the canonical shape.
+ *
+ * Bypasses the SACRED_PROJECT_NAMES guard intentionally — this is the
+ * meta-project's own scaffolder, not a generic per-project migration.
+ */
+export function ensureAionimaSystemProject(
+  workspaceRoot: string,
+): EnsureAionimaSystemResult {
+  const projectPath = aionimaSystemProjectPath(workspaceRoot);
+  if (!existsSync(projectPath)) {
+    mkdirSync(projectPath, { recursive: true });
+  }
+
+  // Scaffold the universal monorepo layout. Inline the layout list rather
+  // than calling scaffoldProjectFolders() because the latter sacred-skips
+  // _aionima — and the meta-project IS sacred (no auto-migration of its
+  // forks), but the layout itself is exactly what we want here.
+  const scaffoldedFolders: string[] = [];
+  const layout = findProjectSkeletonRoot();
+  if (layout) {
+    const created = copySkeletonInto(layout, projectPath);
+    for (const c of created) scaffoldedFolders.push(c.replace(`${projectPath}/`, ""));
+  } else {
+    for (const rel of PROJECT_FOLDER_LAYOUT_FALLBACK) {
+      const abs = join(projectPath, rel);
+      if (!existsSync(abs)) {
+        mkdirSync(abs, { recursive: true });
+        scaffoldedFolders.push(rel);
+      }
+    }
+  }
+
+  // Create starter project.json if missing. Type + name are pinned per
+  // s119 t700 (aionima-system type registered in project-types.ts).
+  const projectJsonPath = join(projectPath, "project.json");
+  let projectJsonCreated = false;
+  if (!existsSync(projectJsonPath)) {
+    const starter = {
+      name: "Aionima",
+      type: "aionima-system",
+      createdAt: new Date().toISOString(),
+    };
+    writeFileSync(projectJsonPath, JSON.stringify(starter, null, 2) + "\n", "utf-8");
+    projectJsonCreated = true;
+  }
+
+  return { projectPath, projectJsonCreated, scaffoldedFolders };
+}
+
+/**
  * Idempotent migration helper. If the legacy config exists and the new
  * one doesn't, copy the file (creating `<projectPath>/.agi/` if needed)
  * and scaffold the s130 folder layout. Returns details about what

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -128,7 +128,7 @@ import { ImageBlobStore } from "./image-blob-store.js";
 import { WorkerPromptLoader } from "./worker-prompt-loader.js";
 import { ChatGarbageCollector } from "./chat-garbage-collector.js";
 import { buildTynnSyncPrompt } from "./plan-tynn-mapper.js";
-import { ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-path.js";
+import { ensureAionimaSystemProject, ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-path.js";
 import { HostingManager } from "./hosting-manager.js";
 import { ProjectConfigManager } from "./project-config-manager.js";
 import { migrateAllProjectConfigShapes } from "./project-config-shape-migration.js";
@@ -1828,6 +1828,25 @@ export async function startGatewayServer(
       logger.warn(
         "migrate",
         `boot-time s150 skeleton seed failed for ${workspaceRoot} (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // s119 t701 (2026-05-09) — always-present `_aionima` meta-project
+    // scaffold. Idempotent; creates the universal monorepo layout
+    // beneath `<workspaceRoot>/_aionima/` if missing. Aion chat on this
+    // project lets the owner work on the Aionima system itself.
+    try {
+      const r = ensureAionimaSystemProject(workspaceRoot);
+      if (r.projectJsonCreated || r.scaffoldedFolders.length > 0) {
+        logger.info(
+          "migrate",
+          `boot-time s119 _aionima scaffold: ${r.projectPath} (project.json=${String(r.projectJsonCreated)}, folders=${String(r.scaffoldedFolders.length)})`,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        "migrate",
+        `boot-time s119 _aionima scaffold failed for ${workspaceRoot} (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Second slice of the s119 _aionima-as-real-project work. Owner directive 2026-05-09: \`_aionima\` is always present + uses the universal monorepo layout.

\`ensureAionimaSystemProject(workspaceRoot)\` creates \`_aionima/{project.json, k/, repos/, sandbox/, .trash/}\` idempotently. Wired in server.ts boot.

**Non-destructive**: legacy 9 forks at \`_aionima/{agi,prime,...}\` (current state) are left alone. t703 mv's them into \`repos/\` in the destructive cutover slice.

Bump 0.4.589 → 0.4.590. s119 progress 2/7.

## Test plan

- [x] Typecheck clean on @agi/gateway-core
- [x] Same-commit guards clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)