### PR TITLE
feat(_aionima): boot-time memory migration ~/.agi/memory/ → k/memory/ (s119 t704)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.593",
+  "version": "0.4.594",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/aionima-memory-migration.test.ts
+++ b/packages/gateway-core/src/aionima-memory-migration.test.ts
@@ -1,0 +1,150 @@
+/**
+ * aionima-memory-migration tests (s119 t704). Pure-logic; runs on host.
+ *
+ * Tests use a temp `homedir` substitute by setting HOME via `process.env`
+ * within each test — the migration helper resolves `~/.agi/memory/`
+ * via `os.homedir()` which honors HOME on Linux.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  aionimaMemoryDir,
+  legacyMemoryDir,
+  migrateAionimaMemoryDir,
+} from "./aionima-memory-migration.js";
+
+let tmp: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mem-mig-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  // Re-home so the test's "~/.agi/memory" resolves under tmp.
+  originalHome = process.env["HOME"];
+  process.env["HOME"] = join(tmp, "home");
+  mkdirSync(process.env["HOME"], { recursive: true });
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = originalHome;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function workspaceRoot(): string {
+  const ws = join(tmp, "workspace");
+  mkdirSync(join(ws, "_aionima", "k"), { recursive: true });
+  return ws;
+}
+
+function seedLegacy(files: Record<string, string>): void {
+  const dir = legacyMemoryDir();
+  mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(dir, name), body, "utf-8");
+  }
+}
+
+describe("aionimaMemoryDir / legacyMemoryDir (s119 t704)", () => {
+  it("aionimaMemoryDir resolves under workspaceRoot", () => {
+    expect(aionimaMemoryDir("/foo/bar")).toBe("/foo/bar/_aionima/k/memory");
+  });
+
+  it("legacyMemoryDir resolves under HOME", () => {
+    expect(legacyMemoryDir()).toBe(join(process.env["HOME"]!, ".agi", "memory"));
+  });
+});
+
+describe("migrateAionimaMemoryDir (s119 t704)", () => {
+  it("clean-install: no source dir → empty result, no errors", () => {
+    const ws = workspaceRoot();
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.scanned).toBe(0);
+    expect(r.moved).toBe(0);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("moves a single file from legacy to canonical", () => {
+    const ws = workspaceRoot();
+    seedLegacy({ "architecture.md": "# arch" });
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.scanned).toBe(1);
+    expect(r.moved).toBe(1);
+    expect(r.errors).toEqual([]);
+    expect(existsSync(join(legacyMemoryDir(), "architecture.md"))).toBe(false);
+    expect(existsSync(join(aionimaMemoryDir(ws), "architecture.md"))).toBe(true);
+    expect(readFileSync(join(aionimaMemoryDir(ws), "architecture.md"), "utf-8")).toBe("# arch");
+  });
+
+  it("moves the typical ~/.agi/memory tree (multiple .md files)", () => {
+    const ws = workspaceRoot();
+    seedLegacy({
+      "architecture.md": "a",
+      "_map.md": "b",
+      "feedback-plugins.md": "c",
+      "deployment.md": "d",
+    });
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.moved).toBe(4);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("is idempotent — second pass skips already-migrated files", () => {
+    const ws = workspaceRoot();
+    seedLegacy({ "architecture.md": "a" });
+    const first = migrateAionimaMemoryDir(ws);
+    expect(first.moved).toBe(1);
+
+    // Re-seed legacy with the same name to test idempotency
+    seedLegacy({ "architecture.md": "stale-copy" });
+    const second = migrateAionimaMemoryDir(ws);
+    expect(second.moved).toBe(0);
+    expect(second.alreadyMigrated).toBe(1);
+    // Target keeps the originally-migrated content; legacy retains the
+    // newer write because nothing happened (idempotent skip).
+    expect(readFileSync(join(aionimaMemoryDir(ws), "architecture.md"), "utf-8")).toBe("a");
+    expect(readFileSync(join(legacyMemoryDir(), "architecture.md"), "utf-8")).toBe("stale-copy");
+  });
+
+  it("skips non-file entries (subdirs) without erroring", () => {
+    const ws = workspaceRoot();
+    mkdirSync(legacyMemoryDir(), { recursive: true });
+    mkdirSync(join(legacyMemoryDir(), "sub"), { recursive: true });
+    writeFileSync(join(legacyMemoryDir(), "real.md"), "x", "utf-8");
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.scanned).toBe(2);
+    expect(r.moved).toBe(1);
+    expect(r.skippedNonFile).toBe(1);
+    expect(existsSync(join(legacyMemoryDir(), "sub"))).toBe(true);
+  });
+
+  it("creates target dir on demand if t701 scaffolder hasn't run", () => {
+    // workspaceRoot() pre-creates _aionima/k/ but NOT k/memory.
+    const ws = workspaceRoot();
+    expect(existsSync(aionimaMemoryDir(ws))).toBe(false);
+
+    seedLegacy({ "x.md": "y" });
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.moved).toBe(1);
+    expect(existsSync(aionimaMemoryDir(ws))).toBe(true);
+  });
+
+  it("captures errors per-file rather than throwing", () => {
+    const ws = workspaceRoot();
+    seedLegacy({ "ok.md": "fine" });
+    // Pre-create the target file with read-only-ish setup to force a
+    // collision on the otherwise-fine path. Easier: create a target
+    // file that already exists for one input, leaving the other to
+    // succeed.
+    mkdirSync(aionimaMemoryDir(ws), { recursive: true });
+    writeFileSync(join(aionimaMemoryDir(ws), "ok.md"), "pre-existing", "utf-8");
+
+    const r = migrateAionimaMemoryDir(ws);
+    expect(r.alreadyMigrated).toBe(1);
+    expect(r.moved).toBe(0);
+  });
+});

--- a/packages/gateway-core/src/aionima-memory-migration.ts
+++ b/packages/gateway-core/src/aionima-memory-migration.ts
@@ -1,0 +1,159 @@
+/**
+ * aionima-memory-migration — s119 t704.
+ *
+ * One-shot, idempotent migration that moves Aion's memory files from
+ * the legacy global location (`~/.agi/memory/`) into the per-project
+ * canonical location (`<workspaceRoot>/_aionima/k/memory/`) so memory
+ * lives with the project that owns it (per s160 + owner directive
+ * 2026-05-09: "the _aionima folder is where memory and user-generated
+ * system knowledge lives").
+ *
+ * Sibling to:
+ *   - mcp-config-migration (s131 t681)
+ *   - project-config-shape-migration (s150 t632)
+ *   - aionima-system-migration (s119 t703)
+ *
+ * Same shape: idempotent, per-item atomic, error-captured. Differs in
+ * that source is `~/.agi/memory/` (homedir, not workspace) and items
+ * are individual `.md` files (not directories).
+ *
+ * Safety:
+ *   - Moves only files (NOT directories). If a memory subdir ever
+ *     appears, it's left untouched for owner inspection.
+ *   - Files already at target are skipped silently (idempotent).
+ *   - Source files NOT present at target are atomically renamed.
+ *   - Errors are captured per-file and reported via the result.
+ *
+ * The legacy `~/.agi/memory/` directory is NOT deleted even after all
+ * files migrate — leaves a recovery anchor and avoids surprising the
+ * owner if they have unrelated tooling that reads from there.
+ */
+
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { aionimaSystemProjectPath } from "./project-config-path.js";
+import type { ComponentLogger } from "./logger.js";
+
+/**
+ * Legacy memory location — fixed by Aion's memory protocol; predates
+ * the universal-monorepo layout.
+ */
+export function legacyMemoryDir(): string {
+  return join(homedir(), ".agi", "memory");
+}
+
+/**
+ * Canonical memory location — one of the `_aionima/k/<area>` knowledge
+ * subdirs created by the t701 scaffolder.
+ */
+export function aionimaMemoryDir(workspaceRoot: string): string {
+  return join(aionimaSystemProjectPath(workspaceRoot), "k", "memory");
+}
+
+export interface AionimaMemoryMigrationResult {
+  /** Total entries scanned at the legacy location. */
+  scanned: number;
+  /** Files moved this call. */
+  moved: number;
+  /** Files already at the canonical location (no-op). */
+  alreadyMigrated: number;
+  /** Entries skipped because they're directories (we only move files). */
+  skippedNonFile: number;
+  /** Per-file errors. */
+  errors: { name: string; reason: string }[];
+}
+
+/**
+ * Move memory `.md` files from `~/.agi/memory/` into
+ * `<workspaceRoot>/_aionima/k/memory/`. Idempotent + atomic per file.
+ */
+export function migrateAionimaMemoryDir(
+  workspaceRoot: string,
+  logger?: ComponentLogger,
+): AionimaMemoryMigrationResult {
+  const result: AionimaMemoryMigrationResult = {
+    scanned: 0,
+    moved: 0,
+    alreadyMigrated: 0,
+    skippedNonFile: 0,
+    errors: [],
+  };
+
+  const src = legacyMemoryDir();
+  const dst = aionimaMemoryDir(workspaceRoot);
+
+  // Source-absent is a clean-install case — nothing to migrate.
+  if (!existsSync(src)) {
+    return result;
+  }
+
+  // Target-absent precondition: t701 scaffolder must run first.
+  // Rather than refusing the migration outright we create the dir
+  // ourselves — t701 may not have run yet on this boot if `_aionima`
+  // is being set up for the first time, and we don't want a chicken-
+  // and-egg dependency between two boot helpers. mkdirSync recursive
+  // is a no-op if the dir already exists.
+  try {
+    mkdirSync(dst, { recursive: true });
+  } catch (err) {
+    result.errors.push({
+      name: "(precondition)",
+      reason: `failed to ensure target dir ${dst}: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return result;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(src);
+  } catch (err) {
+    result.errors.push({
+      name: "(scan)",
+      reason: `failed to read ${src}: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return result;
+  }
+
+  result.scanned = entries.length;
+
+  for (const name of entries) {
+    const oldPath = join(src, name);
+    const newPath = join(dst, name);
+
+    let isFile = false;
+    try {
+      isFile = statSync(oldPath).isFile();
+    } catch (err) {
+      result.errors.push({
+        name,
+        reason: `stat failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      continue;
+    }
+
+    if (!isFile) {
+      result.skippedNonFile++;
+      continue;
+    }
+
+    if (existsSync(newPath)) {
+      result.alreadyMigrated++;
+      continue;
+    }
+
+    try {
+      renameSync(oldPath, newPath);
+      result.moved++;
+      logger?.info(`migrated memory file: ${oldPath} → ${newPath}`);
+    } catch (err) {
+      result.errors.push({
+        name,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -130,6 +130,7 @@ import { ChatGarbageCollector } from "./chat-garbage-collector.js";
 import { buildTynnSyncPrompt } from "./plan-tynn-mapper.js";
 import { ensureAionimaSystemProject, ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-path.js";
 import { migrateAionimaSystemForks } from "./aionima-system-migration.js";
+import { migrateAionimaMemoryDir } from "./aionima-memory-migration.js";
 import { HostingManager } from "./hosting-manager.js";
 import { ProjectConfigManager } from "./project-config-manager.js";
 import { migrateAllProjectConfigShapes } from "./project-config-shape-migration.js";
@@ -1871,6 +1872,28 @@ export async function startGatewayServer(
       logger.warn(
         "migrate",
         `boot-time s119 fork migration failed for ${workspaceRoot} (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // s119 t704 (2026-05-09) — move Aion memory files from legacy
+    // ~/.agi/memory/ into _aionima/k/memory/. Per-file atomic rename;
+    // idempotent (already-migrated files skipped). Source dir is left
+    // intact even after all files migrate to leave a recovery anchor.
+    try {
+      const r = migrateAionimaMemoryDir(workspaceRoot, createComponentLogger(logger, "migrate-aionima-memory"));
+      if (r.moved > 0 || r.errors.length > 0) {
+        logger.info(
+          "migrate",
+          `boot-time s119 memory migration: scanned=${String(r.scanned)} moved=${String(r.moved)} alreadyMigrated=${String(r.alreadyMigrated)} skippedNonFile=${String(r.skippedNonFile)} errors=${String(r.errors.length)}`,
+        );
+        for (const e of r.errors) {
+          logger.warn("migrate", `s119 memory migration error [${e.name}]: ${e.reason}`);
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        "migrate",
+        `boot-time s119 memory migration failed for ${workspaceRoot} (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

s119 t704 — boot-time, idempotent migration that moves Aion's memory files from the legacy global location (~/.agi/memory/) into the per-project canonical location (_aionima/k/memory/). Closes one of the three remaining s119 tasks; closing s119 entirely after t705+t706 follow this turn.

Per-file atomic renameSync. Already-migrated files skipped. Subdirs (if any) left untouched. Source ~/.agi/memory/ NOT deleted — leaves a recovery anchor so unrelated tooling doesn't break.

Sibling to mcp-config-migration (s131), project-config-shape-migration (s150), aionima-system-migration (s119 t703). Same pattern: allow-listed/scanned items, atomic per-item, idempotent, error-captured.

## Test plan

- [x] 9 vitest cases pass (clean-install, single/multi-file, idempotency, non-file skip, target-dir-on-demand, collision)
- [x] Typecheck clean
- [x] Wired into server boot path after t703 fork migration
- [ ] Owner: \`agi upgrade\` → first boot moves the 12 memory files; second boot is no-op
- [ ] Owner: verify \`~/_projects/_aionima/k/memory/\` contains the expected memory files (architecture.md, _map.md, feedback-*.md, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)