### PR TITLE
test(help): page-context wiring e2e + data-chat-context attribute (s137 t533)

### DIFF
--- a/e2e/help-page-context.spec.ts
+++ b/e2e/help-page-context.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Help button page-context wiring (s137 t533).
+ *
+ * Verifies that clicking the header `?` icon opens the chat flyout
+ * with a help-context string derived from the current route. Builds
+ * on:
+ *   - t529 (header help button — already e2e-tested in
+ *     header-help-button.spec.ts)
+ *   - t530 (page-context resolver — pure-logic tested in
+ *     dashboard/src/lib/help-context.test.ts)
+ *
+ * t533's job is the END-TO-END contract that ties them together: the
+ * help button's onClick calls `setChatContext(\`help:${resolveHelpContext(pathname)}\`)`
+ * and that value reaches the ChatFlyout's `data-chat-context`
+ * attribute on the root container.
+ *
+ * The spec drives the UI rather than poking the DOM under the hood —
+ * help button click → assert attribute on chat-flyout container.
+ */
+
+test.describe("Help button page-context wiring (s137 t533)", () => {
+  test("clicking help on /projects opens chat with `help:projects browser` context", async ({ page }) => {
+    await page.goto("/projects");
+    await page.getByTestId("header-help-button").click();
+
+    const flyout = page.locator('[data-testid="chat-flyout"]').first();
+    await expect(flyout).toBeVisible({ timeout: 5_000 });
+    // The route /projects maps to "projects browser" (per help-context.ts)
+    await expect(flyout).toHaveAttribute("data-chat-context", /^help:projects/);
+  });
+
+  test("clicking help on /settings/providers opens chat with providers-keyed context", async ({ page }) => {
+    await page.goto("/settings/providers");
+    await page.getByTestId("header-help-button").click();
+
+    const flyout = page.locator('[data-testid="chat-flyout"]').first();
+    await expect(flyout).toBeVisible({ timeout: 5_000 });
+    await expect(flyout).toHaveAttribute("data-chat-context", /^help:.+/);
+  });
+
+  test("clicking help on different routes produces distinct contexts", async ({ page }) => {
+    await page.goto("/projects");
+    await page.getByTestId("header-help-button").click();
+    const flyoutA = page.locator('[data-testid="chat-flyout"]').first();
+    await expect(flyoutA).toBeVisible({ timeout: 5_000 });
+    const ctxA = await flyoutA.getAttribute("data-chat-context");
+    expect(ctxA).toMatch(/^help:/);
+
+    // Close + reopen on a different route
+    await page.keyboard.press("Escape").catch(() => { /* may not be wired */ });
+    await page.goto("/settings/providers");
+    await page.getByTestId("header-help-button").click();
+    const flyoutB = page.locator('[data-testid="chat-flyout"]').first();
+    await expect(flyoutB).toBeVisible({ timeout: 5_000 });
+    const ctxB = await flyoutB.getAttribute("data-chat-context");
+    expect(ctxB).toMatch(/^help:/);
+
+    expect(ctxA).not.toBe(ctxB);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.605",
+  "version": "0.4.606",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ChatFlyout.tsx
+++ b/ui/dashboard/src/components/ChatFlyout.tsx
@@ -1824,6 +1824,7 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
       <>
         <div
           data-testid="chat-flyout"
+          data-chat-context={openWithContext ?? undefined}
           className="flex h-full border-l border-border bg-background"
           style={{ width: "50%" }}
         >
@@ -1853,6 +1854,7 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
     <>
       <div
         data-testid="chat-flyout"
+        data-chat-context={openWithContext ?? undefined}
         className="fixed inset-x-0 top-12 md:top-14 bottom-0 z-[200] flex justify-end pointer-events-none"
       >
         {!isFullscreen && (


### PR DESCRIPTION
## Summary

s137 t533 — closes the end-to-end contract for help button → chat-with-current-page-context.

Tiny UI seam: \`data-chat-context\` attribute added to the ChatFlyout's root container (both docked and overlay variants). Mirrors the value already computed by t530 + set via setChatContext; exposes it to Playwright without runtime change.

3 e2e cases verify the wiring across multiple routes.

## Test plan

- [x] Typecheck clean
- [ ] Owner: \`agi test --e2e help-page-context\` against test VM after merge
- [ ] Owner: open dashboard, click help button on different routes — flyout's root \`data-chat-context\` attribute reflects the resolved page-context

🤖 Generated with [Claude Code](https://claude.com/claude-code)