### PR TITLE
feat(issues): raw-tier auto-capture sink — Wish #21 Slice 5

### DIFF
--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -239,6 +239,13 @@ agi issue fix i-001 --project /home/wishborn/_projects/_aionima \
 agi issue from-bash-log --project /home/wishborn/_projects/_aionima              # last 7 days
 agi issue from-bash-log --project /home/wishborn/_projects/_aionima --days 30
 agi issue from-bash-log --project /home/wishborn/_projects/_aionima --dry-run    # preview candidates
+
+# Slice 5: raw-tier auto-capture sink. Tools/agents record failures via
+# recordRawCapture() (JSONL append-only at <project>/k/issues/raw.jsonl);
+# operator triages the list + promotes interesting captures to curated.
+agi issue raw list --project /home/wishborn/_projects/_aionima                   # list captures
+agi issue raw promote r-abc123-001 --project /home/wishborn/_projects/_aionima   # promote one
+agi issue raw clear --project /home/wishborn/_projects/_aionima                  # operator reset
 ```
 
 **Dedup model.** Filing computes a `symptom_hash` from the normalized

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.602",
+  "version": "0.4.603",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/issues/index.ts
+++ b/packages/gateway-core/src/issues/index.ts
@@ -36,3 +36,12 @@ export {
   findPromotionCandidates,
   listBashLogFiles,
 } from "./bash-log-promotion.js";
+
+export type { RawCaptureEntry } from "./raw-capture.js";
+export {
+  clearRawCaptures,
+  listRawCaptures,
+  promoteRawCapture,
+  rawCapturePath,
+  recordRawCapture,
+} from "./raw-capture.js";

--- a/packages/gateway-core/src/issues/raw-capture.test.ts
+++ b/packages/gateway-core/src/issues/raw-capture.test.ts
@@ -1,0 +1,165 @@
+/**
+ * raw-capture tests (Wish #21 Slice 5).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  _resetRawCaptureSeqForTest,
+  clearRawCaptures,
+  listRawCaptures,
+  promoteRawCapture,
+  rawCapturePath,
+  recordRawCapture,
+} from "./raw-capture.js";
+import { listIssues } from "./store.js";
+
+let project: string;
+
+beforeEach(() => {
+  project = join(tmpdir(), `raw-capture-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(project, { recursive: true });
+  _resetRawCaptureSeqForTest();
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+describe("rawCapturePath (Wish #21 Slice 5)", () => {
+  it("resolves to <project>/k/issues/raw.jsonl", () => {
+    expect(rawCapturePath("/foo/bar")).toBe("/foo/bar/k/issues/raw.jsonl");
+  });
+});
+
+describe("recordRawCapture (Wish #21 Slice 5)", () => {
+  it("creates k/issues/ and appends a line", () => {
+    const e = recordRawCapture(project, { source: "fetch", summary: "ECONNREFUSED" });
+    expect(e.source).toBe("fetch");
+    expect(e.summary).toBe("ECONNREFUSED");
+    expect(e.id).toMatch(/^r-/);
+    const stat = statSync(rawCapturePath(project));
+    expect(stat.size).toBeGreaterThan(0);
+  });
+
+  it("preserves order across multiple appends", () => {
+    recordRawCapture(project, { source: "a", summary: "1" });
+    recordRawCapture(project, { source: "b", summary: "2" });
+    recordRawCapture(project, { source: "c", summary: "3" });
+    const all = listRawCaptures(project);
+    expect(all.map((e) => e.summary)).toEqual(["1", "2", "3"]);
+  });
+
+  it("preserves details payload", () => {
+    recordRawCapture(project, {
+      source: "tool-x",
+      summary: "boom",
+      details: { exitCode: 1, stderr: "oops" },
+    });
+    const all = listRawCaptures(project);
+    expect(all[0]?.details).toEqual({ exitCode: 1, stderr: "oops" });
+  });
+
+  it("never throws on filesystem failure (side-channel discipline)", () => {
+    // Simulate a non-existent path — the function should swallow the error.
+    expect(() => recordRawCapture("/nonexistent/path-that-cannot-be-created/zz", {
+      source: "x", summary: "y",
+    })).not.toThrow();
+  });
+});
+
+describe("listRawCaptures (Wish #21 Slice 5)", () => {
+  it("returns empty array when raw.jsonl doesn't exist", () => {
+    expect(listRawCaptures(project)).toEqual([]);
+  });
+
+  it("tolerates malformed JSONL lines", () => {
+    recordRawCapture(project, { source: "ok", summary: "good" });
+    // Manually corrupt with an invalid line
+    const path = rawCapturePath(project);
+    const raw = readFileSync(path, "utf-8");
+    require("node:fs").writeFileSync(path, raw + "{ bad json\n", "utf-8");
+
+    const all = listRawCaptures(project);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.summary).toBe("good");
+  });
+});
+
+describe("promoteRawCapture (Wish #21 Slice 5)", () => {
+  it("promotes a raw entry to a curated issue + removes from raw log", () => {
+    const e = recordRawCapture(project, {
+      source: "fetch",
+      summary: "ECONNREFUSED on POST /webhook",
+      details: { exitCode: 1 },
+    });
+    const result = promoteRawCapture(project, e.id);
+    expect(result?.outcome).toBe("created");
+    expect(result?.id).toBe("i-001");
+
+    expect(listRawCaptures(project)).toHaveLength(0);
+    const issues = listIssues(project);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.tags).toContain("auto-captured");
+    expect(issues[0]?.tags).toContain("fetch");
+  });
+
+  it("returns null for unknown raw id", () => {
+    expect(promoteRawCapture(project, "r-bogus-001")).toBeNull();
+  });
+
+  it("dedups via symptom-hash on promotion", () => {
+    // Two raw captures with identical (source, summary) — dedup hash matches
+    const e1 = recordRawCapture(project, { source: "fetch", summary: "ECONNREFUSED" });
+    const e2 = recordRawCapture(project, { source: "fetch", summary: "ECONNREFUSED" });
+
+    const r1 = promoteRawCapture(project, e1.id);
+    expect(r1?.outcome).toBe("created");
+    expect(r1?.occurrences).toBe(1);
+
+    const r2 = promoteRawCapture(project, e2.id);
+    expect(r2?.outcome).toBe("appended");
+    expect(r2?.occurrences).toBe(2);
+
+    const issues = listIssues(project);
+    expect(issues).toHaveLength(1);
+  });
+
+  it("override.title + override.tags applied at promotion", () => {
+    const e = recordRawCapture(project, { source: "fetch", summary: "boom" });
+    const result = promoteRawCapture(project, e.id, {
+      title: "Custom title",
+      tags: ["custom", "operator-curated"],
+    });
+    expect(result?.outcome).toBe("created");
+    const issues = listIssues(project);
+    expect(issues[0]?.title).toBe("Custom title");
+    expect(issues[0]?.tags).toEqual(["custom", "operator-curated"]);
+  });
+
+  it("only the promoted entry is removed (others remain)", () => {
+    const e1 = recordRawCapture(project, { source: "a", summary: "1" });
+    recordRawCapture(project, { source: "b", summary: "2" });
+    recordRawCapture(project, { source: "c", summary: "3" });
+    promoteRawCapture(project, e1.id);
+    const remaining = listRawCaptures(project);
+    expect(remaining).toHaveLength(2);
+    expect(remaining.map((e) => e.summary)).toEqual(["2", "3"]);
+  });
+});
+
+describe("clearRawCaptures (Wish #21 Slice 5)", () => {
+  it("removes all entries + returns count", () => {
+    recordRawCapture(project, { source: "a", summary: "1" });
+    recordRawCapture(project, { source: "b", summary: "2" });
+    expect(clearRawCaptures(project)).toBe(2);
+    expect(listRawCaptures(project)).toEqual([]);
+  });
+
+  it("safe to call when no captures exist", () => {
+    expect(clearRawCaptures(project)).toBe(0);
+  });
+});

