### PR TITLE
feat(issues): per-project issue registry — Wish #21 Slice 1

### DIFF
--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -200,6 +200,51 @@ identify the looping project from logs alone.
 
 ---
 
+### agi issue — per-project issue registry (Wish #21)
+
+Agent-curated registry for failures Aion (or Claude Code) hits when
+attempting an expected action. Each project has its own
+`<projectPath>/k/issues/` directory: one Markdown file per issue
+(frontmatter + body), plus `index.json` for fast hash lookup.
+
+```bash
+# List issues across all projects (aggregate)
+agi issue list
+
+# List issues for one project
+agi issue list --project /home/wishborn/_projects/_aionima
+
+# Show full issue body
+agi issue show i-001 --project /home/wishborn/_projects/_aionima
+
+# File a new issue (auto-dedups via symptom-hash)
+agi issue file --project /home/wishborn/_projects/_aionima \
+  --title "Taskmaster runaway loop" \
+  --symptom "Same job re-queued every 30s; only fix is gateway restart" \
+  --tool taskmaster --exit 1 --tags taskmaster,runaway-loop
+
+# Mark as fixed with a resolution note
+agi issue fix i-001 --project /home/wishborn/_projects/_aionima \
+  --resolution "Fixed in agi v0.4.x via per-key cooldown"
+```
+
+**Dedup model.** Filing computes a `symptom_hash` from the normalized
+symptom + tool + exit_code. If the hash matches an existing issue in
+the project's `index.json`, the existing issue's `occurrences` is
+incremented + an "Investigation log" entry appended. Otherwise a new
+file is created with id `i-NNN`.
+
+**Statuses.** `open` (default on creation) → `known` (acknowledged but
+not yet fixed) → `fixed` (closed via `agi issue fix`). `wont-fix`
+available for issues we explicitly accept.
+
+**Where to file:** the project where the failure occurred. For
+Aionima-system failures (Aion failing to ingest a model, gateway boot
+issues, etc.) file against `_aionima`. Per-app failures file against
+the app project.
+
+---
+
 ### agi config
 
 Read configuration values from `~/.agi/gateway.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.592",
+  "version": "0.4.593",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/issues/index.ts
+++ b/packages/gateway-core/src/issues/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Issue registry — Wish #21. Public barrel.
+ */
+
+export type {
+  Issue,
+  IssueAgent,
+  IssueFrontmatter,
+  IssueIndexEntry,
+  IssueStatus,
+  LogIssueInput,
+  LogIssueResult,
+} from "./types.js";
+
+export { hashSymptom, normalizeSymptom } from "./symptom-hash.js";
+
+export {
+  findBySymptomHash,
+  issuesDir,
+  listIssues,
+  logIssue,
+  nextIssueId,
+  parseIssueFile,
+  readIndex,
+  readIssue,
+  updateIssueStatus,
+} from "./store.js";

--- a/packages/gateway-core/src/issues/store.test.ts
+++ b/packages/gateway-core/src/issues/store.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  findBySymptomHash,
+  issuesDir,
+  listIssues,
+  logIssue,
+  nextIssueId,
+  parseIssueFile,
+  readIndex,
+  readIssue,
+  updateIssueStatus,
+} from "./store.js";
+
+let project: string;
+
+beforeEach(() => {
+  project = join(tmpdir(), `issues-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(project, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+describe("issuesDir (Wish #21)", () => {
+  it("returns <project>/k/issues", () => {
+    expect(issuesDir("/foo/bar")).toBe("/foo/bar/k/issues");
+  });
+});
+
+describe("logIssue create + index (Wish #21)", () => {
+  it("creates a new issue file + index entry on first call", () => {
+    const r = logIssue(project, {
+      title: "Plaid webhook 401",
+      symptom: "401 Unauthorized from POST /v1/webhook",
+      tool: "fetch",
+      exit_code: 401,
+      tags: ["plaid", "auth"],
+    });
+    expect(r.outcome).toBe("created");
+    expect(r.id).toBe("i-001");
+    expect(r.occurrences).toBe(1);
+    expect(existsSync(join(issuesDir(project), "i-001.md"))).toBe(true);
+    expect(existsSync(join(issuesDir(project), "index.json"))).toBe(true);
+
+    const idx = readIndex(project);
+    expect(idx).toHaveLength(1);
+    expect(idx[0]?.id).toBe("i-001");
+    expect(idx[0]?.tags).toEqual(["plaid", "auth"]);
+  });
+
+  it("ids advance i-001 → i-002 → i-003", () => {
+    const a = logIssue(project, { title: "A", symptom: "alpha" });
+    const b = logIssue(project, { title: "B", symptom: "beta" });
+    const c = logIssue(project, { title: "C", symptom: "gamma" });
+    expect(a.id).toBe("i-001");
+    expect(b.id).toBe("i-002");
+    expect(c.id).toBe("i-003");
+  });
+
+  it("nextIssueId still advances when only files exist (no index)", () => {
+    logIssue(project, { title: "first", symptom: "noise" });
+    rmSync(join(issuesDir(project), "index.json"));
+    expect(nextIssueId(project)).toBe("i-002");
+  });
+});
+
+describe("logIssue dedup (Wish #21)", () => {
+  it("appends occurrence when same symptom recurs", () => {
+    const a = logIssue(project, {
+      title: "ENOENT cache",
+      symptom: "ENOENT: /tmp/abc/cache.json @ 2026-05-09T18:30:09Z",
+      tool: "fs.readFileSync",
+      exit_code: 1,
+    });
+    const b = logIssue(project, {
+      title: "ENOENT cache (different paths)",
+      symptom: "ENOENT: /tmp/xyz/cache.json @ 2025-01-01T00:00:00Z",
+      tool: "fs.readFileSync",
+      exit_code: 1,
+    });
+    expect(a.outcome).toBe("created");
+    expect(b.outcome).toBe("appended");
+    expect(b.id).toBe(a.id);
+    expect(b.occurrences).toBe(2);
+
+    const idx = readIndex(project);
+    expect(idx).toHaveLength(1);
+    expect(idx[0]?.occurrences).toBe(2);
+  });
+
+  it("differentiates issues by tool", () => {
+    const a = logIssue(project, { title: "X", symptom: "same", tool: "tool-a", exit_code: 1 });
+    const b = logIssue(project, { title: "Y", symptom: "same", tool: "tool-b", exit_code: 1 });
+    expect(a.id).toBe("i-001");
+    expect(b.id).toBe("i-002");
+  });
+
+  it("appendOccurrence adds an Investigation log entry to the body", () => {
+    logIssue(project, { title: "X", symptom: "same", tool: "t", exit_code: 1 }, new Date("2026-01-01T00:00:00Z"));
+    logIssue(project, { title: "X", symptom: "same", tool: "t", exit_code: 1 }, new Date("2026-02-02T00:00:00Z"));
+    const issue = readIssue(project, "i-001");
+    expect(issue?.body).toContain("recurred");
+    expect(issue?.body).toContain("2026-02-02");
+  });
+});
+
+describe("readIssue + parseIssueFile (Wish #21)", () => {
+  it("round-trips frontmatter through write → read", () => {
+    logIssue(project, {
+      title: "Round trip",
+      symptom: "boom",
+      tool: "x",
+      exit_code: 7,
+      tags: ["a", "b"],
+    });
+    const issue = readIssue(project, "i-001");
+    expect(issue).not.toBeNull();
+    expect(issue?.title).toBe("Round trip");
+    expect(issue?.tool).toBe("x");
+    expect(issue?.exit_code).toBe(7);
+    expect(issue?.tags).toEqual(["a", "b"]);
+    expect(issue?.status).toBe("open");
+    expect(issue?.occurrences).toBe(1);
+  });
+
+  it("handles titles with quotes correctly", () => {
+    logIssue(project, { title: 'Has "quoted" word', symptom: "x" });
+    const issue = readIssue(project, "i-001");
+    expect(issue?.title).toBe('Has "quoted" word');
+  });
+
+  it("returns null for unknown id", () => {
+    expect(readIssue(project, "i-999")).toBeNull();
+  });
+
+  it("parseIssueFile throws on missing fence", () => {
+    expect(() => parseIssueFile("no frontmatter at all")).toThrow();
+  });
+});
+
+describe("listIssues + findBySymptomHash (Wish #21)", () => {
+  it("listIssues returns empty array when no issues", () => {
+    expect(listIssues(project)).toEqual([]);
+  });
+
+  it("findBySymptomHash returns the matching index entry", () => {
+    const r = logIssue(project, { title: "X", symptom: "abc", tool: "t", exit_code: 1 });
+    const entry = findBySymptomHash(project, r.symptom_hash);
+    expect(entry?.id).toBe(r.id);
+  });
+
+  it("findBySymptomHash returns null on miss", () => {
+    expect(findBySymptomHash(project, "0".repeat(40))).toBeNull();
+  });
+});
+
+describe("updateIssueStatus (Wish #21)", () => {
+  it("flips status + appends resolution", () => {
+    logIssue(project, { title: "X", symptom: "y" });
+    const updated = updateIssueStatus(project, "i-001", "fixed", "Reverted PR #99");
+    expect(updated?.status).toBe("fixed");
+    expect(updated?.body).toContain("Reverted PR #99");
+
+    const idx = readIndex(project);
+    expect(idx[0]?.status).toBe("fixed");
+  });
+
+  it("returns null for unknown id", () => {
+    expect(updateIssueStatus(project, "i-404", "fixed")).toBeNull();
+  });
+});
+
+describe("on-disk format sanity (Wish #21)", () => {
+  it("issue file has frontmatter fences and a body", () => {
+    logIssue(project, { title: "Disk format", symptom: "ok" });
+    const text = readFileSync(join(issuesDir(project), "i-001.md"), "utf-8");
+    expect(text.startsWith("---\n")).toBe(true);
+    expect(text).toContain("\n---\n");
+    expect(text).toContain("## Symptom");
+  });
+
+  it("index.json is valid JSON array", () => {
+    logIssue(project, { title: "JSON test", symptom: "ok" });
+    const raw = readFileSync(join(issuesDir(project), "index.json"), "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+});

--- a/packages/gateway-core/src/issues/store.ts
+++ b/packages/gateway-core/src/issues/store.ts
@@ -1,0 +1,361 @@
+/**
+ * Issue store — Wish #21 Slice 1.
+ *
+ * File layout under `<projectPath>/k/issues/`:
+ *   - `<id>.md`      — one issue per file (frontmatter + body)
+ *   - `index.json`   — flat array of `IssueIndexEntry` for O(1) hash lookup
+ *
+ * Concurrency note: this slice is single-process. The on-disk
+ * `index.json` is rewritten in full on each mutation, which is safe
+ * for the gateway's serial request model. If we ever introduce
+ * concurrent writers we'll switch to per-file index updates with a
+ * lockfile — not this slice.
+ *
+ * The frontmatter parser/serializer is deliberately hand-rolled (not
+ * `gray-matter`) — the surface is small enough that bringing a
+ * dependency adds more risk than value.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import type {
+  Issue,
+  IssueFrontmatter,
+  IssueIndexEntry,
+  IssueStatus,
+  LogIssueInput,
+  LogIssueResult,
+} from "./types.js";
+import { hashSymptom } from "./symptom-hash.js";
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+export function issuesDir(projectPath: string): string {
+  return join(projectPath, "k", "issues");
+}
+
+function indexPath(projectPath: string): string {
+  return join(issuesDir(projectPath), "index.json");
+}
+
+function issueFilePath(projectPath: string, id: string): string {
+  return join(issuesDir(projectPath), `${id}.md`);
+}
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter (de)serialization
+// ---------------------------------------------------------------------------
+
+const FRONTMATTER_FENCE = "---";
+
+/**
+ * Parse a `<id>.md` file into `Issue`. Throws if frontmatter is missing
+ * or malformed — every file we wrote has it; absence means corruption.
+ */
+export function parseIssueFile(text: string): Issue {
+  const lines = text.split("\n");
+  if (lines[0] !== FRONTMATTER_FENCE) {
+    throw new Error("issue file is missing frontmatter fence");
+  }
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === FRONTMATTER_FENCE) {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx < 0) {
+    throw new Error("issue file frontmatter has no closing fence");
+  }
+  const fmLines = lines.slice(1, endIdx);
+  const body = lines.slice(endIdx + 1).join("\n").replace(/^\n+/, "");
+  const fm = parseFrontmatter(fmLines);
+  return { ...fm, body };
+}
+
+function parseFrontmatter(lines: string[]): IssueFrontmatter {
+  const map: Record<string, string> = {};
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    const idx = line.indexOf(":");
+    if (idx < 0) continue;
+    const key = line.slice(0, idx).trim();
+    const val = line.slice(idx + 1).trim();
+    map[key] = val;
+  }
+  const tagsRaw = map["tags"] ?? "[]";
+  const tags = parseInlineList(tagsRaw);
+  const occurrencesRaw = Number(map["occurrences"] ?? "1");
+  const exitRaw = map["exit_code"];
+  return {
+    id: map["id"] ?? "",
+    status: (map["status"] as IssueStatus) ?? "open",
+    symptom_hash: map["symptom_hash"] ?? "",
+    tags,
+    agent: map["agent"] ?? "claude-code",
+    title: stripQuotes(map["title"] ?? ""),
+    created: map["created"] ?? "",
+    last_occurrence: map["last_occurrence"] ?? "",
+    occurrences: Number.isFinite(occurrencesRaw) ? occurrencesRaw : 1,
+    tool: map["tool"] ? stripQuotes(map["tool"]) : undefined,
+    exit_code: exitRaw && exitRaw !== "" ? Number(exitRaw) : undefined,
+  };
+}
+
+function parseInlineList(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (trimmed === "" || trimmed === "[]") return [];
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (inner === "") return [];
+    return inner
+      .split(",")
+      .map((s) => stripQuotes(s.trim()))
+      .filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+function stripQuotes(s: string): string {
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(s);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // fall through
+    }
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+function serializeIssueFile(issue: Issue): string {
+  const fm: string[] = [
+    FRONTMATTER_FENCE,
+    `id: ${issue.id}`,
+    `status: ${issue.status}`,
+    `symptom_hash: ${issue.symptom_hash}`,
+    `tags: [${issue.tags.map((t) => JSON.stringify(t)).join(", ")}]`,
+    `agent: ${issue.agent}`,
+    `title: ${JSON.stringify(issue.title)}`,
+    `created: ${issue.created}`,
+    `last_occurrence: ${issue.last_occurrence}`,
+    `occurrences: ${String(issue.occurrences)}`,
+  ];
+  if (issue.tool !== undefined) fm.push(`tool: ${JSON.stringify(issue.tool)}`);
+  if (issue.exit_code !== undefined) fm.push(`exit_code: ${String(issue.exit_code)}`);
+  fm.push(FRONTMATTER_FENCE, "", issue.body);
+  return fm.join("\n") + (issue.body.endsWith("\n") ? "" : "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Index
+// ---------------------------------------------------------------------------
+
+export function readIndex(projectPath: string): IssueIndexEntry[] {
+  const file = indexPath(projectPath);
+  if (!existsSync(file)) return [];
+  try {
+    const raw = readFileSync(file, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as IssueIndexEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function writeIndex(projectPath: string, entries: IssueIndexEntry[]): void {
+  ensureDir(issuesDir(projectPath));
+  writeFileSync(indexPath(projectPath), JSON.stringify(entries, null, 2) + "\n", "utf-8");
+}
+
+function summary(issue: Issue): IssueIndexEntry {
+  return {
+    id: issue.id,
+    status: issue.status,
+    symptom_hash: issue.symptom_hash,
+    tags: issue.tags,
+    title: issue.title,
+    occurrences: issue.occurrences,
+    last_occurrence: issue.last_occurrence,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+export function listIssues(projectPath: string): IssueIndexEntry[] {
+  return readIndex(projectPath);
+}
+
+export function readIssue(projectPath: string, id: string): Issue | null {
+  const file = issueFilePath(projectPath, id);
+  if (!existsSync(file)) return null;
+  return parseIssueFile(readFileSync(file, "utf-8"));
+}
+
+export function findBySymptomHash(projectPath: string, hash: string): IssueIndexEntry | null {
+  return readIndex(projectPath).find((e) => e.symptom_hash === hash) ?? null;
+}
+
+/**
+ * Determine the next issue id by scanning index + on-disk files. Picks
+ * `i-NNN` where NNN is `max(existing) + 1`, zero-padded to 3 digits.
+ */
+export function nextIssueId(projectPath: string): string {
+  const dir = issuesDir(projectPath);
+  const used = new Set<string>(readIndex(projectPath).map((e) => e.id));
+  if (existsSync(dir)) {
+    for (const f of readdirSync(dir)) {
+      if (f.endsWith(".md")) used.add(f.replace(/\.md$/, ""));
+    }
+  }
+  let maxN = 0;
+  for (const id of used) {
+    const m = id.match(/^i-(\d+)$/);
+    if (m) {
+      const n = Number(m[1]);
+      if (n > maxN) maxN = n;
+    }
+  }
+  const next = maxN + 1;
+  return `i-${String(next).padStart(3, "0")}`;
+}
+
+/**
+ * Create or append-occurrence on an issue. Dedup driven by
+ * `symptom_hash`. If a matching hash exists in the index, the existing
+ * issue's `occurrences` is incremented + `last_occurrence` updated. New
+ * tags / metadata from `input` are NOT merged into the existing record
+ * (would be surprising behavior; agent should call `update` explicitly).
+ */
+export function logIssue(projectPath: string, input: LogIssueInput, now: Date = new Date()): LogIssueResult {
+  ensureDir(issuesDir(projectPath));
+  const symptom_hash = hashSymptom(input.symptom, input.tool, input.exit_code);
+  const existing = findBySymptomHash(projectPath, symptom_hash);
+
+  if (existing) {
+    const issue = readIssue(projectPath, existing.id);
+    if (!issue) throw new Error(`index points at ${existing.id} but file is missing`);
+    issue.occurrences += 1;
+    issue.last_occurrence = now.toISOString();
+    issue.body = appendOccurrenceLine(issue.body, now);
+    writeFileSync(issueFilePath(projectPath, issue.id), serializeIssueFile(issue), "utf-8");
+    const idx = readIndex(projectPath);
+    const at = idx.findIndex((e) => e.id === issue.id);
+    if (at >= 0) idx[at] = summary(issue);
+    writeIndex(projectPath, idx);
+    return { outcome: "appended", id: issue.id, symptom_hash, occurrences: issue.occurrences };
+  }
+
+  const id = nextIssueId(projectPath);
+  const iso = now.toISOString();
+  const issue: Issue = {
+    id,
+    status: "open",
+    symptom_hash,
+    tags: input.tags ?? [],
+    agent: input.agent ?? "claude-code",
+    title: input.title,
+    created: iso,
+    last_occurrence: iso,
+    occurrences: 1,
+    tool: input.tool,
+    exit_code: input.exit_code,
+    body: input.body ?? defaultBody(input),
+  };
+  writeFileSync(issueFilePath(projectPath, id), serializeIssueFile(issue), "utf-8");
+  const idx = readIndex(projectPath);
+  idx.push(summary(issue));
+  writeIndex(projectPath, idx);
+  return { outcome: "created", id, symptom_hash, occurrences: 1 };
+}
+
+function defaultBody(input: LogIssueInput): string {
+  const sections: string[] = [
+    "## Symptom",
+    "",
+    input.symptom,
+    "",
+    "## Context",
+    "",
+  ];
+  if (input.tool) sections.push(`- tool: \`${input.tool}\``);
+  if (typeof input.exit_code === "number") sections.push(`- exit_code: ${String(input.exit_code)}`);
+  sections.push(
+    "",
+    "## Repro",
+    "",
+    "_(steps to reproduce — fill in if known)_",
+    "",
+    "## Investigation log",
+    "",
+    `- ${new Date().toISOString()} — initial filing`,
+    "",
+    "## Resolution",
+    "",
+    "_(filled when status flips to `fixed`)_",
+    "",
+  );
+  return sections.join("\n");
+}
+
+function appendOccurrenceLine(body: string, when: Date): string {
+  const marker = "## Investigation log";
+  const idx = body.indexOf(marker);
+  const line = `- ${when.toISOString()} — recurred (auto-incremented)`;
+  if (idx < 0) {
+    return `${body.trimEnd()}\n\n${marker}\n\n${line}\n`;
+  }
+  const after = body.slice(idx + marker.length);
+  const nextHeaderRel = after.search(/\n##\s/);
+  const insertAt = nextHeaderRel < 0 ? body.length : idx + marker.length + nextHeaderRel;
+  return `${body.slice(0, insertAt).trimEnd()}\n${line}\n${nextHeaderRel < 0 ? "" : "\n"}${body.slice(insertAt).trimStart()}`;
+}
+
+export function updateIssueStatus(
+  projectPath: string,
+  id: string,
+  status: IssueStatus,
+  resolution?: string,
+): Issue | null {
+  const issue = readIssue(projectPath, id);
+  if (!issue) return null;
+  issue.status = status;
+  if (resolution) {
+    issue.body = appendResolution(issue.body, resolution);
+  }
+  writeFileSync(issueFilePath(projectPath, id), serializeIssueFile(issue), "utf-8");
+  const idx = readIndex(projectPath);
+  const at = idx.findIndex((e) => e.id === id);
+  if (at >= 0) idx[at] = summary(issue);
+  writeIndex(projectPath, idx);
+  return issue;
+}
+
+function appendResolution(body: string, resolution: string): string {
+  const marker = "## Resolution";
+  const idx = body.indexOf(marker);
+  if (idx < 0) {
+    return `${body.trimEnd()}\n\n${marker}\n\n${resolution}\n`;
+  }
+  const after = body.slice(idx + marker.length);
+  const nextHeaderRel = after.search(/\n##\s/);
+  const sectionEnd = nextHeaderRel < 0 ? body.length : idx + marker.length + nextHeaderRel;
+  return `${body.slice(0, sectionEnd).trimEnd()}\n\n${resolution}\n${nextHeaderRel < 0 ? "" : "\n"}${body.slice(sectionEnd).trimStart()}`;
+}

--- a/packages/gateway-core/src/issues/symptom-hash.test.ts
+++ b/packages/gateway-core/src/issues/symptom-hash.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+
+import { hashSymptom, normalizeSymptom } from "./symptom-hash.js";
+
+describe("normalizeSymptom (Wish #21)", () => {
+  it("strips ISO timestamps", () => {
+    const a = normalizeSymptom("Failed at 2026-05-09T18:30:09.123Z to connect");
+    const b = normalizeSymptom("Failed at 2025-01-01T00:00:00Z to connect");
+    expect(a).toBe(b);
+  });
+
+  it("strips absolute paths", () => {
+    const a = normalizeSymptom("ENOENT: /home/wishborn/.agi/foo.json missing");
+    const b = normalizeSymptom("ENOENT: /opt/agi/runtime/foo.json missing");
+    expect(a).toBe(b);
+  });
+
+  it("strips long numeric IDs", () => {
+    const a = normalizeSymptom("entity 12345 not found");
+    const b = normalizeSymptom("entity 99999 not found");
+    expect(a).toBe(b);
+  });
+
+  it("strips hex hashes", () => {
+    const a = normalizeSymptom("commit abc123def456 missing");
+    const b = normalizeSymptom("commit deadbeefcafe9000 missing");
+    expect(a).toBe(b);
+  });
+
+  it("collapses whitespace + lowercases", () => {
+    expect(normalizeSymptom("  HELLO\n\nworld  "))
+      .toBe("hello world");
+  });
+});
+
+describe("hashSymptom (Wish #21)", () => {
+  it("is deterministic for the same input", () => {
+    expect(hashSymptom("oops", "tool", 1)).toBe(hashSymptom("oops", "tool", 1));
+  });
+
+  it("collapses across timestamp / path / id noise", () => {
+    const a = hashSymptom("ENOENT: /tmp/abc123/file.json @ 2026-05-09T00:00:00Z (id=12345)", "fs.readFileSync", 1);
+    const b = hashSymptom("ENOENT: /tmp/xyz789/file.json @ 2025-01-01T00:00:00Z (id=99999)", "fs.readFileSync", 1);
+    expect(a).toBe(b);
+  });
+
+  it("differs when tool differs", () => {
+    expect(hashSymptom("oops", "fs.readFileSync", 1))
+      .not.toBe(hashSymptom("oops", "fs.writeFileSync", 1));
+  });
+
+  it("differs when exit_code differs", () => {
+    expect(hashSymptom("oops", "tool", 1))
+      .not.toBe(hashSymptom("oops", "tool", 2));
+  });
+
+  it("handles missing tool/exit gracefully", () => {
+    const h = hashSymptom("oops");
+    expect(h).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("produces a 40-char sha1 hex", () => {
+    expect(hashSymptom("any", "tool", 0)).toMatch(/^[a-f0-9]{40}$/);
+  });
+});

--- a/packages/gateway-core/src/issues/symptom-hash.ts
+++ b/packages/gateway-core/src/issues/symptom-hash.ts
@@ -1,0 +1,62 @@
+/**
+ * Symptom-hash — Wish #21 Slice 1 dedup key.
+ *
+ * Deterministic hash of a normalized failure signature. Two failures
+ * collapse onto the same issue when their `(symptom, tool, exit_code)`
+ * tuple normalizes identically.
+ *
+ * Normalization aggressively strips noise that wouldn't matter for a
+ * "have I seen this before?" lookup:
+ *   - timestamps          (any `\d{4}-\d{2}-\d{2}T...` or unix epoch)
+ *   - absolute paths      (replaced with `<path>`)
+ *   - numeric IDs         (`/\b\d{4,}\b/` → `<n>`)
+ *   - temp dirs           (`/tmp/<rand>/...` → `<tmp>/...`)
+ *   - whitespace          (collapsed)
+ *   - case                (lowercased)
+ *
+ * The algorithm is intentionally simple — false collisions are rare for
+ * curated issue logging and far cheaper to fix manually than running an
+ * embedding pipeline (deferred to a future slice if symptom-hash proves
+ * insufficient).
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Strip noise from raw symptom text so equivalent failures produce the
+ * same canonical form.
+ */
+export function normalizeSymptom(raw: string): string {
+  return raw
+    // Unix epoch (ms or s) inside brackets/parens or bare
+    .replace(/\b\d{10,13}\b/g, "<ts>")
+    // ISO timestamps
+    .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?/g, "<iso>")
+    // Common temp-dir patterns first (before generic absolute path)
+    .replace(/\/tmp\/[A-Za-z0-9._-]+/g, "<tmp>")
+    .replace(/\/var\/tmp\/[A-Za-z0-9._-]+/g, "<tmp>")
+    // Absolute paths (Linux / macOS) — match anything starting with /
+    // followed by a non-space sequence of chars.
+    .replace(/(^|\s)\/[A-Za-z0-9._/-]+/g, "$1<path>")
+    // Long numeric IDs (4+ digits)
+    .replace(/\b\d{4,}\b/g, "<n>")
+    // Hex hashes (8+ hex chars)
+    .replace(/\b[a-f0-9]{8,}\b/g, "<hash>")
+    // Collapse whitespace
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Compose the dedup key from the three identifying fields.
+ * `tool` and `exit_code` are optional — missing fields render as the
+ * literal string `none` so the hash is still well-defined.
+ */
+export function hashSymptom(symptom: string, tool?: string, exitCode?: number): string {
+  const normalized = normalizeSymptom(symptom);
+  const toolPart = tool?.trim().toLowerCase() ?? "none";
+  const exitPart = typeof exitCode === "number" ? String(exitCode) : "none";
+  const key = `${normalized}::${toolPart}::${exitPart}`;
+  return createHash("sha1").update(key, "utf8").digest("hex");
+}

--- a/packages/gateway-core/src/issues/types.ts
+++ b/packages/gateway-core/src/issues/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue registry types — Wish #21 Slice 1.
+ *
+ * Per-project Markdown registry at `<projectPath>/k/issues/`. Each issue
+ * is one `.md` file with frontmatter (the structured fields below) plus
+ * Markdown body (Symptom / Context / Repro / Investigation / Resolution).
+ * `index.json` at the same path is a flat array of summary records for
+ * fast hash lookup without parsing every file.
+ */
+
+export type IssueStatus = "open" | "known" | "fixed" | "wont-fix";
+
+export type IssueAgent = "$A0" | "claude-code" | "owner" | string;
+
+/**
+ * One frontmatter record. Body Markdown is stored separately by the
+ * store API (which reads/writes the whole file).
+ */
+export interface IssueFrontmatter {
+  /** Stable identifier scoped to the project — `i-001`, `i-002`, … */
+  id: string;
+  /** Workflow state. */
+  status: IssueStatus;
+  /**
+   * Deterministic dedup hash derived from
+   * `sha1(normalize(symptom) || "::" || tool || "::" || exit_code)`.
+   * See `symptom-hash.ts`.
+   */
+  symptom_hash: string;
+  /** Free-form tags for human-curated grouping (e.g. "taskmaster", "mcp-config-drift"). */
+  tags: string[];
+  /** Who filed the issue. */
+  agent: IssueAgent;
+  /** Short headline. */
+  title: string;
+  /** ISO timestamp at first-file-creation. */
+  created: string;
+  /** ISO timestamp of the most recent occurrence (== created on first file). */
+  last_occurrence: string;
+  /** Counter incremented each time the same symptom_hash recurs. */
+  occurrences: number;
+  /** Optional: tool/command/endpoint that failed. */
+  tool?: string;
+  /** Optional: numeric exit code (0 = N/A). */
+  exit_code?: number;
+}
+
+/** Compact summary for `index.json` — what we keep for fast lookup. */
+export interface IssueIndexEntry {
+  id: string;
+  status: IssueStatus;
+  symptom_hash: string;
+  tags: string[];
+  title: string;
+  occurrences: number;
+  last_occurrence: string;
+}
+
+/** Full issue: frontmatter + body. */
+export interface Issue extends IssueFrontmatter {
+  body: string;
+}
+
+/** Input shape for `logIssue` (creates new OR appends to existing). */
+export interface LogIssueInput {
+  title: string;
+  symptom: string;
+  tool?: string;
+  exit_code?: number;
+  tags?: string[];
+  agent?: IssueAgent;
+  /** Optional Markdown body for first-creation. Ignored on dedup-append. */
+  body?: string;
+}
+
+/** Result of a `logIssue` call. */
+export interface LogIssueResult {
+  /** "created" if new file, "appended" if existing issue's occurrence counter bumped. */
+  outcome: "created" | "appended";
+  id: string;
+  symptom_hash: string;
+  occurrences: number;
+}

--- a/packages/gateway-core/src/project-config-path.ts
+++ b/packages/gateway-core/src/project-config-path.ts
@@ -132,6 +132,7 @@ const PROJECT_FOLDER_LAYOUT_FALLBACK: readonly string[] = Object.freeze([
   "k/pm",
   "k/memory",
   "k/chat",
+  "k/issues",
   "repos",
   "sandbox",
   ".trash",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -66,6 +66,14 @@ import type { DashboardSession } from "./dashboard-user-store.js";
 import type { FederationRouter as FedRouter } from "./federation-router.js";
 import { appendUpgradeLog, clearUpgradeLog, getUpgradeLog } from "./upgrade-log.js";
 import { projectConfigPath } from "./project-config-path.js";
+import {
+  listIssues as listIssuesStore,
+  logIssue as logIssueStore,
+  readIssue as readIssueStore,
+  updateIssueStatus as updateIssueStatusStore,
+  type IssueIndexEntry,
+  type IssueStatus,
+} from "./issues/index.js";
 import type { IterativeWorkScheduler } from "./iterative-work/scheduler.js";
 import { cadenceToStaggeredCron } from "./iterative-work/cron.js";
 import {
@@ -2007,6 +2015,123 @@ export async function createGatewayRuntimeState(
 
     const cleared = deps.iterativeWorkScheduler?.forceClearAll() ?? { inFlightCleared: 0, lastFiredCleared: 0 };
     return reply.send({ ok: true, configFlippedCount, configErrorCount, ...cleared });
+  });
+
+  // -----------------------------------------------------------------------
+  // Issue registry — Wish #21 Slice 1.
+  // Per-project k/issues/ surface. Three routes:
+  //   GET   /api/projects/issues?path=<projectPath>           — list summaries
+  //   GET   /api/projects/issues/:id?path=<projectPath>       — read full issue
+  //   POST  /api/projects/issues?path=<projectPath>           — log (create or append)
+  //   PATCH /api/projects/issues/:id?path=<projectPath>       — update status (+resolution)
+  //   GET   /api/issues                                        — aggregate across all workspace projects
+  // Private-network-only; same workspace-projects scoping as the
+  // iterative-work routes above.
+  // -----------------------------------------------------------------------
+
+  function validateIssueProjectPath(request: { raw: IncomingMessage; query: unknown }, reply: { code: (n: number) => { send: (b: unknown) => unknown } }):
+    | { ok: true; targetPath: string }
+    | { ok: false; sent: unknown } {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) {
+      return { ok: false, sent: reply.code(403).send({ error: "Issues API only allowed from private network" }) };
+    }
+    const projectDirs = deps.workspaceProjects ?? [];
+    const query = request.query as Record<string, string>;
+    const pathParam = query["path"];
+    if (!pathParam) {
+      return { ok: false, sent: reply.code(400).send({ error: "path query parameter is required" }) };
+    }
+    const targetPath = resolvePath(pathParam);
+    const isInWorkspace = projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)));
+    if (!isInWorkspace) {
+      return { ok: false, sent: reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" }) };
+    }
+    return { ok: true, targetPath };
+  }
+
+  fastify.get("/api/projects/issues", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const issues = listIssuesStore(v.targetPath);
+    return reply.send({ issues });
+  });
+
+  fastify.get<{ Params: { id: string } }>("/api/projects/issues/:id", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const issue = readIssueStore(v.targetPath, request.params.id);
+    if (!issue) return reply.code(404).send({ error: "Issue not found" });
+    return reply.send({ issue });
+  });
+
+  fastify.post("/api/projects/issues", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== "object") {
+      return reply.code(400).send({ error: "JSON body required" });
+    }
+    const title = typeof body["title"] === "string" ? body["title"] : "";
+    const symptom = typeof body["symptom"] === "string" ? body["symptom"] : "";
+    if (!title || !symptom) {
+      return reply.code(400).send({ error: "title and symptom are required" });
+    }
+    const tool = typeof body["tool"] === "string" ? body["tool"] : undefined;
+    const exitRaw = body["exit_code"];
+    const exit_code = typeof exitRaw === "number" ? exitRaw : undefined;
+    const tagsRaw = body["tags"];
+    const tags = Array.isArray(tagsRaw) ? tagsRaw.filter((t): t is string => typeof t === "string") : undefined;
+    const agentRaw = body["agent"];
+    const agent = typeof agentRaw === "string" ? agentRaw : undefined;
+    const result = logIssueStore(v.targetPath, { title, symptom, tool, exit_code, tags, agent });
+    return reply.send(result);
+  });
+
+  fastify.patch<{ Params: { id: string } }>("/api/projects/issues/:id", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const body = request.body as Record<string, unknown> | null;
+    if (!body || typeof body !== "object") {
+      return reply.code(400).send({ error: "JSON body required" });
+    }
+    const status = body["status"];
+    const validStatuses: IssueStatus[] = ["open", "known", "fixed", "wont-fix"];
+    if (typeof status !== "string" || !validStatuses.includes(status as IssueStatus)) {
+      return reply.code(400).send({ error: `status must be one of ${validStatuses.join(", ")}` });
+    }
+    const resolutionRaw = body["resolution"];
+    const resolution = typeof resolutionRaw === "string" ? resolutionRaw : undefined;
+    const updated = updateIssueStatusStore(v.targetPath, request.params.id, status as IssueStatus, resolution);
+    if (!updated) return reply.code(404).send({ error: "Issue not found" });
+    return reply.send({ issue: updated });
+  });
+
+  fastify.get("/api/issues", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) {
+      return reply.code(403).send({ error: "Issues API only allowed from private network" });
+    }
+    const projectDirs = deps.workspaceProjects ?? [];
+    const aggregated: Array<IssueIndexEntry & { project: string }> = [];
+    for (const wsDir of projectDirs) {
+      let entries: string[];
+      try {
+        entries = readdirSync(wsDir);
+      } catch {
+        continue;
+      }
+      for (const slug of entries) {
+        const projectPath = resolvePath(`${wsDir}/${slug}`);
+        try {
+          const issues = listIssuesStore(projectPath);
+          for (const i of issues) aggregated.push({ ...i, project: slug });
+        } catch {
+          // skip projects without issues directory
+        }
+      }
+    }
+    return reply.send({ issues: aggregated });
   });
 
   // -----------------------------------------------------------------------

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -16,6 +16,7 @@
 #   agi config [key]    — read config value (dot-path, e.g. agi config hosting.enabled)
 #   agi projects        — list hosted projects with status
 #   agi iw stop --project <path>  — STOP iterative-work on one project
+#   agi issue list / show / file / fix — per-project issue registry (Wish #21)
 #                                    (kill switch — runs without gateway restart)
 #   agi iw stop --all   — STOP iterative-work on ALL projects (nuclear option)
 # ---------------------------------------------------------------------------
@@ -1216,6 +1217,121 @@ cmd_iw() {
   esac
 }
 
+cmd_issue() {
+  # Wish #21 Slice 1 — agent-curated issue registry CLI.
+  # Reads/writes per-project k/issues/ via the gateway HTTP API so
+  # concurrency control + index maintenance stay server-side.
+  local action="${1:-list}"
+  shift || true
+  local gw_url="http://127.0.0.1:3100"
+  local fmt
+  fmt="$(command -v jq >/dev/null && echo "jq ." || echo "cat")"
+
+  case "$action" in
+    list)
+      local project=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          *) err "Unknown flag: $1"; exit 1 ;;
+        esac
+      done
+      if [ -n "$project" ]; then
+        local encoded
+        encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+        curl -s "$gw_url/api/projects/issues?path=$encoded" | ($fmt)
+      else
+        curl -s "$gw_url/api/issues" | ($fmt)
+      fi
+      ;;
+    show)
+      local id="${1:-}"
+      shift || true
+      local project=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          *) err "Unknown flag: $1"; exit 1 ;;
+        esac
+      done
+      if [ -z "$id" ] || [ -z "$project" ]; then
+        err "Usage: agi issue show <id> --project <absolute-path>"
+        exit 1
+      fi
+      local encoded
+      encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+      curl -s "$gw_url/api/projects/issues/$id?path=$encoded" | ($fmt)
+      ;;
+    file)
+      local project=""
+      local title=""
+      local symptom=""
+      local tool=""
+      local exit_code=""
+      local tags=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          --title) title="${2:-}"; shift 2 ;;
+          --symptom) symptom="${2:-}"; shift 2 ;;
+          --tool) tool="${2:-}"; shift 2 ;;
+          --exit) exit_code="${2:-}"; shift 2 ;;
+          --tags) tags="${2:-}"; shift 2 ;;
+          *) err "Unknown flag: $1"; exit 1 ;;
+        esac
+      done
+      if [ -z "$project" ] || [ -z "$title" ] || [ -z "$symptom" ]; then
+        err "Usage: agi issue file --project <absolute-path> --title <t> --symptom <s> [--tool <t>] [--exit <n>] [--tags a,b,c]"
+        exit 1
+      fi
+      local encoded
+      encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+      python3 -c "
+import json,sys,urllib.request
+body={'title':sys.argv[1],'symptom':sys.argv[2]}
+if sys.argv[3]: body['tool']=sys.argv[3]
+if sys.argv[4]: body['exit_code']=int(sys.argv[4])
+if sys.argv[5]: body['tags']=[t.strip() for t in sys.argv[5].split(',') if t.strip()]
+data=json.dumps(body).encode()
+req=urllib.request.Request(sys.argv[6],data=data,headers={'Content-Type':'application/json'},method='POST')
+with urllib.request.urlopen(req) as r: print(r.read().decode())
+" "$title" "$symptom" "$tool" "$exit_code" "$tags" "$gw_url/api/projects/issues?path=$encoded" | ($fmt)
+      ;;
+    fix)
+      local id="${1:-}"
+      shift || true
+      local project=""
+      local resolution=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          --resolution) resolution="${2:-}"; shift 2 ;;
+          *) err "Unknown flag: $1"; exit 1 ;;
+        esac
+      done
+      if [ -z "$id" ] || [ -z "$project" ]; then
+        err "Usage: agi issue fix <id> --project <absolute-path> [--resolution <text>]"
+        exit 1
+      fi
+      local encoded
+      encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+      python3 -c "
+import json,sys,urllib.request
+body={'status':'fixed'}
+if sys.argv[1]: body['resolution']=sys.argv[1]
+data=json.dumps(body).encode()
+req=urllib.request.Request(sys.argv[2],data=data,headers={'Content-Type':'application/json'},method='PATCH')
+with urllib.request.urlopen(req) as r: print(r.read().decode())
+" "$resolution" "$gw_url/api/projects/issues/$id?path=$encoded" | ($fmt)
+      ;;
+    *)
+      err "Unknown issue action: $action"
+      echo "  Actions: list [--project <path>] | show <id> --project <path> | file --project <path> --title <t> --symptom <s> [--tool] [--exit] [--tags] | fix <id> --project <path> [--resolution]"
+      exit 1
+      ;;
+  esac
+}
+
 cmd_projects() {
   # Accept subcommands. Default (no arg) lists all projects.
   case "${1:-list}" in
@@ -1956,6 +2072,13 @@ cmd_help() {
   echo "  iw <CMD>        Iterative-work operator commands (s159 t692 kill switch):"
   echo "                    stop --project <path>         Stop iterative-work on one project"
   echo "                    stop --all                    Stop iterative-work on ALL projects"
+  echo "  issue <CMD>     Per-project issue registry (Wish #21):"
+  echo "                    list [--project <path>]       List all issues (or one project)"
+  echo "                    show <id> --project <path>    Read full issue body"
+  echo "                    file --project <path> --title <t> --symptom <s>"
+  echo "                       [--tool t] [--exit n] [--tags a,b,c]   Log issue (auto-dedup)"
+  echo "                    fix <id> --project <path> [--resolution <text>]"
+  echo "                                                  Mark fixed + append resolution"
   echo "  models CMD      HF model management — pulled/cached/installed models"
   echo "                  (list|running|status|install|start|stop|remove|search|hardware)."
   echo "                  For provider/router config (which Provider, cost-mode), use"
@@ -2032,6 +2155,7 @@ case "${1:-help}" in
   config)   cmd_config "${2:-}" ;;
   projects) shift; cmd_projects "$@" ;;
   iw)       shift; cmd_iw "$@" ;;
