### PR TITLE
feat(issues): register issue tool in Aion's tool registry — Wish #21 Slice 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.600",
+  "version": "0.4.601",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -100,6 +100,7 @@ import { ToolRegistry } from "./tool-registry.js";
 import { AgentInvoker } from "./agent-invoker.js";
 import { ChatEventBuffer } from "./chat-event-buffer.js";
 import { registerAllTools, registerAgentTools } from "./tools/index.js";
+import { createIssueHandler, ISSUE_TOOL_MANIFEST, ISSUE_TOOL_INPUT_SCHEMA } from "./tools/issue-tools.js";
 import { SkillRegistry } from "@agi/skills";
 import { CompositeMemoryAdapter } from "@agi/memory";
 import {
@@ -2854,6 +2855,18 @@ export async function startGatewayServer(
       },
       required: ["action"],
     },
+  );
+
+  // Wish #21 Slice 3 — issue registry tool. Per-project k/issues/
+  // surface (log/search/show/list/fix). Same store as Slices 1+2 and
+  // the agi CLI; this binding lets Aion self-serve without bouncing
+  // through the CLI.
+  toolRegistry.register(
+    ISSUE_TOOL_MANIFEST,
+    createIssueHandler({
+      workspaceProjects: () => Array.isArray(config.workspace?.projects) ? config.workspace.projects : [],
+    }),
+    ISSUE_TOOL_INPUT_SCHEMA,
   );
 
   // Register HF model management tool for the agent