--- a/packages/gateway-core/src/issues/raw-capture.ts
+++ b/packages/gateway-core/src/issues/raw-capture.ts
@@ -1,0 +1,203 @@
+/**
+ * Raw-tier issue capture (Wish #21 Slice 5).
+ *
+ * Auto-capture sink for tool-call failures + similar agent-side
+ * exceptions. Lives at `<projectPath>/k/issues/raw.jsonl` (append-only)
+ * to keep disk growth bounded — full Markdown issue files are reserved
+ * for the curated tier.
+ *
+ * Workflow:
+ *   1. Tool dispatcher (or any caller) records a failure via
+ *      `recordRawCapture()`.
+ *   2. Capture lives in raw.jsonl; doesn't appear in the curated
+ *      `index.json`.
+ *   3. Agent (or owner) reviews via `listRawCaptures()`.
+ *   4. Agent promotes interesting captures via `promoteRawCapture()`,
+ *      which calls `logIssue()` against the curated store and removes
+ *      the entry from raw.jsonl.
+ *
+ * The raw tier intentionally has NO dedup — every error gets logged.
+ * Dedup happens at promotion time via `logIssue`'s symptom-hash. This
+ * matches the design from CLAUDE.md § 4 Pattern Substrate: capture
+ * everything richly, distill later.
+ *
+ * Disk-growth safeguard: raw.jsonl is opportunistically truncated when
+ * it crosses RAW_LOG_MAX_BYTES — we keep the most recent half. Truly
+ * paranoid operators can add a cron rotate or wire the bash-policy log
+ * rotation pattern (sibling concept).
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { issuesDir, logIssue } from "./store.js";
+import type { LogIssueResult } from "./types.js";
+
+export interface RawCaptureEntry {
+  /** Stable id within the raw log (timestamp + sequence — idiomatic JSONL key). */
+  id: string;
+  /** ISO-8601 timestamp of capture. */
+  ts: string;
+  /** Tool / surface that failed (`fetch`, `taskmaster`, `agent-invoker`, etc.). */
+  source: string;
+  /** Single-line summary of the failure. */
+  summary: string;
+  /** Optional structured details — exit code, error class, etc. */
+  details?: Record<string, unknown>;
+}
+
+const RAW_LOG_FILENAME = "raw.jsonl";
+const RAW_LOG_MAX_BYTES = 5 * 1024 * 1024; // 5 MB before opportunistic truncation
+
+let rawCaptureSeq = 0;
+
+export function rawCapturePath(projectPath: string): string {
+  return join(issuesDir(projectPath), RAW_LOG_FILENAME);
+}
+
+function ensureIssuesDir(projectPath: string): void {
+  const dir = issuesDir(projectPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function generateId(now: Date = new Date()): string {
+  rawCaptureSeq = (rawCaptureSeq + 1) % 100000;
+  return `r-${now.getTime().toString(36)}-${rawCaptureSeq.toString(36).padStart(3, "0")}`;
+}
+
+/**
+ * Append a raw capture. Cheap (single fs append). Never throws — raw
+ * capture is a side-channel; failure to record shouldn't propagate
+ * back to the caller.
+ */
+export function recordRawCapture(
+  projectPath: string,
+  partial: Omit<RawCaptureEntry, "id" | "ts"> & Partial<Pick<RawCaptureEntry, "id" | "ts">>,
+  now: Date = new Date(),
+): RawCaptureEntry {
+  const entry: RawCaptureEntry = {
+    id: partial.id ?? generateId(now),
+    ts: partial.ts ?? now.toISOString(),
+    source: partial.source,
+    summary: partial.summary,
+    details: partial.details,
+  };
+  try {
+    ensureIssuesDir(projectPath);
+    appendFileSync(rawCapturePath(projectPath), JSON.stringify(entry) + "\n", "utf-8");
+    truncateIfExcessive(projectPath);
+  } catch {
+    // Side-channel — swallow errors; capture failure must not leak.
+  }
+  return entry;
+}
+
+/** Read all raw captures (most-recent-last per JSONL append order). */
+export function listRawCaptures(projectPath: string): RawCaptureEntry[] {
+  const path = rawCapturePath(projectPath);
+  if (!existsSync(path)) return [];
+  const entries: RawCaptureEntry[] = [];
+  try {
+    const raw = readFileSync(path, "utf-8");
+    for (const line of raw.split("\n")) {
+      if (line.trim() === "") continue;
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (parsed && typeof parsed === "object") {
+          entries.push(parsed as RawCaptureEntry);
+        }
+      } catch {
+        // skip malformed line
+      }
+    }
+  } catch {
+    // unreadable — treat as empty
+  }
+  return entries;
+}
+
+/**
+ * Promote a single raw capture to a curated issue. Writes to the
+ * Markdown registry via `logIssue` (which auto-dedups via
+ * symptom-hash) AND removes the entry from raw.jsonl by rewriting the
+ * file without that line. Returns the LogIssueResult.
+ *
+ * If the raw id isn't found, returns null without touching disk.
+ */
+export function promoteRawCapture(
+  projectPath: string,
+  rawId: string,
+  override?: { title?: string; tags?: string[] },
+): LogIssueResult | null {
+  const all = listRawCaptures(projectPath);
+  const match = all.find((e) => e.id === rawId);
+  if (!match) return null;
+
+  const title = override?.title ?? `Auto-captured: ${match.summary}`;
+  const tags = override?.tags ?? ["auto-captured", match.source];
+  const detailsBlob = match.details ? `\n\n## Details\n\n\`\`\`json\n${JSON.stringify(match.details, null, 2)}\n\`\`\`\n` : "";
+  const result = logIssue(projectPath, {
+    title,
+    symptom: `${match.source}: ${match.summary}`,
+    tool: match.source,
+    tags,
+    body: `## Symptom\n\n${match.summary}\n\n## Context\n\n- source: \`${match.source}\`\n- captured: ${match.ts}${detailsBlob}\n\n## Investigation log\n\n- ${new Date().toISOString()} — promoted from raw capture ${rawId}.\n\n## Resolution\n\n_(filled when status flips to \`fixed\`)_\n`,
+    agent: "raw-promotion",
+  });
+
+  // Remove the promoted entry from raw.jsonl
+  const remaining = all.filter((e) => e.id !== rawId);
+  rewriteRawLog(projectPath, remaining);
+  return result;
+}
+
+/** Remove all raw captures (operator reset). Returns count cleared. */
+export function clearRawCaptures(projectPath: string): number {
+  const all = listRawCaptures(projectPath);
+  rewriteRawLog(projectPath, []);
+  return all.length;
+}
+
+function rewriteRawLog(projectPath: string, entries: RawCaptureEntry[]): void {
+  const path = rawCapturePath(projectPath);
+  if (entries.length === 0) {
+    try {
+      writeFileSync(path, "", "utf-8");
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+  try {
+    writeFileSync(path, entries.map((e) => JSON.stringify(e)).join("\n") + "\n", "utf-8");
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Opportunistic truncation: if raw.jsonl exceeds the configured cap,
+ * keep the most recent half. Cheap heuristic — operators who need
+ * stricter rotation should swap in their own.
+ */
+function truncateIfExcessive(projectPath: string): void {
+  const path = rawCapturePath(projectPath);
+  if (!existsSync(path)) return;
+  try {
+    const stat = statSync(path);
+    if (stat.size <= RAW_LOG_MAX_BYTES) return;
+    const all = listRawCaptures(projectPath);
+    const keep = all.slice(Math.floor(all.length / 2));
+    rewriteRawLog(projectPath, keep);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Test-only helper to reset the in-process sequence counter so tests
+ * produce deterministic ids when paired with a frozen `Date`.
+ */
+export function _resetRawCaptureSeqForTest(): void {
+  rawCaptureSeq = 0;
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -68,10 +68,14 @@ import { appendUpgradeLog, clearUpgradeLog, getUpgradeLog } from "./upgrade-log.
 import { projectConfigPath } from "./project-config-path.js";
 import {
   buildCandidatePayload,
+  clearRawCaptures,
   findPromotionCandidates,
   listIssues as listIssuesStore,
+  listRawCaptures,
   logIssue as logIssueStore,
+  promoteRawCapture as promoteRawCaptureStore,
   readIssue as readIssueStore,
+  recordRawCapture as recordRawCaptureStore,
   searchIssues as searchIssuesStore,
   updateIssueStatus as updateIssueStatusStore,
   type IssueIndexEntry,
@@ -2030,6 +2034,49 @@ export async function createGatewayRuntimeState(
     const query = (request.query as Record<string, string>)["q"] ?? "";
     const hits = searchIssuesStore(v.targetPath, query);
     return reply.send({ hits });
+  });
+
+  // Wish #21 Slice 5 — raw-tier auto-capture endpoints.
+  // GET    /api/projects/issues/raw                  — list raw captures
+  // POST   /api/projects/issues/raw                  — record (body: {source, summary, details?})
+  // POST   /api/projects/issues/raw/:id/promote      — promote one to curated
+  // DELETE /api/projects/issues/raw                  — clear all
+  fastify.get("/api/projects/issues/raw", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    return reply.send({ captures: listRawCaptures(v.targetPath) });
+  });
+
+  fastify.post("/api/projects/issues/raw", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const body = (request.body as Record<string, unknown> | null) ?? {};
+    const source = typeof body["source"] === "string" ? body["source"] : "";
+    const summary = typeof body["summary"] === "string" ? body["summary"] : "";
+    if (!source || !summary) return reply.code(400).send({ error: "source and summary are required" });
+    const detailsRaw = body["details"];
+    const details = detailsRaw && typeof detailsRaw === "object" ? (detailsRaw as Record<string, unknown>) : undefined;
+    const entry = recordRawCaptureStore(v.targetPath, { source, summary, details });
+    return reply.send({ entry });
+  });
+
+  fastify.post<{ Params: { id: string } }>("/api/projects/issues/raw/:id/promote", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const body = (request.body as Record<string, unknown> | null) ?? {};
+    const title = typeof body["title"] === "string" ? body["title"] : undefined;
+    const tagsRaw = body["tags"];
+    const tags = Array.isArray(tagsRaw) ? tagsRaw.filter((t): t is string => typeof t === "string") : undefined;
+    const result = promoteRawCaptureStore(v.targetPath, request.params.id, { title, tags });
+    if (!result) return reply.code(404).send({ error: "Raw capture not found" });
+    return reply.send(result);
+  });
+
+  fastify.delete("/api/projects/issues/raw", async (request, reply) => {
+    const v = validateIssueProjectPath(request, reply);
+    if (!v.ok) return v.sent;
+    const cleared = clearRawCaptures(v.targetPath);
+    return reply.send({ cleared });
   });
 
   // Wish #21 Slice 6 — promote bash audit-log entries to issues.

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -1320,6 +1320,58 @@ req=urllib.request.Request(sys.argv[6],data=data,headers={'Content-Type':'applic
 with urllib.request.urlopen(req) as r: print(r.read().decode())
 " "$title" "$symptom" "$tool" "$exit_code" "$tags" "$gw_url/api/projects/issues?path=$encoded" | ($fmt)
       ;;
+    raw)
+      # Wish #21 Slice 5 — raw-tier auto-capture management.
+      # Subcommands: list / promote <id> / clear
+      local sub="${1:-list}"
+      shift || true
+      local project=""
+      local title=""
+      local tags=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --project) project="${2:-}"; shift 2 ;;
+          --title) title="${2:-}"; shift 2 ;;
+          --tags) tags="${2:-}"; shift 2 ;;
+          *) break ;;
+        esac
+      done
+      if [ -z "$project" ]; then
+        err "Usage: agi issue raw <list|promote <id>|clear> --project <absolute-path>"
+        exit 1
+      fi
+      local encoded
+      encoded="$(python3 -c "import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1],safe=''))" "$project")"
+      case "$sub" in
+        list)
+          curl -s "$gw_url/api/projects/issues/raw?path=$encoded" | ($fmt)
+          ;;
+        promote)
+          local raw_id="$1"
+          if [ -z "$raw_id" ]; then
+            err "Usage: agi issue raw promote <raw-id> --project <path> [--title <t>] [--tags a,b,c]"
+            exit 1
+          fi
+          python3 -c "
+import json,sys,urllib.request
+body={}
+if sys.argv[1]: body['title']=sys.argv[1]
+if sys.argv[2]: body['tags']=[t.strip() for t in sys.argv[2].split(',') if t.strip()]
+data=json.dumps(body).encode()
+req=urllib.request.Request(sys.argv[3],data=data,headers={'Content-Type':'application/json'},method='POST')
+with urllib.request.urlopen(req) as r: print(r.read().decode())
+" "$title" "$tags" "$gw_url/api/projects/issues/raw/$raw_id/promote?path=$encoded" | ($fmt)
+          ;;
+        clear)
+          curl -s -X DELETE "$gw_url/api/projects/issues/raw?path=$encoded" | ($fmt)
+          ;;
+        *)
+          err "Unknown raw subcommand: $sub"
+          echo "  Subcommands: list | promote <id> | clear" >&2
+          exit 1
+          ;;
+      esac
+      ;;
     from-bash-log)
       # Wish #21 Slice 6 — promote bash audit-log entries to issues.
       # Scans ~/.agi/logs/agi-bash-*.jsonl for the last --days N days,
