### PR TITLE
feat(pm): read-back conflict detection — s155 t672 Phase 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.611",
+  "version": "0.4.612",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/conflict-detection.test.ts
+++ b/packages/gateway-core/src/pm/conflict-detection.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Conflict-detection tests (s155 t672 Phase 4).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectConflicts,
+  isHardStatusConflict,
+  lwwWinner,
+  TRACKED_FIELDS,
+} from "./conflict-detection.js";
+import type { TaskFieldTimestamps } from "./tynn-lite-provider.js";
+
+const FLOOR = "2026-01-01T00:00:00Z";
+const NEWER = "2026-05-01T00:00:00Z";
+const NEWEST = "2026-05-09T00:00:00Z";
+
+function timestamps(overrides: Partial<TaskFieldTimestamps> = {}): TaskFieldTimestamps {
+  return {
+    title: FLOOR,
+    description: FLOOR,
+    status: FLOOR,
+    codeArea: FLOOR,
+    verificationSteps: FLOOR,
+    ...overrides,
+  };
+}
+
+describe("isHardStatusConflict (s155 t672 Phase 4)", () => {
+  it("identical statuses are never hard-conflict", () => {
+    expect(isHardStatusConflict("doing", "doing")).toBe(false);
+    expect(isHardStatusConflict("backlog", "backlog")).toBe(false);
+  });
+
+  it("terminal vs not-started is hard", () => {
+    expect(isHardStatusConflict("finished", "backlog")).toBe(true);
+    expect(isHardStatusConflict("archived", "backlog")).toBe(true);
+    expect(isHardStatusConflict("backlog", "finished")).toBe(true);
+  });
+
+  it("blocked vs live state is hard", () => {
+    expect(isHardStatusConflict("blocked", "doing")).toBe(true);
+    expect(isHardStatusConflict("blocked", "testing")).toBe(true);
+    expect(isHardStatusConflict("doing", "blocked")).toBe(true);
+  });
+
+  it("normal forward transitions are NOT hard", () => {
+    // backlog → doing, doing → testing, testing → finished — all soft
+    expect(isHardStatusConflict("backlog", "doing")).toBe(false);
+    expect(isHardStatusConflict("doing", "testing")).toBe(false);
+    expect(isHardStatusConflict("testing", "finished")).toBe(false);
+  });
+
+  it("backwards transitions within active states are soft", () => {
+    expect(isHardStatusConflict("doing", "backlog")).toBe(false); // backlog isn't terminal
+    expect(isHardStatusConflict("testing", "doing")).toBe(false);
+  });
+});
+
+describe("detectConflicts (s155 t672 Phase 4)", () => {
+  const baseInput = {
+    projectPath: "/p",
+    entityType: "task" as const,
+    entityId: "t-1",
+  };
+
+  it("returns empty array when records agree", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { title: "T", description: "D", status: "doing" },
+      lite: { title: "T", description: "D", status: "doing" },
+      liteTimestamps: timestamps(),
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("emits one descriptor per diverged field", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { title: "Primary", description: "Primary D", status: "doing" },
+      lite: { title: "Lite", description: "Lite D", status: "doing" },
+      liteTimestamps: timestamps({ title: NEWER, description: NEWER }),
+    });
+    expect(conflicts).toHaveLength(2);
+    const fields = conflicts.map((c) => c.field).sort();
+    expect(fields).toEqual(["description", "title"]);
+  });
+
+  it("threads projectPath / entityType / entityId into every descriptor", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { title: "A" },
+      lite: { title: "B" },
+      liteTimestamps: timestamps({ title: NEWER }),
+    });
+    expect(conflicts[0]?.projectPath).toBe("/p");
+    expect(conflicts[0]?.entityType).toBe("task");
+    expect(conflicts[0]?.entityId).toBe("t-1");
+  });
+
+  it("captures both primary + lite values + timestamps", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { title: "Primary" },
+      lite: { title: "Lite" },
+      liteTimestamps: timestamps({ title: NEWER }),
+      primaryTimestamps: { title: NEWEST },
+    });
+    expect(conflicts[0]?.primaryValue).toBe("Primary");
+    expect(conflicts[0]?.liteValue).toBe("Lite");
+    expect(conflicts[0]?.primaryUpdatedAt).toBe(NEWEST);
+    expect(conflicts[0]?.liteUpdatedAt).toBe(NEWER);
+  });
+
+  it("flags status divergence as hard when transition is invalid", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { status: "finished" },
+      lite: { status: "backlog" },
+      liteTimestamps: timestamps({ status: NEWER }),
+    });
+    expect(conflicts[0]?.field).toBe("status");
+    expect(conflicts[0]?.hard).toBe(true);
+  });
+
+  it("status divergence within soft states is NOT hard", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { status: "testing" },
+      lite: { status: "doing" },
+      liteTimestamps: timestamps({ status: NEWER }),
+    });
+    expect(conflicts[0]?.hard).toBe(false);
+  });
+
+  it("non-status fields are never hard-conflict", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: { title: "wildly different", description: "as is desc" },
+      lite: { title: "lite version", description: "lite desc" },
+      liteTimestamps: timestamps({ title: NEWER, description: NEWER }),
+    });
+    for (const c of conflicts) {
+      expect(c.hard).toBe(false);
+    }
+  });
+
+  it("array fields use element-wise equality", () => {
+    const conflicts1 = detectConflicts({
+      ...baseInput,
+      primary: { verificationSteps: ["a", "b"] },
+      lite: { verificationSteps: ["a", "b"] },
+      liteTimestamps: timestamps(),
+    });
+    expect(conflicts1).toEqual([]);
+
+    const conflicts2 = detectConflicts({
+      ...baseInput,
+      primary: { verificationSteps: ["a", "b"] },
+      lite: { verificationSteps: ["a", "c"] },
+      liteTimestamps: timestamps({ verificationSteps: NEWER }),
+    });
+    expect(conflicts2).toHaveLength(1);
+    expect(conflicts2[0]?.field).toBe("verificationSteps");
+  });
+
+  it("undefined vs undefined is not a divergence", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: {},
+      lite: {},
+      liteTimestamps: timestamps(),
+    });
+    expect(conflicts).toEqual([]);
+  });
+
+  it("undefined vs defined IS a divergence", () => {
+    const conflicts = detectConflicts({
+      ...baseInput,
+      primary: {},
+      lite: { codeArea: "src/foo.ts" },
+      liteTimestamps: timestamps({ codeArea: NEWER }),
+    });
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.field).toBe("codeArea");
+  });
+});
+
+describe("lwwWinner (s155 t672 Phase 4)", () => {
+  const make = (overrides: Partial<{
+    primaryUpdatedAt: string;
+    liteUpdatedAt: string;
+  }> = {}) => ({
+    projectPath: "/p",
+    entityType: "task",
+    entityId: "t-1",
+    field: "title",
+    primaryValue: "P",
+    liteValue: "L",
+    hard: false,
+    ...overrides,
+  });
+
+  it("primary wins when primaryUpdatedAt > liteUpdatedAt", () => {
+    expect(lwwWinner(make({ primaryUpdatedAt: NEWEST, liteUpdatedAt: NEWER }))).toBe("primary");
+  });
+
+  it("lite wins when liteUpdatedAt > primaryUpdatedAt", () => {
+    expect(lwwWinner(make({ primaryUpdatedAt: NEWER, liteUpdatedAt: NEWEST }))).toBe("lite");
+  });
+
+  it("lite wins when primary timestamp is missing (ADR floor stance)", () => {
+    expect(lwwWinner(make({ liteUpdatedAt: NEWER }))).toBe("lite");
+  });
+
+  it("primary wins when only lite timestamp is missing", () => {
+    expect(lwwWinner(make({ primaryUpdatedAt: NEWER }))).toBe("primary");
+  });
+
+  it("ties resolved as lite (gte beats lite-newer-or-equal)", () => {
+    expect(lwwWinner(make({ primaryUpdatedAt: NEWER, liteUpdatedAt: NEWER }))).toBe("lite");
+  });
+});
+
+describe("TRACKED_FIELDS (s155 t672 Phase 4)", () => {
+  it("matches the keys in TaskFieldTimestamps", () => {
+    expect([...TRACKED_FIELDS].sort()).toEqual(
+      ["codeArea", "description", "status", "title", "verificationSteps"].sort(),
+    );
+  });
+});

