### PR TITLE
feat(pm): LayeredPmProvider write integration with feature flag — s155 t672 Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.609",
+  "version": "0.4.610",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/layered-pm-provider.test.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.test.ts
@@ -171,3 +171,166 @@ describe("LayeredPmProvider", () => {
     expect(info).toHaveBeenCalledWith(expect.stringContaining("primary threw for getNext"));
   });
 });
+
+// ---------------------------------------------------------------------------
+// s155 t672 Phase 2 — layered-write enqueue tests
+// ---------------------------------------------------------------------------
+
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach } from "vitest";
+import { _resetSyncSeqForTest, clearSyncQueue, readSyncQueue } from "./sync-queue.js";
+
+describe("LayeredPmProvider — Phase 2 layered writes (s155 t672)", () => {
+  let tmp: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = join(tmpdir(), `lpm-phase2-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+    mkdirSync(tmp, { recursive: true });
+    originalHome = process.env["HOME"];
+    process.env["HOME"] = join(tmp, "home");
+    mkdirSync(process.env["HOME"], { recursive: true });
+    _resetSyncSeqForTest();
+    clearSyncQueue();
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = originalHome;
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("default-off: primary failure does NOT enqueue (Phase 1 behavior intact)", async () => {
+    const primary = makeMockProvider("primary", {
+      setTaskStatus: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    // No enableLayeredWrites option set
+    const layered = new LayeredPmProvider({ primary, fallback });
+
+    await layered.setTaskStatus("t-1", "doing");
+    expect(readSyncQueue()).toEqual([]);
+  });
+
+  it("flag-on + primary failure: enqueues the call for replay", async () => {
+    const primary = makeMockProvider("primary", {
+      setTaskStatus: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({
+      primary,
+      fallback,
+      enableLayeredWrites: true,
+      projectPath: "/projects/myproj",
+    });
+
+    await layered.setTaskStatus("t-1", "doing", "starting work");
+    const queue = readSyncQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.method).toBe("setTaskStatus");
+    expect(queue[0]?.args).toEqual(["t-1", "doing", "starting work"]);
+    expect(queue[0]?.projectPath).toBe("/projects/myproj");
+    expect(queue[0]?.failureReason).toContain("offline");
+    expect(queue[0]?.attempts).toBe(0);
+  });
+
+  it("flag-on + primary success: does NOT enqueue", async () => {
+    const primary = makeMockProvider("primary"); // succeeds
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({
+      primary,
+      fallback,
+      enableLayeredWrites: true,
+      projectPath: "/projects/myproj",
+    });
+
+    await layered.setTaskStatus("t-1", "doing");
+    expect(readSyncQueue()).toEqual([]);
+  });
+
+  it("flag-on + error-shaped payload: enqueues + falls through to fallback", async () => {
+    const primary = makeMockProvider("primary", {
+      // The "looks like error payload" path — primary returns instead of throws
+      // Using `as never` because PmProvider.setTaskStatus is typed PmTask but
+      // looksLikeErrorPayload accepts unknown shapes.
+      setTaskStatus: vi.fn(async () => ({ error: "tynn unavailable" } as never)),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({
+      primary,
+      fallback,
+      enableLayeredWrites: true,
+      projectPath: "/projects/p",
+    });
+
+    await layered.setTaskStatus("t-1", "doing");
+    expect(fallback.setTaskStatus).toHaveBeenCalledOnce();
+    const queue = readSyncQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0]?.failureReason).toContain("error-shaped");
+  });
+
+  it("flag-on captures all 5 write methods (setTaskStatus/addComment/updateTask/createTask/iWish)", async () => {
+    const fail = vi.fn(async () => { throw new Error("offline"); });
+    const primary = makeMockProvider("primary", {
+      setTaskStatus: fail,
+      addComment: fail,
+      updateTask: fail,
+      createTask: fail,
+      iWish: fail,
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({
+      primary,
+      fallback,
+      enableLayeredWrites: true,
+      projectPath: "/p",
+    });
+
+    await layered.setTaskStatus("t", "doing");
+    await layered.addComment("task", "t", "hello");
+    await layered.updateTask("t", { title: "x" });
+    await layered.createTask({ title: "new", storyId: "s" });
+    await layered.iWish({ title: "wish", category: "feedback" });
+
+    const queue = readSyncQueue();
+    expect(queue.map((e) => e.method)).toEqual([
+      "setTaskStatus",
+      "addComment",
+      "updateTask",
+      "createTask",
+      "iWish",
+    ]);
+  });
+
+  it("primary === fallback (single-provider config): enqueue not invoked", async () => {
+    const provider = makeMockProvider("solo");
+    const layered = new LayeredPmProvider({
+      primary: provider,
+      fallback: provider,
+      enableLayeredWrites: true,
+      projectPath: "/p",
+    });
+    await layered.setTaskStatus("t", "doing");
+    expect(readSyncQueue()).toEqual([]);
+  });
+
+  it("uses '(unknown)' projectPath when omitted under flag-on", async () => {
+    const primary = makeMockProvider("primary", {
+      setTaskStatus: vi.fn(async () => { throw new Error("offline"); }),
+    });
+    const fallback = makeMockProvider("fallback");
+    const layered = new LayeredPmProvider({
+      primary,
+      fallback,
+      enableLayeredWrites: true,
+      // projectPath intentionally omitted
+    });
+
+    await layered.setTaskStatus("t", "doing");
+    const queue = readSyncQueue();
+    expect(queue[0]?.projectPath).toBe("(unknown)");
+  });
+});

--- a/packages/gateway-core/src/pm/layered-pm-provider.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.ts
@@ -42,6 +42,8 @@ import type {
   PmIWishInput,
 } from "@agi/sdk";
 
+import { enqueueSync } from "./sync-queue.js";
+
 export interface LayeredPmProviderOptions {
   /** The configured primary (e.g. TynnPmProvider). All reads + writes try here first. */
   primary: PmProvider;
@@ -49,6 +51,23 @@ export interface LayeredPmProviderOptions {
   fallback: PmProvider;
   /** Optional logger for fallback events. */
   logger?: { info(msg: string): void; warn(msg: string): void };
+  /**
+   * s155 t672 Phase 2 — when true, write methods that succeed via the
+   * fallback path (primary unreachable / errored) also enqueue the
+   * original call to `~/.agi/sync-queue.jsonl` so it can be replayed
+   * against primary later. Default `false` keeps Phase 1 / pre-flag
+   * behavior intact. Owner enables once Phase 3 (per-field timestamps)
+   * + Phase 4 (read-back diff) ship.
+   */
+  enableLayeredWrites?: boolean;
+  /**
+   * Project path for sync-queue scoping. Required when
+   * `enableLayeredWrites` is true; otherwise the queue can't filter
+   * replays per-project. When omitted (or flag off), queue entries
+   * carry the literal "(unknown)" string and surface as a soft
+   * diagnostic warning.
+   */
+  projectPath?: string;
 }
 
 function looksLikeErrorPayload(value: unknown): boolean {
@@ -70,11 +89,15 @@ export class LayeredPmProvider implements PmProvider {
   private readonly primary: PmProvider;
   private readonly fallback: PmProvider;
   private readonly logger?: { info(msg: string): void; warn(msg: string): void };
+  private readonly enableLayeredWrites: boolean;
+  private readonly projectPath: string;
 
   constructor(opts: LayeredPmProviderOptions) {
     this.primary = opts.primary;
     this.fallback = opts.fallback;
     this.logger = opts.logger;
+    this.enableLayeredWrites = opts.enableLayeredWrites ?? false;
+    this.projectPath = opts.projectPath ?? "(unknown)";
     // Prefer primary's id for logging; the layering is invisible to consumers.
     this.providerId = `layered(${opts.primary.providerId}+${opts.fallback.providerId})`;
   }
@@ -92,6 +115,54 @@ export class LayeredPmProvider implements PmProvider {
       this.logger?.info(`pm-layer: primary threw for ${label} (${err instanceof Error ? err.message : String(err)}); trying fallback`);
       return await op(this.fallback);
     }
+  }
+
+  /**
+   * Phase 2 — write wrapper. Mirrors `withFallback` but additionally
+   * enqueues the original call to the sync-queue when:
+   *   - `enableLayeredWrites` is true
+   *   - primary failed (threw OR returned error-shape)
+   *   - fallback succeeded
+   *
+   * Side-channel discipline: enqueue NEVER affects the call's return
+   * path. Queue failures are silent (sync-queue.ts swallows fs errors
+   * by design).
+   */
+  private async withFallbackWrite<T>(
+    method: string,
+    args: unknown[],
+    op: (p: PmProvider) => Promise<T>,
+  ): Promise<T> {
+    if (this.primary === this.fallback) return op(this.primary);
+    let primaryFailed = false;
+    let failureReason = "";
+    try {
+      const result = await op(this.primary);
+      if (looksLikeErrorPayload(result)) {
+        primaryFailed = true;
+        failureReason = "error-shaped payload from primary";
+        this.logger?.info(`pm-layer: primary returned error-shaped payload for ${method}; trying fallback`);
+      } else {
+        return result;
+      }
+    } catch (err) {
+      primaryFailed = true;
+      failureReason = err instanceof Error ? err.message : String(err);
+      this.logger?.info(`pm-layer: primary threw for ${method} (${failureReason}); trying fallback`);
+    }
+
+    // Primary path failed — fallback is now the source of truth for
+    // this call. If layered-writes is enabled, enqueue for replay.
+    const fallbackResult = await op(this.fallback);
+    if (this.enableLayeredWrites && primaryFailed) {
+      enqueueSync({
+        method,
+        args,
+        projectPath: this.projectPath,
+        failureReason,
+      });
+    }
+    return fallbackResult;
   }
 
   // ---- Reads (each falls through to fallback on primary failure) ----
@@ -120,29 +191,29 @@ export class LayeredPmProvider implements PmProvider {
     return this.withFallback("getComments", (p) => p.getComments(entityType, entityId));
   }
 
-  // ---- Writes (route through primary; fallback only on primary failure) ----
+  // ---- Writes (Phase 2 — withFallbackWrite enqueues on primary failure when enableLayeredWrites=true) ----
 
   setTaskStatus(taskId: string, status: PmStatus, note?: string): Promise<PmTask> {
-    return this.withFallback("setTaskStatus", (p) => p.setTaskStatus(taskId, status, note));
+    return this.withFallbackWrite("setTaskStatus", [taskId, status, note], (p) => p.setTaskStatus(taskId, status, note));
   }
 
   addComment(entityType: "task" | "story" | "version", entityId: string, body: string): Promise<PmComment> {
-    return this.withFallback("addComment", (p) => p.addComment(entityType, entityId, body));
+    return this.withFallbackWrite("addComment", [entityType, entityId, body], (p) => p.addComment(entityType, entityId, body));
   }
 
   updateTask(
     taskId: string,
     fields: Partial<Pick<PmTask, "title" | "description" | "verificationSteps" | "codeArea">>,
   ): Promise<PmTask> {
-    return this.withFallback("updateTask", (p) => p.updateTask(taskId, fields));
+    return this.withFallbackWrite("updateTask", [taskId, fields], (p) => p.updateTask(taskId, fields));
   }
 
   createTask(input: PmCreateTaskInput): Promise<PmTask> {
-    return this.withFallback("createTask", (p) => p.createTask(input));
+    return this.withFallbackWrite("createTask", [input], (p) => p.createTask(input));
   }
 
   iWish(input: PmIWishInput): Promise<{ id: string; title: string }> {
-    return this.withFallback("iWish", (p) => p.iWish(input));
+    return this.withFallbackWrite("iWish", [input], (p) => p.iWish(input));
   }
 
   async getActiveFocusProgress(): ReturnType<NonNullable<PmProvider["getActiveFocusProgress"]>> {


### PR DESCRIPTION
## Summary

s155 t672 Phase 2 — wires Phase 1's sync-queue helpers (PR #119) into LayeredPmProvider's write path.

New \`withFallbackWrite\` enqueues the original call to \`~/.agi/sync-queue.jsonl\` when primary fails AND fallback succeeds. Gated by \`enableLayeredWrites\` constructor option (default \`false\`); flag-off behavior is bit-identical to pre-Phase-2.

5 write methods covered: setTaskStatus, addComment, updateTask, createTask, iWish.

Side-channel discipline: enqueue failures never propagate. Hot-path-safe.

Phases 3-6 (per-field timestamps, read-back diff, /api/pm/conflicts REST, dashboard panel, background worker) follow.

## Test plan

- [x] 17 vitest cases pass (10 existing + 7 new Phase 2)
- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` then verify default (flag-off) — no behavior change
- [ ] Owner (later phase): set \`agent.pm.enableLayeredWrites: true\` in gateway.json + watch \`~/.agi/sync-queue.jsonl\` populate when primary unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)