@@ -1381,7 +1433,7 @@ with urllib.request.urlopen(req) as r: print(r.read().decode())
       ;;
     *)
       err "Unknown issue action: $action"
-      echo "  Actions: list [--project <path>] | search <query> --project <path> | show <id> --project <path> | file --project <path> --title <t> --symptom <s> [--tool] [--exit] [--tags] | fix <id> --project <path> [--resolution] | from-bash-log --project <path> [--days N] [--dry-run]"
+      echo "  Actions: list [--project <path>] | search <query> --project <path> | show <id> --project <path> | file --project <path> --title <t> --symptom <s> [--tool] [--exit] [--tags] | fix <id> --project <path> [--resolution] | from-bash-log --project <path> [--days N] [--dry-run] | raw <list|promote <id>|clear> --project <path>"
       exit 1
       ;;
   esac
@@ -2137,6 +2189,8 @@ cmd_help() {
   echo "                                                  Mark fixed + append resolution"
   echo "                    from-bash-log --project <path> [--days N] [--dry-run]"
   echo "                                                  Promote ~/.agi/logs/agi-bash-*.jsonl entries"
+  echo "                    raw <list|promote <id>|clear> --project <path>"
+  echo "                                                  Manage raw-tier auto-capture sink"
   echo "  models CMD      HF model management — pulled/cached/installed models"
   echo "                  (list|running|status|install|start|stop|remove|search|hardware)."
   echo "                  For provider/router config (which Provider, cost-mode), use"


### PR DESCRIPTION
## Summary

Wish #21 Slice 5 — raw-tier sink for auto-capture sources (tool dispatcher, agent-invoker, future hooks). Per CLAUDE.md § 4 Pattern Substrate framing: capture richly into raw (\`<project>/k/issues/raw.jsonl\`), distill on promotion via \`logIssue()\` symptom-hash dedup.

**Note:** agent-invoker hot-path integration is NOT in this slice. Helpers exist + are tested; wiring is a follow-up cycle to avoid hot-path regression risk in this PR.

Slices remaining: 4 (dashboard tab), 7 (Playwright e2e).

## Test plan

- [x] 14 new vitest cases pass (75 total in issues subsystem)
- [x] Typecheck clean; docs-vs-help clean (27 subcommands)
- [ ] Owner: \`agi upgrade\` then \`agi issue raw list --project <p>\` — verify empty list
- [ ] Owner: POST a sample raw capture via curl + verify \`agi issue raw promote <id>\` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)