### PR TITLE
feat(issues): bash audit-log promotion — Wish #21 Slice 6

### DIFF
--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -232,6 +232,13 @@ agi issue file --project /home/wishborn/_projects/_aionima \
 # Mark as fixed with a resolution note
 agi issue fix i-001 --project /home/wishborn/_projects/_aionima \
   --resolution "Fixed in agi v0.4.x via per-key cooldown"
+
+# Slice 6: backfill from ~/.agi/logs/agi-bash-*.jsonl audit log.
+# Promotes blocked + non-zero-exit entries to issues; symptom-hash
+# auto-dedups so recurring patterns roll up.
+agi issue from-bash-log --project /home/wishborn/_projects/_aionima              # last 7 days
+agi issue from-bash-log --project /home/wishborn/_projects/_aionima --days 30
+agi issue from-bash-log --project /home/wishborn/_projects/_aionima --dry-run    # preview candidates
 ```
 
 **Dedup model.** Filing computes a `symptom_hash` from the normalized

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.601",
+  "version": "0.4.602",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/issues/bash-log-promotion.test.ts
+++ b/packages/gateway-core/src/issues/bash-log-promotion.test.ts
@@ -1,0 +1,207 @@
+/**
+ * bash-log-promotion tests (Wish #21 Slice 6).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  buildCandidatePayload,
+  findPromotionCandidates,
+  listBashLogFiles,
+  type BashAuditEntry,
+} from "./bash-log-promotion.js";
+
+let tmp: string;
+let originalHome: string | undefined;
+
+function entry(overrides: Partial<BashAuditEntry>): BashAuditEntry {
+  return {
+    ts: "2026-05-09T18:00:00Z",
+    caller: "claude-code",
+    cwd: "/home/wishborn/temp_core",
+    cmd_hash: "abc123",
+    exit_code: 0,
+    duration_ms: 1,
+    stdout_bytes: 0,
+    stderr_bytes: 0,
+    blocked: false,
+    denial_reason: "",
+    audit_note: "",
+    ...overrides,
+  };
+}
+
+function writeJsonlFile(date: string, entries: BashAuditEntry[]): void {
+  const dir = join(tmp, "home", ".agi", "logs");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, `agi-bash-${date}.jsonl`);
+  writeFileSync(file, entries.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+}
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `bash-log-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  originalHome = process.env["HOME"];
+  process.env["HOME"] = join(tmp, "home");
+  mkdirSync(process.env["HOME"], { recursive: true });
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = originalHome;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("listBashLogFiles (Wish #21 Slice 6)", () => {
+  it("returns empty when log dir doesn't exist", () => {
+    expect(listBashLogFiles(7)).toEqual([]);
+  });
+
+  it("returns files for the requested day window", () => {
+    writeJsonlFile("2026-05-09", [entry({})]);
+    writeJsonlFile("2026-05-08", [entry({})]);
+    writeJsonlFile("2026-05-01", [entry({})]); // out of 3-day window
+    const now = new Date("2026-05-09T18:00:00Z");
+    const files = listBashLogFiles(3, now);
+    expect(files.map((f) => f.split("/").pop())).toEqual([
+      "agi-bash-2026-05-07.jsonl",
+      "agi-bash-2026-05-08.jsonl",
+      "agi-bash-2026-05-09.jsonl",
+    ].filter((f) => f === "agi-bash-2026-05-08.jsonl" || f === "agi-bash-2026-05-09.jsonl"));
+  });
+});
+
+describe("findPromotionCandidates (Wish #21 Slice 6)", () => {
+  it("returns no candidates when all entries succeeded", () => {
+    writeJsonlFile("2026-05-09", [entry({}), entry({})]);
+    expect(findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"))).toEqual([]);
+  });
+
+  it("captures blocked entries", () => {
+    writeJsonlFile("2026-05-09", [
+      entry({ blocked: true, denial_reason: "reset --hard not allowed", cmd_hash: "h1" }),
+      entry({}), // success — ignored
+    ]);
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.blocked).toBe(true);
+    expect(candidates[0]?.denial_reason).toBe("reset --hard not allowed");
+  });
+
+  it("captures non-zero-exit entries", () => {
+    writeJsonlFile("2026-05-09", [entry({ exit_code: 1, cmd_hash: "h2" })]);
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.exit_code).toBe(1);
+  });
+
+  it("groups identical (cmd_hash, blocked, exit, reason) tuples and counts", () => {
+    writeJsonlFile("2026-05-09", [
+      entry({ blocked: true, denial_reason: "X", cmd_hash: "h1", ts: "2026-05-09T10:00:00Z" }),
+      entry({ blocked: true, denial_reason: "X", cmd_hash: "h1", ts: "2026-05-09T11:00:00Z" }),
+      entry({ blocked: true, denial_reason: "X", cmd_hash: "h1", ts: "2026-05-09T12:00:00Z" }),
+    ]);
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.count).toBe(3);
+    expect(candidates[0]?.first_ts).toBe("2026-05-09T10:00:00Z");
+    expect(candidates[0]?.last_ts).toBe("2026-05-09T12:00:00Z");
+  });
+
+  it("differentiates groups by reason", () => {
+    writeJsonlFile("2026-05-09", [
+      entry({ blocked: true, denial_reason: "A", cmd_hash: "h1" }),
+      entry({ blocked: true, denial_reason: "B", cmd_hash: "h1" }),
+    ]);
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates).toHaveLength(2);
+  });
+
+  it("orders candidates by count desc", () => {
+    writeJsonlFile("2026-05-09", [
+      entry({ blocked: true, denial_reason: "rare", cmd_hash: "h1" }),
+      entry({ blocked: true, denial_reason: "common", cmd_hash: "h2" }),
+      entry({ blocked: true, denial_reason: "common", cmd_hash: "h2" }),
+      entry({ blocked: true, denial_reason: "common", cmd_hash: "h2" }),
+    ]);
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates[0]?.denial_reason).toBe("common");
+    expect(candidates[0]?.count).toBe(3);
+    expect(candidates[1]?.denial_reason).toBe("rare");
+  });
+
+  it("tolerates malformed JSONL lines", () => {
+    const dir = join(tmp, "home", ".agi", "logs");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "agi-bash-2026-05-09.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify(entry({ blocked: true, denial_reason: "X", cmd_hash: "h1" })),
+        "{ malformed json",
+        "",
+        JSON.stringify(entry({ blocked: true, denial_reason: "Y", cmd_hash: "h2" })),
+      ].join("\n"),
+      "utf-8",
+    );
+    const candidates = findPromotionCandidates(3, new Date("2026-05-09T18:00:00Z"));
+    expect(candidates).toHaveLength(2);
+  });
+});
+
+describe("buildCandidatePayload (Wish #21 Slice 6)", () => {
+  it("blocked candidate produces 'Bash policy blocked' title + bash-blocked tag", () => {
+    const p = buildCandidatePayload({
+      cmd_hash: "h1",
+      blocked: true,
+      exit_code: 0,
+      denial_reason: "git reset --hard blocked",
+      count: 5,
+      first_ts: "2026-05-09T10:00:00Z",
+      last_ts: "2026-05-09T15:00:00Z",
+      example_caller: "claude-code",
+      example_cwd: "/tmp/p",
+    });
+    expect(p.title).toBe("Bash policy blocked: git reset --hard blocked");
+    expect(p.tags).toContain("bash-blocked");
+    expect(p.tags).toContain("audit-promoted");
+    expect(p.body).toContain("5 times");
+    expect(p.body).toContain("h1");
+  });
+
+  it("failed-exit candidate produces 'Bash command failed' title + bash-failed tag", () => {
+    const p = buildCandidatePayload({
+      cmd_hash: "h2",
+      blocked: false,
+      exit_code: 127,
+      denial_reason: "",
+      count: 2,
+      first_ts: "2026-05-09T10:00:00Z",
+      last_ts: "2026-05-09T11:00:00Z",
+      example_caller: "claude-code",
+      example_cwd: "/tmp/p",
+    });
+    expect(p.title).toContain("Bash command failed");
+    expect(p.tags).toContain("bash-failed");
+    expect(p.exit_code).toBe(127);
+  });
+
+  it("symptom strings collapse different timestamps to the same hash", () => {
+    const a = buildCandidatePayload({
+      cmd_hash: "h", blocked: true, exit_code: 0, denial_reason: "X", count: 1,
+      first_ts: "2026-05-09T10:00:00Z", last_ts: "2026-05-09T10:00:00Z",
+      example_caller: "c", example_cwd: "/p",
+    });
+    const b = buildCandidatePayload({
+      cmd_hash: "h", blocked: true, exit_code: 0, denial_reason: "X", count: 5,
+      first_ts: "2026-05-08T00:00:00Z", last_ts: "2026-05-09T20:00:00Z",
+      example_caller: "c", example_cwd: "/p",
+    });
+    // The symptom strings (used as logIssue dedup input) are equal — count
+    // and timestamps don't affect dedup, only the body.
+    expect(a.symptom).toBe(b.symptom);
+  });
+});