+  issue)    shift; cmd_issue "$@" ;;
   models)    shift; cmd_models "$@" ;;
   providers) shift; cmd_providers "$@" ;;
   marketplace) shift; cmd_marketplace "$@" ;;


### PR DESCRIPTION
## Summary

Wish #21 Slice 1 — agent-curated issue registry. Aion (and Claude Code) can now log + search recurring action failures per-project, with symptom-hash dedup that collapses equivalent failures across timestamp/path/ID noise.

**Storage:** `<project>/k/issues/` — one Markdown file per issue (frontmatter + body) plus `index.json` for fast hash lookup. Per-project per CLAUDE.md \xc2\xa7 owner-confirmed shape decisions.

**Surfaces this slice:** agi CLI (`agi issue list/show/file/fix`) + HTTP API. Aion MCP tool, dashboard tab, auto-capture hook, bash-log promotion, and e2e land in slices 2-7.

## Test plan

- [x] 29 vitest cases pass (symptom-hash + store)
- [x] Typecheck clean; staged-tree clean; docs-vs-help clean (27 subcommands)
- [x] Frontmatter round-trip preserves quoted titles, multi-tag arrays, exit codes
- [x] Symptom-hash collapses across timestamp / path / ID / hex-hash noise
- [ ] Owner: \`agi upgrade\`, then \`agi issue file --project <p> --title T --symptom S\` — verify issue appears in \`<p>/k/issues/i-001.md\` + \`index.json\`
- [ ] Owner: re-file same symptom → verify occurrences becomes 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)