--- a/packages/gateway-core/src/pm/conflict-detection.ts
+++ b/packages/gateway-core/src/pm/conflict-detection.ts
@@ -1,0 +1,156 @@
+/**
+ * Read-back conflict detection — s155 t672 Phase 4.
+ *
+ * Pure-logic comparator that takes a primary record + a TynnLite record
+ * + per-field updated-at timestamps and emits conflict descriptors per
+ * the t669 ADR (`agi/docs/agents/adr-layered-pm-conflict-resolution.md`).
+ *
+ * Inputs come from upstream (Phase 6 worker fetches from primary; Phase
+ * 3's `getTaskFieldTimestamps` provides TynnLite's stamps). Output
+ * descriptors get fed to `recordSyncConflict()` by the caller for
+ * surface in the dashboard PM-Lite panel (Phase 5).
+ *
+ * Resolution model (per ADR):
+ *   - Soft conflict: per-field divergence with valid LWW resolution
+ *     possible. The newer-stamped side wins; the loser's value is
+ *     surfaced in the conflict log so the owner can see the override.
+ *   - Hard conflict: status moved through an invalid transition (e.g.
+ *     primary says `done`, lite says `backlog` — neither is reachable
+ *     from the other without intermediate states). Blocks auto-merge;
+ *     owner-resolves via the dashboard.
+ *
+ * Hard-conflict detection is STATUS-ONLY for this phase. Future phases
+ * could add hard rules for other fields (e.g. tags can never go from
+ * non-empty to empty without explicit clear), but status is the clear
+ * winner today: it has a defined state graph, and "backwards" moves
+ * (done → backlog) are nearly always errors.
+ */
+
+import type { PmStatus, PmTask } from "@agi/sdk";
+import type { TaskFieldTimestamps } from "./tynn-lite-provider.js";
+import type { SyncConflictEntry } from "./sync-queue.js";
+
+/** Fields the diff covers. Mirror the keys in TaskFieldTimestamps. */
+export const TRACKED_FIELDS = ["title", "description", "status", "codeArea", "verificationSteps"] as const;
+export type TrackedField = (typeof TRACKED_FIELDS)[number];
+
+/** Output of the diff — one entry per diverged field. */
+export type DetectedConflict = Omit<SyncConflictEntry, "id" | "ts">;
+
+/** Per-field comparison input. */
+export interface DiffInput {
+  /** Project the records belong to. Threaded into output entries. */
+  projectPath: string;
+  /** Tynn entity type (typically "task" — extends to "story" later). */
+  entityType: string;
+  /** Tynn entity id. */
+  entityId: string;
+  /** Record value as observed on primary. Fields may be undefined when
+   *  the upstream API omits them (e.g. tynn doesn't always populate
+   *  codeArea); the diff treats undefined identically on both sides. */
+  primary: Partial<Pick<PmTask, "title" | "description" | "status" | "codeArea" | "verificationSteps">>;
+  /** Same shape from TynnLite. */
+  lite: Partial<Pick<PmTask, "title" | "description" | "status" | "codeArea" | "verificationSteps">>;
+  /** Per-field updated-at timestamps from TynnLite. */
+  liteTimestamps: TaskFieldTimestamps;
+  /**
+   * Per-field timestamps as observed on primary. Often unavailable
+   * (most PmProvider implementations don't expose them). When
+   * undefined, LWW defaults to "lite is newer" — primary's stale data
+   * loses, which matches the ADR's "TynnLite is the floor" stance.
+   */
+  primaryTimestamps?: Partial<TaskFieldTimestamps>;
+}
+
+/**
+ * Hard-conflict detection: status moves that aren't reachable in the
+ * canonical workflow. Returns true when the (primary, lite) pair is
+ * an invalid bypass (e.g. one says `done`, other says `backlog`).
+ *
+ * Soft moves (e.g. `doing` ↔ `testing`, `backlog` → `doing`,
+ * `doing` → `finished`) are NOT hard conflicts even when they
+ * diverge — LWW resolves them.
+ */
+export function isHardStatusConflict(primaryStatus: PmStatus, liteStatus: PmStatus): boolean {
+  if (primaryStatus === liteStatus) return false;
+  // The status pairs that can't be reconciled by LWW alone:
+  // - terminal vs not-yet-started (done/archived <-> backlog)
+  // - blocked + active (blocked <-> doing/testing/finished)
+  const terminal: PmStatus[] = ["finished", "archived"];
+  const notStarted: PmStatus[] = ["backlog"];
+  const liveStates: PmStatus[] = ["starting", "doing", "testing"];
+  if (terminal.includes(primaryStatus) && notStarted.includes(liteStatus)) return true;
+  if (terminal.includes(liteStatus) && notStarted.includes(primaryStatus)) return true;
+  if (primaryStatus === "blocked" && liveStates.includes(liteStatus)) return true;
+  if (liteStatus === "blocked" && liveStates.includes(primaryStatus)) return true;
+  return false;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || a === undefined) return b === null || b === undefined;
+  if (b === null || b === undefined) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Walk every tracked field; for each that diverges, emit a conflict
+ * descriptor. Returns an empty array when records agree on all fields.
+ *
+ * Pure: same input → same output. No I/O, no clock. Caller is
+ * responsible for actually writing the descriptors via
+ * `recordSyncConflict()`.
+ */
+export function detectConflicts(input: DiffInput): DetectedConflict[] {
+  const conflicts: DetectedConflict[] = [];
+  const ptimes = input.primaryTimestamps ?? {};
+
+  for (const field of TRACKED_FIELDS) {
+    const liteValue = input.lite[field];
+    const primaryValue = input.primary[field];
+    if (valuesEqual(liteValue, primaryValue)) continue;
+
+    // Status gets the hard-conflict check.
+    const isHard = field === "status"
+      ? isHardStatusConflict(primaryValue as PmStatus, liteValue as PmStatus)
+      : false;
+
+    conflicts.push({
+      projectPath: input.projectPath,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      field,
+      primaryValue,
+      liteValue,
+      primaryUpdatedAt: ptimes[field],
+      liteUpdatedAt: input.liteTimestamps[field],
+      hard: isHard,
+    });
+  }
+
+  return conflicts;
+}
+
+/**
+ * Resolve a single conflict by LWW: returns `"primary"` when primary's
+ * timestamp is strictly greater than lite's, `"lite"` otherwise. When
+ * primary's timestamp is undefined (most current PmProviders don't
+ * expose them), lite wins — matches the ADR's "TynnLite is the floor"
+ * stance.
+ *
+ * Hard conflicts SHOULD NOT be auto-resolved; this helper still
+ * returns a winner for completeness but callers should check
+ * `c.hard` before using the result.
+ */
+export function lwwWinner(c: DetectedConflict): "primary" | "lite" {
+  if (!c.primaryUpdatedAt) return "lite";
+  if (!c.liteUpdatedAt) return "primary";
+  return c.primaryUpdatedAt > c.liteUpdatedAt ? "primary" : "lite";
+}

