### PR TITLE
chore(deps): add @particle-academy/fancy-3d to dashboard (s142 t563 — CLOSES s142)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.596",
+  "version": "0.4.597",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -26,6 +26,7 @@
     "@particle-academy/react-echarts": "^1.1.3",
     "@particle-academy/react-fancy": "^2.9.0",
     "@particle-academy/fancy-sheets": "^0.7.2",
+    "@particle-academy/fancy-3d": "^0.1.6",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
     "@trpc/client": "^11.10.0",


### PR DESCRIPTION
## Summary

Pre-empts the "first consumer dep bump" friction. fancy-3d is now ready to import without a separate dep step in whichever PR introduces the first 3D consumer (likely COA chain visualization or entity-graph view).

**Closes s142** — PAx-primitive sweep (8/8 tasks). All scope shipped.

## Test plan

- [x] Typecheck clean
- [x] 2-line dep bump only (no behavioral changes)
- [ ] Owner: agi upgrade → next pnpm install picks up @particle-academy/fancy-3d ^0.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)