### PR TITLE
feat(pm): SyncReplayWorker — periodic queue replay + read-back diff (s155 t672 Phase 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.612",
+  "version": "0.4.613",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm/sync-replay-worker.test.ts
+++ b/packages/gateway-core/src/pm/sync-replay-worker.test.ts
@@ -1,0 +1,249 @@
+/**
+ * SyncReplayWorker tests (s155 t672 Phase 6).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { SyncReplayWorker } from "./sync-replay-worker.js";
+import {
+  _resetSyncSeqForTest,
+  clearSyncConflicts,
+  clearSyncQueue,
+  enqueueSync,
+  readSyncConflicts,
+  readSyncQueue,
+} from "./sync-queue.js";
+import { TynnLitePmProvider } from "./tynn-lite-provider.js";
+import type { PmProvider, PmTask, PmStatus, PmComment, PmCreateTaskInput, PmIWishInput } from "@agi/sdk";
+
+let tmp: string;
+let originalHome: string | undefined;
+let projectRoot: string;
+let lite: TynnLitePmProvider;
+
+function makeMockPrimary(overrides: Partial<PmProvider> = {}): PmProvider {
+  const stubTask = (taskId: string): PmTask => ({
+    id: taskId, number: 1, storyId: "s1", title: `task-${taskId}`, status: "doing",
+  });
+  return {
+    providerId: "mock-primary",
+    getProject: vi.fn(async () => ({ id: "p", name: "p" })),
+    getNext: vi.fn(async () => ({ version: null, topStory: null, tasks: [] })),
+    getTask: vi.fn(async (idOrNumber: string | number) => stubTask(`${String(idOrNumber)}`)),
+    getStory: vi.fn(async () => null),
+    findTasks: vi.fn(async () => []),
+    getComments: vi.fn(async () => []),
+    setTaskStatus: vi.fn(async (taskId: string, _status: PmStatus) => stubTask(taskId)),
+    addComment: vi.fn(async (_etype, _eid, body: string): Promise<PmComment> => ({ id: "c1", body, createdAt: "2026-05-08T00:00:00Z" })),
+    updateTask: vi.fn(async (taskId: string) => stubTask(taskId)),
+    createTask: vi.fn(async (input: PmCreateTaskInput) => ({ ...stubTask("new"), title: input.title })),
+    iWish: vi.fn(async (input: PmIWishInput) => ({ id: "w1", title: input.title })),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `srw-test-${String(Date.now())}-${String(Math.random()).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  originalHome = process.env["HOME"];
+  process.env["HOME"] = join(tmp, "home");
+  mkdirSync(process.env["HOME"], { recursive: true });
+  _resetSyncSeqForTest();
+  clearSyncQueue();
+  clearSyncConflicts();
+  projectRoot = join(tmp, "proj");
+  mkdirSync(projectRoot, { recursive: true });
+  lite = new TynnLitePmProvider({ projectRoot, projectName: "test-project" });
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env["HOME"];
+  else process.env["HOME"] = originalHome;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("SyncReplayWorker — start/stop lifecycle (s155 t672 Phase 6)", () => {
+  it("disabled worker: start() is no-op", () => {
+    const worker = new SyncReplayWorker({ primary: makeMockPrimary(), lite, enabled: false });
+    worker.start();
+    // No interval scheduled → stop() is also no-op
+    expect(() => worker.stop()).not.toThrow();
+  });
+
+  it("enabled worker: start() schedules interval; stop() clears it", () => {
+    vi.useFakeTimers();
+    const worker = new SyncReplayWorker({ primary: makeMockPrimary(), lite, enabled: true, tickIntervalMs: 1000 });
+    worker.start();
+    // Idempotent — second start is no-op
+    worker.start();
+    worker.stop();
+    worker.stop(); // also no-op
+    vi.useRealTimers();
+  });
+});
+
+describe("SyncReplayWorker.tick — replay (s155 t672 Phase 6)", () => {
+  it("empty queue: returns zero counts", async () => {
+    const worker = new SyncReplayWorker({ primary: makeMockPrimary(), lite, enabled: true });
+    const result = await worker.tick();
+    expect(result).toEqual({ scanned: 0, succeeded: 0, failed: 0, conflicts: 0 });
+  });
+
+  it("successful replay drains entry from queue", async () => {
+    enqueueSync({ method: "setTaskStatus", args: ["t-1", "doing"], projectPath: projectRoot });
+    expect(readSyncQueue()).toHaveLength(1);
+
+    const primary = makeMockPrimary();
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+
+    expect(result.scanned).toBe(1);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(readSyncQueue()).toEqual([]);
+    expect(primary.setTaskStatus).toHaveBeenCalledWith("t-1", "doing", undefined);
+  });
+
+  it("failed replay bumps attempts; entry stays queued", async () => {
+    enqueueSync({ method: "setTaskStatus", args: ["t-1", "doing"], projectPath: projectRoot });
+
+    const primary = makeMockPrimary({
+      setTaskStatus: vi.fn(async () => { throw new Error("still offline"); }),
+    });
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+
+    expect(result.scanned).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(1);
+    const remaining = readSyncQueue();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.attempts).toBe(1);
+  });
+
+  it("mixed success/fail: only succeeded entries drain", async () => {
+    enqueueSync({ method: "setTaskStatus", args: ["t-1", "doing"], projectPath: projectRoot });
+    enqueueSync({ method: "setTaskStatus", args: ["t-2", "doing"], projectPath: projectRoot });
+
+    const primary = makeMockPrimary({
+      setTaskStatus: vi.fn(async (taskId: string) => {
+        if (taskId === "t-2") throw new Error("offline for t-2");
+        return { id: taskId, number: 1, storyId: "s", title: "ok", status: "doing" } as PmTask;
+      }),
+    });
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(1);
+    const remaining = readSyncQueue();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.args).toEqual(["t-2", "doing"]);
+  });
+
+  it("dispatches all 5 write methods", async () => {
+    enqueueSync({ method: "setTaskStatus", args: ["t", "doing"], projectPath: projectRoot });
+    enqueueSync({ method: "addComment", args: ["task", "t", "hi"], projectPath: projectRoot });
+    enqueueSync({ method: "updateTask", args: ["t", { title: "x" }], projectPath: projectRoot });
+    enqueueSync({ method: "createTask", args: [{ storyId: "s", title: "n", description: "" }], projectPath: projectRoot });
+    enqueueSync({ method: "iWish", args: [{ title: "wish" }], projectPath: projectRoot });
+
+    const primary = makeMockPrimary();
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+
+    expect(result.succeeded).toBe(5);
+    expect(primary.setTaskStatus).toHaveBeenCalled();
+    expect(primary.addComment).toHaveBeenCalled();
+    expect(primary.updateTask).toHaveBeenCalled();
+    expect(primary.createTask).toHaveBeenCalled();
+    expect(primary.iWish).toHaveBeenCalled();
+  });
+
+  it("unknown method: marks failed + bumps attempts", async () => {
+    enqueueSync({ method: "unknownMethod", args: [], projectPath: projectRoot });
+    const worker = new SyncReplayWorker({ primary: makeMockPrimary(), lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+    expect(result.failed).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(readSyncQueue()[0]?.attempts).toBe(1);
+  });
+});
+
+describe("SyncReplayWorker.tick — read-back diff (s155 t672 Phase 6)", () => {
+  it("records conflicts when primary's read-back diverges from lite", async () => {
+    // Seed lite with a task; primary will return DIFFERENT title on read-back.
+    const liteTask = await lite.createTask({ storyId: "s1", title: "Lite version", description: "D" });
+    enqueueSync({ method: "setTaskStatus", args: [liteTask.id, "doing"], projectPath: projectRoot });
+
+    const primary = makeMockPrimary({
+      setTaskStatus: vi.fn(async (taskId: string) => ({
+        id: taskId, number: 1, storyId: "s1", title: "Primary version different",
+        description: "D", status: "doing",
+      } as PmTask)),
+    });
+
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: true });
+    const result = await worker.tick();
+
+    expect(result.succeeded).toBe(1);
+    expect(result.conflicts).toBeGreaterThan(0);
+    const conflicts = readSyncConflicts();
+    expect(conflicts.find((c) => c.field === "title")).toBeDefined();
+  });
+
+  it("no conflicts when records agree", async () => {
+    // Pre-set lite-side to 'doing' so lite + primary read-back agree on
+    // every tracked field (title, description, status). createTask
+    // defaults to backlog; setTaskStatus moves it to doing.
+    const liteTask = await lite.createTask({ storyId: "s1", title: "Same title", description: "D" });
+    await lite.setTaskStatus(liteTask.id, "doing");
+    enqueueSync({ method: "setTaskStatus", args: [liteTask.id, "doing"], projectPath: projectRoot });
+
+    const primary = makeMockPrimary({
+      setTaskStatus: vi.fn(async (taskId: string) => ({
+        id: taskId, number: 1, storyId: "s1", title: "Same title",
+        description: "D", status: "doing",
+      } as PmTask)),
+    });
+
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: true });
+    const result = await worker.tick();
+
+    expect(result.succeeded).toBe(1);
+    expect(result.conflicts).toBe(0);
+    expect(readSyncConflicts()).toEqual([]);
+  });
+
+  it("comments / wishes don't trigger read-back diff", async () => {
+    enqueueSync({ method: "addComment", args: ["task", "t-1", "note"], projectPath: projectRoot });
+    enqueueSync({ method: "iWish", args: [{ title: "wish" }], projectPath: projectRoot });
+
+    const worker = new SyncReplayWorker({ primary: makeMockPrimary(), lite, enabled: true, enableReadBackDiff: true });
+    const result = await worker.tick();
+
+    expect(result.succeeded).toBe(2);
+    expect(result.conflicts).toBe(0);
+  });
+
+  it("disabled read-back diff: no conflicts even when records differ", async () => {
+    const liteTask = await lite.createTask({ storyId: "s1", title: "Lite", description: "" });
+    enqueueSync({ method: "setTaskStatus", args: [liteTask.id, "doing"], projectPath: projectRoot });
+
+    const primary = makeMockPrimary({
+      setTaskStatus: vi.fn(async (taskId: string) => ({
+        id: taskId, number: 1, storyId: "s1", title: "Primary diff",
+        description: "", status: "doing",
+      } as PmTask)),
+    });
+
+    const worker = new SyncReplayWorker({ primary, lite, enabled: true, enableReadBackDiff: false });
+    const result = await worker.tick();
+
+    expect(result.conflicts).toBe(0);
+    expect(readSyncConflicts()).toEqual([]);
+  });
+});

--- a/packages/gateway-core/src/pm/sync-replay-worker.ts
+++ b/packages/gateway-core/src/pm/sync-replay-worker.ts
@@ -1,0 +1,222 @@
+/**
+ * Sync replay worker — s155 t672 Phase 6.
+ *
+ * Periodically attempts to replay queued writes against primary, then
+ * reads back to detect divergence between primary's state and
+ * TynnLite's state via the Phase 4 conflict-detection module.
+ *
+ * Lifecycle: created with `new SyncReplayWorker(...)`, started via
+ * `start()` (begins the interval tick), stopped via `stop()`. Single-
+ * tick reentrant: a second `start()` while running is a no-op.
+ *
+ * Tick behavior:
+ *   1. Read pending entries from `sync-queue.jsonl` (Phase 1).
+ *   2. For each entry: invoke `<primary>[entry.method](...entry.args)`.
+ *      - Success: mark for drain.
+ *      - Throw / error-shaped payload: bumpAttempts (Phase 1).
+ *   3. After all replays processed, drainSyncQueue with the success set.
+ *   4. (Optional, when `enableReadBackDiff: true`): for each successful
+ *      replay against a task-typed primary call, read the task back +
+ *      diff against TynnLite via `detectConflicts` (Phase 4); record
+ *      any divergences via `recordSyncConflict` (Phase 1).
+ *
+ * Default-disabled (`enabled: false`) — owner opts in via gateway.json
+ * once Phase 5's REST/UI surface lands. The worker constructs cheaply
+ * + safely; calling `start()` on a disabled instance is a no-op.
+ *
+ * Side-channel discipline: tick errors NEVER throw. The worker is
+ * defensive: any error during replay/diff is logged + the entry stays
+ * queued (with bumped attempts) for the next tick. A poisoned entry
+ * (always errors) accumulates attempts that an operator can clear via
+ * `agi issue raw clear` (or a future `agi pm sync clear` command).
+ */
+
+import type { PmProvider, PmTask } from "@agi/sdk";
+import type { TynnLitePmProvider } from "./tynn-lite-provider.js";
+import { bumpAttempts, drainSyncQueue, readSyncQueue, recordSyncConflict } from "./sync-queue.js";
+import { detectConflicts } from "./conflict-detection.js";
+
+export interface SyncReplayWorkerOptions {
+  /** Whether to start the interval at all. Default false. */
+  enabled?: boolean;
+  /**
+   * Tick interval in milliseconds. Default 5min — owner can lower for
+   * test VMs or raise for cloud-cost scenarios.
+   */
+  tickIntervalMs?: number;
+  /** Primary provider to replay against. */
+  primary: PmProvider;
+  /** TynnLite provider — used for read-back diff against primary. */
+  lite: TynnLitePmProvider;
+  /**
+   * When true, after each successful replay, read the task back from
+   * primary + diff against TynnLite. Records conflicts via Phase 1's
+   * `recordSyncConflict`. Default true; the conflict log is the main
+   * output of the worker. Set false to test replay-only behavior.
+   */
+  enableReadBackDiff?: boolean;
+  /** Optional logger for diagnostic events. */
+  logger?: { info(msg: string): void; warn(msg: string): void };
+}
+
+const DEFAULT_TICK_MS = 5 * 60 * 1000;
+
+export class SyncReplayWorker {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+  private readonly enabled: boolean;
+  private readonly tickIntervalMs: number;
+  private readonly primary: PmProvider;
+  private readonly lite: TynnLitePmProvider;
+  private readonly enableReadBackDiff: boolean;
+  private readonly logger?: { info(msg: string): void; warn(msg: string): void };
+
+  constructor(opts: SyncReplayWorkerOptions) {
+    this.enabled = opts.enabled ?? false;
+    this.tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_MS;
+    this.primary = opts.primary;
+    this.lite = opts.lite;
+    this.enableReadBackDiff = opts.enableReadBackDiff ?? true;
+    this.logger = opts.logger;
+  }
+
+  /** Start the periodic tick. No-op when disabled or already running. */
+  start(): void {
+    if (!this.enabled || this.timer !== null) return;
+    this.timer = setInterval(() => {
+      void this.tick().catch((err) => {
+        this.logger?.warn(`sync-replay tick error: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    }, this.tickIntervalMs);
+  }
+
+  /** Stop the periodic tick. No-op when not running. */
+  stop(): void {
+    if (this.timer === null) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  /**
+   * Run one replay cycle. Public for testing + manual operator triggers
+   * (e.g. an `agi pm sync replay` CLI command in a future slice).
+   *
+   * Returns a summary of the cycle (counts).
+   */
+  async tick(): Promise<{ scanned: number; succeeded: number; failed: number; conflicts: number }> {
+    if (this.running) {
+      // Re-entrancy guard — if a previous tick is still mid-flight,
+      // skip this one rather than overlapping.
+      this.logger?.info("sync-replay: previous tick still running; skipping");
+      return { scanned: 0, succeeded: 0, failed: 0, conflicts: 0 };
+    }
+    this.running = true;
+    try {
+      const queue = readSyncQueue();
+      const succeededIds = new Set<string>();
+      let failed = 0;
+      let conflicts = 0;
+
+      for (const entry of queue) {
+        try {
+          const replayResult = await this.replayEntry(entry.method, entry.args);
+          succeededIds.add(entry.id);
+
+          if (this.enableReadBackDiff) {
+            const detected = await this.diffReplayResult(entry, replayResult);
+            for (const c of detected) {
+              recordSyncConflict(c);
+              conflicts++;
+            }
+          }
+        } catch (err) {
+          failed++;
+          bumpAttempts(entry.id);
+          this.logger?.info(
+            `sync-replay: entry ${entry.id} (${entry.method}) failed on replay: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      if (succeededIds.size > 0) {
+        drainSyncQueue(succeededIds);
+      }
+
+      return { scanned: queue.length, succeeded: succeededIds.size, failed, conflicts };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /**
+   * Invoke a method on the primary provider with the queued args.
+   * Type-narrowed at runtime — args[0/1/2/...] casts as needed.
+   * Throws on unknown method or primary error.
+   */
+  private async replayEntry(method: string, args: unknown[]): Promise<unknown> {
+    switch (method) {
+      case "setTaskStatus":
+        return this.primary.setTaskStatus(args[0] as string, args[1] as PmTask["status"], args[2] as string | undefined);
+      case "addComment":
+        return this.primary.addComment(args[0] as "task" | "story" | "version", args[1] as string, args[2] as string);
+      case "updateTask":
+        return this.primary.updateTask(args[0] as string, args[1] as Partial<PmTask>);
+      case "createTask":
+        return this.primary.createTask(args[0] as Parameters<PmProvider["createTask"]>[0]);
+      case "iWish":
+        return this.primary.iWish(args[0] as Parameters<PmProvider["iWish"]>[0]);
+      default:
+        throw new Error(`sync-replay: unknown method "${method}"`);
+    }
+  }
+
+  /**
+   * After a successful replay, read the task back from primary + diff
+   * against TynnLite. Returns conflict descriptors (caller writes them
+   * to the conflict log). Only meaningful for task-typed mutations;
+   * comment / wish / iWish replays return early with no diff.
+   */
+  private async diffReplayResult(
+    entry: { method: string; args: unknown[]; projectPath: string },
+    replayResult: unknown,
+  ): Promise<ReturnType<typeof detectConflicts>> {
+    // Only task mutations have a primary-readable record + lite-side
+    // counterpart we can diff. Comments + wishes are append-only on
+    // both sides; no LWW resolution to do.
+    if (entry.method !== "setTaskStatus" && entry.method !== "updateTask" && entry.method !== "createTask") {
+      return [];
+    }
+
+    const replayTask = replayResult as PmTask | null;
+    if (!replayTask || typeof replayTask !== "object" || !("id" in replayTask)) return [];
+
+    const liteTask = await this.lite.getTask(replayTask.id);
+    if (!liteTask) return [];
+
+    const liteTimestamps = this.lite.getTaskFieldTimestamps(replayTask.id);
+    if (!liteTimestamps) return [];
+
+    return detectConflicts({
+      projectPath: entry.projectPath,
+      entityType: "task",
+      entityId: replayTask.id,
+      primary: {
+        title: replayTask.title,
+        description: replayTask.description,
+        status: replayTask.status,
+        codeArea: replayTask.codeArea,
+        verificationSteps: replayTask.verificationSteps,
+      },
+      lite: {
+        title: liteTask.title,
+        description: liteTask.description,
+        status: liteTask.status,
+        codeArea: liteTask.codeArea,
+        verificationSteps: liteTask.verificationSteps,
+      },
+      liteTimestamps,
+      // Most PmProviders don't expose primary-side timestamps; LWW
+      // defaults to lite-wins per ADR floor stance.
+    });
+  }
+}


### PR DESCRIPTION
## Summary

s155 t672 Phase 6 — closes the t672 implementation loop end-to-end without UI. Periodic worker reads sync-queue.jsonl, replays entries against primary, drains on success, runs Phase 4 conflict-detection on read-back, records divergences via Phase 1 helpers.

Default-disabled (\`enabled: false\`); owner opts in via gateway.json once Phase 5's REST/UI surface lands. Worker construction is cheap; calling \`start()\` on a disabled instance is a no-op.

12 new vitest cases (183 total in PM suite): lifecycle, replay (success/fail/mixed/all-5-methods/unknown), read-back diff (divergence/agreement/comments-skip/disabled-flag).

With Phase 6 shipped, t672's CORE function works headless. Phase 5 (REST surface + dashboard tab) remains as the optional UI surface.

## Test plan

- [x] 183 vitest cases pass
- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` — Phase 6 wires the worker class but doesn't START it. Phase 5 will add gateway.json config to enable + a server.ts boot wire-up. Until then the worker is class-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)