--- a/packages/gateway-core/src/pm/layered-pm-provider.test.ts
+++ b/packages/gateway-core/src/pm/layered-pm-provider.test.ts
@@ -292,8 +292,8 @@ describe("LayeredPmProvider — Phase 2 layered writes (s155 t672)", () => {
     await layered.setTaskStatus("t", "doing");
     await layered.addComment("task", "t", "hello");
     await layered.updateTask("t", { title: "x" });
-    await layered.createTask({ title: "new", storyId: "s" });
-    await layered.iWish({ title: "wish", category: "feedback" });
+    await layered.createTask({ title: "new", storyId: "s", description: "" });
+    await layered.iWish({ title: "wish", needs: "test" });
 
     const queue = readSyncQueue();
     expect(queue.map((e) => e.method)).toEqual([


### PR DESCRIPTION
## Summary

s155 t672 Phase 4 — pure-logic comparator that takes a primary record + a TynnLite record + per-field timestamps and emits SyncConflict descriptors per the t669 ADR.

\`detectConflicts()\` walks 5 tracked fields, emits one descriptor per divergence, threads project/entity context.

\`isHardStatusConflict()\` identifies status moves that bypass the canonical state graph (terminal vs not-started, blocked vs live). Status is the only field with a defined hard-conflict rule today.

\`lwwWinner()\` resolves soft conflicts: lite wins when primary timestamp is missing (per ADR floor stance).

Also picks up a Phase 2 typing fix that was missed in PR #122 (storyId + needs vs the strict PmCreateTaskInput / PmIWishInput shapes).

21 vitest cases (171 total in PM suite). Phases 5-6 follow.

## Test plan

- [x] 171 vitest cases pass
- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` — pure-logic addition, no behavior change. Phase 6 worker will exercise this routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)