--- a/packages/gateway-core/src/issues/bash-log-promotion.ts
+++ b/packages/gateway-core/src/issues/bash-log-promotion.ts
@@ -1,0 +1,184 @@
+/**
+ * Bash audit log → issue registry promotion (Wish #21 Slice 6).
+ *
+ * Backfills the per-project issue registry from `~/.agi/logs/agi-bash-*.jsonl`
+ * audit-log entries that match an issue-worthy pattern:
+ *   - `blocked === true` — bash policy denied the command (most actionable;
+ *     agent tried something the policy stopped, worth knowing about)
+ *   - `exit_code !== 0` — command failed (signals a real error, but the
+ *     audit log doesn't carry the raw cmd so context is sparse)
+ *
+ * Entries are grouped by their natural dedup key so the same recurring
+ * failure collapses to one candidate; counts roll up. Each surviving
+ * group becomes a candidate for `logIssue()` — the symptom-hash inside
+ * `logIssue` then auto-increments occurrences on already-filed issues.
+ *
+ * The bash audit log doesn't capture the raw command (only `cmd_hash`).
+ * That limits the symptom string we can build to denial_reason +
+ * exit_code + cmd_hash. Future Slice could enrich by capturing the
+ * command text into the audit log (separate change in the bash policy
+ * surface — out of scope for this slice).
+ */
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Single bash audit log entry shape (mirrors what cmd_bash writes). */
+export interface BashAuditEntry {
+  ts: string;
+  caller: string;
+  cwd: string;
+  cmd_hash: string;
+  exit_code: number;
+  duration_ms: number;
+  stdout_bytes: number;
+  stderr_bytes: number;
+  blocked: boolean;
+  denial_reason: string;
+  audit_note: string;
+}
+
+/** Grouped candidate (one per `(cmd_hash, blocked, exit_code, denial_reason)`). */
+export interface PromotionCandidate {
+  cmd_hash: string;
+  blocked: boolean;
+  exit_code: number;
+  denial_reason: string;
+  count: number;
+  first_ts: string;
+  last_ts: string;
+  example_caller: string;
+  example_cwd: string;
+}
+
+export function bashLogDir(): string {
+  return join(homedir(), ".agi", "logs");
+}
+
+/**
+ * List bash audit log files for the last `daysBack` days. Filenames are
+ * `agi-bash-YYYY-MM-DD.jsonl`; missing days are skipped silently.
+ */
+export function listBashLogFiles(daysBack: number, now: Date = new Date()): string[] {
+  const dir = bashLogDir();
+  if (!existsSync(dir)) return [];
+  const wanted = new Set<string>();
+  for (let i = 0; i < daysBack; i++) {
+    const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+    wanted.add(`agi-bash-${d.toISOString().slice(0, 10)}.jsonl`);
+  }
+  const present = readdirSync(dir).filter((f) => wanted.has(f));
+  return present.map((f) => join(dir, f)).sort();
+}
+
+/** Read all matching entries from a single JSONL file. Tolerates malformed lines. */
+function readBashLogFile(path: string): BashAuditEntry[] {
+  if (!existsSync(path)) return [];
+  const out: BashAuditEntry[] = [];
+  const raw = readFileSync(path, "utf-8");
+  for (const line of raw.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed && typeof parsed === "object") {
+        out.push(parsed as BashAuditEntry);
+      }
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk recent bash logs + return grouped candidates. Default
+ * filter: blocked entries OR non-zero-exit entries. Groups identical
+ * `(cmd_hash, blocked, exit_code, denial_reason)` so recurring failures
+ * collapse.
+ */
+export function findPromotionCandidates(daysBack: number, now: Date = new Date()): PromotionCandidate[] {
+  const groups = new Map<string, PromotionCandidate>();
+  for (const file of listBashLogFiles(daysBack, now)) {
+    for (const entry of readBashLogFile(file)) {
+      if (!entry.blocked && entry.exit_code === 0) continue;
+      const key = `${entry.cmd_hash}::${String(entry.blocked)}::${String(entry.exit_code)}::${entry.denial_reason}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.count++;
+        if (entry.ts > existing.last_ts) existing.last_ts = entry.ts;
+        if (entry.ts < existing.first_ts) existing.first_ts = entry.ts;
+      } else {
+        groups.set(key, {
+          cmd_hash: entry.cmd_hash,
+          blocked: entry.blocked,
+          exit_code: entry.exit_code,
+          denial_reason: entry.denial_reason,
+          count: 1,
+          first_ts: entry.ts,
+          last_ts: entry.ts,
+          example_caller: entry.caller,
+          example_cwd: entry.cwd,
+        });
+      }
+    }
+  }
+  return [...groups.values()].sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Build the LogIssueInput payload for a candidate. Caller wraps with
+ * `logIssue(projectPath, ...)`. Symptom string is structured so the
+ * dedup hash collapses recurring runs of the same blocked pattern.
+ */
+export interface CandidatePayload {
+  title: string;
+  symptom: string;
+  tool: string;
+  exit_code: number;
+  tags: string[];
+  body: string;
+}
+
+export function buildCandidatePayload(c: PromotionCandidate): CandidatePayload {
+  const isBlocked = c.blocked;
+  const reason = c.denial_reason || (isBlocked ? "(blocked, no reason)" : `exit ${String(c.exit_code)}`);
+  const title = isBlocked
+    ? `Bash policy blocked: ${reason}`
+    : `Bash command failed: ${reason}`;
+  const symptom = isBlocked
+    ? `denial_reason="${c.denial_reason}" cmd_hash=${c.cmd_hash}`
+    : `exit_code=${String(c.exit_code)} cmd_hash=${c.cmd_hash}`;
+  const tags = isBlocked
+    ? ["bash-blocked", "audit-promoted"]
+    : ["bash-failed", "audit-promoted"];
+  const body = [
+    "## Symptom",
+    "",
+    title,
+    "",
+    "## Context",
+    "",
+    `- caller: \`${c.example_caller}\``,
+    `- cwd: \`${c.example_cwd}\``,
+    `- cmd_hash: \`${c.cmd_hash}\``,
+    `- blocked: ${String(c.blocked)}`,
+    `- exit_code: ${String(c.exit_code)}`,
+    `- denial_reason: ${c.denial_reason || "(none)"}`,
+    "",
+    "## Repro",
+    "",
+    `Triggered ${String(c.count)} times in the bash audit log between ${c.first_ts} and ${c.last_ts}.`,
+    "Raw command not captured by the audit log (only \`cmd_hash\` is stored). To reproduce, search ~/.agi/logs/agi-bash-*.jsonl for the cmd_hash above and check the chat session that originated the call.",
+    "",
+    "## Investigation log",
+    "",
+    `- ${new Date().toISOString()} — promoted from bash audit log via \`agi issue from-bash-log\`. ${String(c.count)} occurrences seen.`,
+    "",
+    "## Resolution",
+    "",
+    "_(filled when status flips to `fixed`)_",
+    "",
+  ].join("\n");
+  return { title, symptom, tool: "agi-bash", exit_code: c.exit_code, tags, body };
+}

--- a/packages/gateway-core/src/issues/index.ts
+++ b/packages/gateway-core/src/issues/index.ts
@@ -28,3 +28,11 @@ export {
 
 export type { IssueSearchHit, IssueSearchHitWithBody } from "./search.js";
 export { parseSearchQuery, searchIssues } from "./search.js";
+
+export type { BashAuditEntry, CandidatePayload, PromotionCandidate } from "./bash-log-promotion.js";
+export {
+  bashLogDir,
+  buildCandidatePayload,
+  findPromotionCandidates,
+  listBashLogFiles,
+} from "./bash-log-promotion.js";

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -67,6 +67,8 @@ import type { FederationRouter as FedRouter } from "./federation-router.js";
 import { appendUpgradeLog, clearUpgradeLog, getUpgradeLog } from "./upgrade-log.js";
 import { projectConfigPath } from "./project-config-path.js";
 import {
+  buildCandidatePayload,
+  findPromotionCandidates,
   listIssues as listIssuesStore,
   logIssue as logIssueStore,
   readIssue as readIssueStore,
@@ -2028,6 +2030,41 @@ export async function createGatewayRuntimeState(
     const query = (request.query as Record<string, string>)["q"] ?? "";
     const hits = searchIssuesStore(v.targetPath, query);
     return reply.send({ hits });
+  });
+
+  // Wish #21 Slice 6 — promote bash audit-log entries to issues.
+  // POST body: { days?: number (default 7), promote?: boolean (default true) }.
+  // When promote=false, returns just the candidate list (dry run).
+  fastify.post("/api/projects/issues/from-bash-log", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const body = (request.body as Record<string, unknown> | null) ?? {};
+    const daysRaw = body["days"];
+    const days = typeof daysRaw === "number" && Number.isFinite(daysRaw) && daysRaw > 0 ? Math.floor(daysRaw) : 7;
+    const promote = body["promote"] !== false; // default true
+    const candidates = findPromotionCandidates(days);
+    if (!promote) {
+      return reply.send({ daysScanned: days, candidates, promoted: 0, appended: 0, dryRun: true });
+    }
+    let promoted = 0;
+    let appended = 0;
+    const results: { id: string; outcome: string; occurrences: number }[] = [];
+    for (const c of candidates) {
+      const payload = buildCandidatePayload(c);
+      const result = logIssueStore(v.targetPath, {
+        title: payload.title,
+        symptom: payload.symptom,
+        tool: payload.tool,
+        exit_code: payload.exit_code,
+        tags: payload.tags,
+        body: payload.body,
+        agent: "audit-promotion",
+      });
+      if (result.outcome === "created") promoted++;
+      else appended++;
+      results.push({ id: result.id, outcome: result.outcome, occurrences: result.occurrences });
+    }
+    return reply.send({ daysScanned: days, candidates: candidates.length, promoted, appended, results });
   });
 
   fastify.get<{ Params: { id: string } }>("/api/projects/issues/:id", async (request, reply) => {

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -1320,6 +1320,38 @@ req=urllib.request.Request(sys.argv[6],data=data,headers={'Content-Type':'applic
 with urllib.request.urlopen(req) as r: print(r.read().decode())
 " "$title" "$symptom" "$tool" "$exit_code" "$tags" "$gw_url/api/projects/issues?path=$encoded" | ($fmt)
       ;;
+    from-bash-log)
+      # Wish #21 Slice 6 — promote bash audit-log entries to issues.
+      # Scans ~/.agi/logs/agi-bash-*.jsonl for the last --days N days,
+      # groups blocked + non-zero-exit entries, files them via logIssue
+      # (which auto-dedups via symptom-hash). Use --dry-run to see the
+      # candidate list without filing.
+      local project=""
+      local days="7"
+      local dryrun=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          --days) days="${2:-}"; shift 2 ;;
+          --dry-run) dryrun="true"; shift ;;
+          *) err "Unknown flag: $1"; exit 1 ;;
+        esac
+      done
+      if [ -z "$project" ]; then
+        err "Usage: agi issue from-bash-log --project <absolute-path> [--days N] [--dry-run]"
+        exit 1
+      fi
+      local encoded
+      encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+      python3 -c "
+import json,sys,urllib.request
+body={'days':int(sys.argv[1])}
+if sys.argv[2]=='true': body['promote']=False
+data=json.dumps(body).encode()
+req=urllib.request.Request(sys.argv[3],data=data,headers={'Content-Type':'application/json'},method='POST')
+with urllib.request.urlopen(req) as r: print(r.read().decode())
+" "$days" "$dryrun" "$gw_url/api/projects/issues/from-bash-log?path=$encoded" | ($fmt)
+      ;;
     fix)
       local id="${1:-}"
       shift || true
@@ -1349,7 +1381,7 @@ with urllib.request.urlopen(req) as r: print(r.read().decode())
       ;;
     *)
       err "Unknown issue action: $action"
