### PR TITLE
feat(pm): per-field timestamps in TynnLite + getTaskFieldTimestamps — s155 t672 Phase 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.610",
+  "version": "0.4.611",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/tynn-lite-provider.test.ts
+++ b/packages/gateway-core/src/pm/tynn-lite-provider.test.ts
@@ -424,6 +424,56 @@ describe("TynnLitePmProvider — pluggable storageDir (s155 t670)", () => {
   });
 });
 
+describe("TynnLitePmProvider — per-field timestamps (s155 t672 Phase 3)", () => {
+  it("getTaskFieldTimestamps returns null for unknown task", () => {
+    expect(provider.getTaskFieldTimestamps("t-bogus")).toBeNull();
+  });
+
+  it("after createTask: every field timestamp falls back to createdAt", async () => {
+    const t = await provider.createTask({ storyId: "", title: "T", description: "D" });
+    const ts = provider.getTaskFieldTimestamps(t.id);
+    expect(ts).not.toBeNull();
+    // No directly-set fields yet — all should equal the record's createdAt
+    expect(ts?.title).toBe(ts?.status);
+    expect(ts?.description).toBe(ts?.status);
+  });
+
+  it("setTaskStatus stamps the status timestamp", async () => {
+    const t = await provider.createTask({ storyId: "", title: "T", description: "D" });
+    const before = provider.getTaskFieldTimestamps(t.id);
+    await new Promise((r) => setTimeout(r, 5));
+    await provider.setTaskStatus(t.id, "doing");
+    const after = provider.getTaskFieldTimestamps(t.id);
+    expect(after?.status).not.toBe(before?.status);
+    // Title/description NOT touched — should remain at floor
+    expect(after?.title).toBe(before?.title);
+  });
+
+  it("updateTask stamps each mutated field independently", async () => {
+    const t = await provider.createTask({ storyId: "", title: "T", description: "D" });
+    await new Promise((r) => setTimeout(r, 5));
+    await provider.updateTask(t.id, { title: "T2" });
+    const tsAfterTitle = provider.getTaskFieldTimestamps(t.id);
+    await new Promise((r) => setTimeout(r, 5));
+    await provider.updateTask(t.id, { description: "D2" });
+    const tsAfterDesc = provider.getTaskFieldTimestamps(t.id);
+    // title should be unchanged from when it was last stamped
+    expect(tsAfterDesc?.title).toBe(tsAfterTitle?.title);
+    // description should be newer than the title's stamp
+    expect(tsAfterDesc?.description.localeCompare(tsAfterDesc?.title ?? "")).toBeGreaterThan(0);
+  });
+
+  it("timestamps carry through subsequent snapshots (fold preserves)", async () => {
+    const t = await provider.createTask({ storyId: "", title: "T", description: "D" });
+    await provider.updateTask(t.id, { title: "T2" });
+    const tsAfterTitle = provider.getTaskFieldTimestamps(t.id);
+    // Now mutate a different field — title timestamp should NOT change
+    await provider.setTaskStatus(t.id, "doing");
+    const tsFinal = provider.getTaskFieldTimestamps(t.id);
+    expect(tsFinal?.title).toBe(tsAfterTitle?.title);
+  });
+});
+
 describe("migrateTynnLiteStorage (s155 t670)", () => {
   let testRoot: string;
   beforeEach(() => {

--- a/packages/gateway-core/src/pm/tynn-lite-provider.ts
+++ b/packages/gateway-core/src/pm/tynn-lite-provider.ts
@@ -70,6 +70,30 @@ interface TynnLiteTaskRecord {
   codeArea?: string;
   /** Optional: verification steps mirroring PmTask.verificationSteps. */
   verificationSteps?: string[];
+  /**
+   * s155 t672 Phase 3 — per-field updated-at timestamps for the
+   * conflict-resolution layer (Phase 4 reads these to detect divergence
+   * vs primary). Optional/sparse: a missing key means "never directly
+   * set" (defaults to record's createdAt for the conflict-detection
+   * fold). When a setter mutates a field, it stamps the corresponding
+   * key. Inherited timestamps carry forward across snapshot writes.
+   */
+  updatedAt?: {
+    title?: string;
+    description?: string;
+    status?: string;
+    codeArea?: string;
+    verificationSteps?: string;
+  };
+}
+
+/** Per-field timestamps surfaced by getTaskFieldTimestamps for Phase 4 conflict-detection. */
+export interface TaskFieldTimestamps {
+  title: string;
+  description: string;
+  status: string;
+  codeArea: string;
+  verificationSteps: string;
 }
 
 /** One line in comments.jsonl — append-only, never mutated. */
@@ -336,6 +360,7 @@ export class TynnLitePmProvider implements PmProvider {
       status,
       startedAt: status === "doing" && current.startedAt === null ? now : current.startedAt,
       finishedAt: (status === "finished" || status === "archived") && current.finishedAt === null ? now : current.finishedAt,
+      updatedAt: { ...(current.updatedAt ?? {}), status: now },
     };
     this.appendRecord(updated);
     const refolded = [...this.foldRecords().values()];
@@ -369,16 +394,47 @@ export class TynnLitePmProvider implements PmProvider {
     const folded = this.foldRecords();
     const current = folded.get(taskId);
     if (current === undefined) throw new Error(`tynn-lite: unknown task ${taskId}`);
+    const now = new Date().toISOString();
+    const newTimestamps: NonNullable<TynnLiteTaskRecord["updatedAt"]> = { ...(current.updatedAt ?? {}) };
+    if (fields.title !== undefined) newTimestamps.title = now;
+    if (fields.description !== undefined) newTimestamps.description = now;
+    if (fields.verificationSteps !== undefined) newTimestamps.verificationSteps = now;
+    if (fields.codeArea !== undefined) newTimestamps.codeArea = now;
     const updated: TynnLiteTaskRecord = {
       ...current,
       title: fields.title ?? current.title,
       description: fields.description ?? current.description,
       verificationSteps: fields.verificationSteps ?? current.verificationSteps,
       codeArea: fields.codeArea ?? current.codeArea,
+      updatedAt: newTimestamps,
     };
     this.appendRecord(updated);
     const refolded = [...this.foldRecords().values()];
     return this.toPmTask(updated, refolded.findIndex((r) => r.id === updated.id) + 1);
+  }
+
+  /**
+   * s155 t672 Phase 3 — surface per-field updated-at timestamps for
+   * the Phase 4 read-back diff routine. Returns an exhaustive map
+   * with createdAt as the floor for any field that's never been
+   * directly mutated (so callers can diff against any field without
+   * undefined-checks).
+   *
+   * Returns null when the task is unknown.
+   */
+  getTaskFieldTimestamps(taskId: string): TaskFieldTimestamps | null {
+    const folded = this.foldRecords();
+    const record = folded.get(taskId);
+    if (record === undefined) return null;
+    const floor = record.createdAt;
+    const ts = record.updatedAt ?? {};
+    return {
+      title: ts.title ?? floor,
+      description: ts.description ?? floor,
+      status: ts.status ?? floor,
+      codeArea: ts.codeArea ?? floor,
+      verificationSteps: ts.verificationSteps ?? floor,
+    };
   }
 
   async iWish(input: PmIWishInput): Promise<{ id: string; title: string }> {


### PR DESCRIPTION
## Summary

s155 t672 Phase 3 — adds optional \`updatedAt\` field-map to \`TynnLiteTaskRecord\` carrying per-field stamp times. Setters stamp their corresponding fields; inherited timestamps carry forward across snapshot writes.

New \`getTaskFieldTimestamps(taskId)\` exposes an exhaustive map for Phase 4's read-back diff routine.

5 new vitest cases (150 total in PM suite). Phases 4-6 (read-back diff, /api/pm/conflicts REST + dashboard, background worker) follow.

## Test plan

- [x] 150 vitest cases pass
- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` — schema additive (new optional \`updatedAt\` field), no migration needed; existing tasks.jsonl reads cleanly with timestamps falling back to record.createdAt

🤖 Generated with [Claude Code](https://claude.com/claude-code)