--- a/packages/gateway-core/src/tools/issue-tools.test.ts
+++ b/packages/gateway-core/src/tools/issue-tools.test.ts
@@ -1,0 +1,180 @@
+/**
+ * issue tool tests (Wish #21 Slice 3).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createIssueHandler } from "./issue-tools.js";
+
+let workspace: string;
+let project: string;
+let handler: (input: Record<string, unknown>) => Promise<string> | string;
+
+beforeEach(() => {
+  workspace = join(tmpdir(), `issue-tool-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(workspace, { recursive: true });
+  project = join(workspace, "myproj");
+  mkdirSync(project, { recursive: true });
+  handler = createIssueHandler({
+    workspaceProjects: () => [workspace],
+  });
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+async function call(input: Record<string, unknown>): Promise<unknown> {
+  const out = await Promise.resolve(handler(input));
+  return JSON.parse(out);
+}
+
+describe("issue tool — input validation (Wish #21 Slice 3)", () => {
+  it("rejects unknown action", async () => {
+    const r = await call({ action: "bogus", projectPath: project });
+    expect((r as { error?: string }).error).toMatch(/action must be one of/);
+  });
+
+  it("rejects missing projectPath", async () => {
+    const r = await call({ action: "list" });
+    expect((r as { error?: string }).error).toMatch(/projectPath is required/);
+  });
+
+  it("rejects projectPath outside workspace", async () => {
+    const r = await call({ action: "list", projectPath: "/tmp/not-in-workspace" });
+    expect((r as { error?: string }).error).toMatch(/not inside a configured workspace/);
+  });
+});
+
+describe("issue tool — log action (Wish #21 Slice 3)", () => {
+  it("creates a new issue", async () => {
+    const r = await call({
+      action: "log",
+      projectPath: project,
+      title: "Plaid 401",
+      symptom: "401 Unauthorized",
+      tool: "fetch",
+      exit_code: 401,
+      tags: ["plaid"],
+    });
+    expect((r as { outcome?: string }).outcome).toBe("created");
+    expect((r as { id?: string }).id).toBe("i-001");
+    expect(existsSync(join(project, "k", "issues", "i-001.md"))).toBe(true);
+  });
+
+  it("rejects log without title or symptom", async () => {
+    const r1 = await call({ action: "log", projectPath: project, title: "x" });
+    expect((r1 as { error?: string }).error).toMatch(/title and symptom/);
+    const r2 = await call({ action: "log", projectPath: project, symptom: "y" });
+    expect((r2 as { error?: string }).error).toMatch(/title and symptom/);
+  });
+
+  it("dedup: same symptom appends occurrence", async () => {
+    await call({ action: "log", projectPath: project, title: "X", symptom: "boom", tool: "t", exit_code: 1 });
+    const r2 = await call({ action: "log", projectPath: project, title: "X again", symptom: "boom", tool: "t", exit_code: 1 });
+    expect((r2 as { outcome?: string }).outcome).toBe("appended");
+    expect((r2 as { occurrences?: number }).occurrences).toBe(2);
+  });
+
+  it("defaults agent to $A0 (Aion)", async () => {
+    await call({ action: "log", projectPath: project, title: "agent-default", symptom: "x" });
+    const showResult = await call({ action: "show", projectPath: project, id: "i-001" });
+    expect((showResult as { issue?: { agent: string } }).issue?.agent).toBe("$A0");
+  });
+
+  it("respects explicit agent override", async () => {
+    await call({
+      action: "log",
+      projectPath: project,
+      title: "explicit",
+      symptom: "y",
+      agent: "claude-code",
+    });
+    const showResult = await call({ action: "show", projectPath: project, id: "i-001" });
+    expect((showResult as { issue?: { agent: string } }).issue?.agent).toBe("claude-code");
+  });
+});
+
+describe("issue tool — search action (Wish #21 Slice 3)", () => {
+  beforeEach(async () => {
+    await call({
+      action: "log",
+      projectPath: project,
+      title: "Plaid webhook 401",
+      symptom: "auth-fail-plaid",
+      tags: ["plaid", "auth"],
+    });
+    await call({
+      action: "log",
+      projectPath: project,
+      title: "Stripe charge",
+      symptom: "card-decline",
+      tags: ["stripe"],
+    });
+  });
+
+  it("free-text search returns matching hits", async () => {
+    const r = await call({ action: "search", projectPath: project, query: "plaid" });
+    expect((r as { hits?: unknown[] }).hits).toHaveLength(1);
+  });
+
+  it("tag filter narrows results", async () => {
+    const r = await call({ action: "search", projectPath: project, query: "tag:stripe" });
+    expect((r as { hits?: unknown[] }).hits).toHaveLength(1);
+  });
+
+  it("status filter narrows results", async () => {
+    const r = await call({ action: "search", projectPath: project, query: "status:open" });
+    expect((r as { hits?: unknown[] }).hits).toHaveLength(2);
+    const r2 = await call({ action: "search", projectPath: project, query: "status:fixed" });
+    expect((r2 as { hits?: unknown[] }).hits).toHaveLength(0);
+  });
+
+  it("empty query returns all issues", async () => {
+    const r = await call({ action: "search", projectPath: project, query: "" });
+    expect((r as { hits?: unknown[] }).hits).toHaveLength(2);
+  });
+});
+
+describe("issue tool — show + list + fix actions (Wish #21 Slice 3)", () => {
+  beforeEach(async () => {
+    await call({ action: "log", projectPath: project, title: "First", symptom: "first-symptom" });
+    await call({ action: "log", projectPath: project, title: "Second", symptom: "second-symptom" });
+  });
+
+  it("list returns summary index", async () => {
+    const r = await call({ action: "list", projectPath: project });
+    expect((r as { issues?: unknown[] }).issues).toHaveLength(2);
+  });
+
+  it("show returns the full issue", async () => {
+    const r = await call({ action: "show", projectPath: project, id: "i-001" });
+    expect((r as { issue?: { title: string } }).issue?.title).toBe("First");
+  });
+
+  it("show returns error for unknown id", async () => {
+    const r = await call({ action: "show", projectPath: project, id: "i-999" });
+    expect((r as { error?: string }).error).toMatch(/not found/);
+  });
+
+  it("fix flips status to fixed", async () => {
+    const r = await call({ action: "fix", projectPath: project, id: "i-001", resolution: "Reverted PR #99" });
+    expect((r as { status?: string }).status).toBe("fixed");
+    const showResult = await call({ action: "show", projectPath: project, id: "i-001" });
+    expect((showResult as { issue?: { status: string } }).issue?.status).toBe("fixed");
+    expect((showResult as { issue?: { body: string } }).issue?.body).toContain("Reverted PR #99");
+  });
+
+  it("fix accepts custom status (e.g. 'known')", async () => {
+    const r = await call({ action: "fix", projectPath: project, id: "i-001", status: "known" });
+    expect((r as { status?: string }).status).toBe("known");
+  });
+
+  it("fix returns error for unknown id", async () => {
+    const r = await call({ action: "fix", projectPath: project, id: "i-404" });
+    expect((r as { error?: string }).error).toMatch(/not found/);
+  });
+});

--- a/packages/gateway-core/src/tools/issue-tools.ts
+++ b/packages/gateway-core/src/tools/issue-tools.ts
@@ -1,0 +1,192 @@
+/**
+ * issue tool — Wish #21 Slice 3.
+ *
+ * Aion-facing surface for the per-project issue registry. Action
+ * dispatcher (read/search/show/log/fix) over the per-project
+ * `<projectPath>/k/issues/` Markdown registry from Slice 1; backed by
+ * the same store + search logic Slice 2 added.
+ *
+ * Owner directive 2026-05-09: "Aion needs to log issues when expected
+ * actions fail; searchable so it can find known issues; readable by
+ * Claude Code." This handler is the Aion side; Claude Code uses the
+ * `agi issue` CLI shipped earlier (functionally identical).
+ *
+ * The tool routes by `input.action`:
+ *   - search:  free-text + tag:/status: filters → ranked hits
+ *   - show:    fetch one issue by id (full body)
+ *   - list:    summary index without body
+ *   - log:     create or append-occurrence (symptom-hash dedup)
+ *   - fix:     mark `fixed` + append optional resolution
+ *
+ * Project scoping: every action requires a `projectPath` input —
+ * issues live per-project and the agent must be explicit about which
+ * project's registry to operate on. Mirrors the `notes` tool's
+ * project-scope-gating pattern.
+ */
+
+import type { ToolHandler } from "../tool-registry.js";
+import {
+  listIssues,
+  logIssue,
+  readIssue,
+  searchIssues,
+  updateIssueStatus,
+  type IssueStatus,
+  type LogIssueInput,
+} from "../issues/index.js";
+
+export interface CreateIssueHandlerConfig {
+  /** Workspace project paths used to validate `projectPath` input. */
+  workspaceProjects: () => string[];
+  /** Optional override for resolve+normalize behavior; defaults to identity. */
+  normalizePath?: (p: string) => string;
+}
+
+const VALID_ACTIONS = new Set(["search", "show", "list", "log", "fix"]);
+const VALID_STATUSES: IssueStatus[] = ["open", "known", "fixed", "wont-fix"];
+
+function err(message: string): string {
+  return JSON.stringify({ error: message });
+}
+
+export function createIssueHandler(config: CreateIssueHandlerConfig): ToolHandler {
+  const normalize = config.normalizePath ?? ((p: string) => p);
+
+  function isInWorkspace(projectPath: string): boolean {
+    const target = normalize(projectPath);
+    return config.workspaceProjects().some((dir) => target.startsWith(normalize(dir)));
+  }
+
+  return async (input: Record<string, unknown>): Promise<string> => {
+    const action = String(input.action ?? "").trim();
+    if (!VALID_ACTIONS.has(action)) {
+      return err(`action must be one of ${[...VALID_ACTIONS].join(", ")}`);
+    }
+    const projectPath = typeof input.projectPath === "string" ? input.projectPath.trim() : "";
+    if (!projectPath) {
+      return err("projectPath is required");
+    }
+    if (!isInWorkspace(projectPath)) {
+      return err("projectPath is not inside a configured workspace.projects directory");
+    }
+
+    try {
+      switch (action) {
+        case "search": {
+          const query = typeof input.query === "string" ? input.query : "";
+          const hits = searchIssues(projectPath, query);
+          return JSON.stringify({ action: "search", query, hits });
+        }
+        case "show": {
+          const id = typeof input.id === "string" ? input.id.trim() : "";
+          if (!id) return err("id is required for show");
+          const issue = readIssue(projectPath, id);
+          if (!issue) return JSON.stringify({ action: "show", id, error: "not found" });
+          return JSON.stringify({ action: "show", id, issue });
+        }
+        case "list": {
+          const issues = listIssues(projectPath);
+          return JSON.stringify({ action: "list", issues });
+        }
+        case "log": {
+          const title = typeof input.title === "string" ? input.title : "";
+          const symptom = typeof input.symptom === "string" ? input.symptom : "";
+          if (!title || !symptom) return err("title and symptom are required for log");
+          const tool = typeof input.tool === "string" ? input.tool : undefined;
+          const exitRaw = input.exit_code;
+          const exit_code = typeof exitRaw === "number" ? exitRaw : undefined;
+          const tagsRaw = input.tags;
+          const tags = Array.isArray(tagsRaw)
+            ? tagsRaw.filter((t): t is string => typeof t === "string")
+            : undefined;
+          const agentRaw = input.agent;
+          const agent = typeof agentRaw === "string" ? agentRaw : "$A0";
+          const inputBody: LogIssueInput = { title, symptom, tool, exit_code, tags, agent };
+          const result = logIssue(projectPath, inputBody);
+          return JSON.stringify({ action: "log", ...result });
+        }
+        case "fix": {
+          const id = typeof input.id === "string" ? input.id.trim() : "";
+          if (!id) return err("id is required for fix");
+          const status = (typeof input.status === "string" && (VALID_STATUSES as string[]).includes(input.status))
+            ? (input.status as IssueStatus)
+            : "fixed";
+          const resolution = typeof input.resolution === "string" ? input.resolution : undefined;
+          const updated = updateIssueStatus(projectPath, id, status, resolution);
+          if (!updated) return JSON.stringify({ action: "fix", id, error: "not found" });
+          return JSON.stringify({ action: "fix", id, status: updated.status });
+        }
+        default:
+          return err(`unknown action: ${action}`);
+      }
+    } catch (e) {
+      return err(e instanceof Error ? e.message : String(e));
+    }
+  };
+}
+
+export const ISSUE_TOOL_MANIFEST = {
+  name: "issue",
+  description:
+    "Per-project issue registry — log/search/show/fix recurring failures. Symptom-hash dedup auto-increments occurrences when the same failure recurs (so the same problem doesn't get filed twice). Use 'search' BEFORE filing to check for known issues; use 'log' when an expected action fails and you want it tracked. Actions: 'search' (text + tag:/status: filters), 'show' (full body by id), 'list' (summary index), 'log' (create or append-occurrence), 'fix' (mark fixed + append resolution). Issues live at <projectPath>/k/issues/.",
+  requiresState: ["ONLINE" as const, "LIMBO" as const],
+  requiresTier: ["verified" as const, "sealed" as const],
+};
+
+export const ISSUE_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    action: {
+      type: "string",
+      enum: ["search", "show", "list", "log", "fix"],
+      description: "Which issue operation to run.",
+    },
+    projectPath: {
+      type: "string",
+      description: "Absolute path of the project whose registry to operate on. Must be inside a workspace.projects directory.",
+    },
+    query: {
+      type: "string",
+      description: "(search) Free-text query. Tokens AND-combined; case-insensitive. Supports `tag:<name>` and `status:<s>` filters.",
+    },
+    id: {
+      type: "string",
+      description: "(show, fix) Issue id (e.g. 'i-001').",
+    },
+    title: {
+      type: "string",
+      description: "(log) Short headline for a new issue.",
+    },
+    symptom: {
+      type: "string",
+      description: "(log) Description of the failure — used for symptom-hash dedup.",
+    },
+    tool: {
+      type: "string",
+      description: "(log) Tool/command/endpoint that failed (factors into dedup hash).",
+    },
+    exit_code: {
+      type: "number",
+      description: "(log) Exit code (factors into dedup hash).",
+    },
+    tags: {
+      type: "array",
+      items: { type: "string" },
+      description: "(log) Free-form tags for grouping (e.g. 'taskmaster', 'auth').",
+    },
+    agent: {
+      type: "string",
+      description: "(log) Who filed it. Defaults to '$A0' (Aion).",
+    },
+    status: {
+      type: "string",
+      enum: ["open", "known", "fixed", "wont-fix"],
+      description: "(fix) Status to set; defaults to 'fixed'.",
+    },
+    resolution: {
+      type: "string",
+      description: "(fix) Optional resolution note appended to the issue body.",
+    },
+  },
+  required: ["action", "projectPath"],
+};


### PR DESCRIPTION
## Summary

Wish #21 Slice 3 — registers the per-project issue registry as an Aion-callable tool (action dispatch: search / show / list / log / fix). Same store as Slices 1+2 + the agi CLI; this binding lets Aion self-serve without bouncing through the CLI.

Closes the "Aion can search + log" side of the owner directive. Claude Code already has CLI access via Slice 1. Slices 4-7 (dashboard tab, auto-capture, bash-log promotion, e2e) remain.

## Test plan

- [x] 18 new vitest cases pass (input validation, log+dedup, search+filters, show+list+fix, agent default, status overrides)
- [x] Typecheck clean
- [ ] Owner: agi upgrade → in next Aion chat say "search the issue registry for any plaid-related issues" — verify Aion uses the new tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)