-      echo "  Actions: list [--project <path>] | search <query> --project <path> | show <id> --project <path> | file --project <path> --title <t> --symptom <s> [--tool] [--exit] [--tags] | fix <id> --project <path> [--resolution]"
+      echo "  Actions: list [--project <path>] | search <query> --project <path> | show <id> --project <path> | file --project <path> --title <t> --symptom <s> [--tool] [--exit] [--tags] | fix <id> --project <path> [--resolution] | from-bash-log --project <path> [--days N] [--dry-run]"
       exit 1
       ;;
   esac
@@ -2103,6 +2135,8 @@ cmd_help() {
   echo "                       [--tool t] [--exit n] [--tags a,b,c]   Log issue (auto-dedup)"
   echo "                    fix <id> --project <path> [--resolution <text>]"
   echo "                                                  Mark fixed + append resolution"
+  echo "                    from-bash-log --project <path> [--days N] [--dry-run]"
+  echo "                                                  Promote ~/.agi/logs/agi-bash-*.jsonl entries"
   echo "  models CMD      HF model management — pulled/cached/installed models"
   echo "                  (list|running|status|install|start|stop|remove|search|hardware)."
   echo "                  For provider/router config (which Provider, cost-mode), use"


### PR DESCRIPTION
## Summary

Wish #21 Slice 6 — backfills the per-project issue registry from existing \`~/.agi/logs/agi-bash-*.jsonl\` audit-log entries. Promotes:
- \`blocked === true\` (policy denied — most actionable)
- \`exit_code !== 0\` (failed commands)

Groups by \`(cmd_hash, blocked, exit_code, denial_reason)\` so recurring patterns collapse. Symptom-hash dedup in \`logIssue()\` then appends occurrences for already-filed issues — re-running is idempotent.

## Test plan

- [x] 12 new vitest cases pass (61 total in issues subsystem)
- [x] Typecheck clean; docs-vs-help clean (27 subcommands)
- [ ] Owner: \`agi upgrade\` then \`agi issue from-bash-log --project /home/wishborn/_projects/_aionima --dry-run\` to preview, then run without \`--dry-run\` to commit promotions

🤖 Generated with [Claude Code](https://claude.com/claude-code)