### PR TITLE
feat(pm): sync-queue + sync-conflicts REST surface — s155 t672 Phase 5a

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.614",
+  "version": "0.4.615",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm-api.test.ts
+++ b/packages/gateway-core/src/pm-api.test.ts
@@ -243,4 +243,41 @@ describe("pm-api routes", () => {
       expect(r.statusCode).toBe(403);
     });
   });
+
+  describe("s155 t672 Phase 5a — sync queue + conflicts REST", () => {
+    it("GET /api/pm/sync-queue returns empty entries when queue is empty", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/sync-queue" });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { entries: unknown[] };
+      expect(Array.isArray(body.entries)).toBe(true);
+    });
+
+    it("GET /api/pm/sync-queue?projectPath=... filters by project", async () => {
+      // No entries yet — both queries should return empty arrays
+      const all = await app.inject({ method: "GET", url: "/api/pm/sync-queue" });
+      const filtered = await app.inject({
+        method: "GET",
+        url: `/api/pm/sync-queue?projectPath=${encodeURIComponent(projectPath)}`,
+      });
+      expect(all.statusCode).toBe(200);
+      expect(filtered.statusCode).toBe(200);
+    });
+
+    it("GET /api/pm/sync-conflicts returns empty conflicts when log is empty", async () => {
+      const r = await app.inject({ method: "GET", url: "/api/pm/sync-conflicts" });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { conflicts: unknown[] };
+      expect(Array.isArray(body.conflicts)).toBe(true);
+    });
+
+    it("POST /api/pm/sync-conflicts/:id/resolve returns 404 for unknown id", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/pm/sync-conflicts/c-bogus/resolve",
+      });
+      expect(r.statusCode).toBe(404);
+      const body = r.json() as { error: string };
+      expect(body.error).toContain("not found");
+    });
+  });
 });

--- a/packages/gateway-core/src/pm-api.ts
+++ b/packages/gateway-core/src/pm-api.ts
@@ -23,6 +23,13 @@
 import type { FastifyInstance } from "fastify";
 import type { PmProvider, PmStatus } from "@agi/sdk";
 import type { PlanStore } from "./plan-store.js";
+import {
+  readSyncConflicts,
+  readSyncConflictsForProject,
+  readSyncQueue,
+  readSyncQueueForProject,
+  resolveSyncConflict,
+} from "./pm/sync-queue.js";
 
 export interface PmApiDeps {
   pmProvider: PmProvider;
@@ -169,6 +176,41 @@ export function registerPmRoutes(app: FastifyInstance, deps: PmApiDeps): void {
       return reply.code(404).send({ error: `plan ${planId} not found in ${projectPath}` });
     }
     return plan;
+  });
+
+  // -------------------------------------------------------------------------
+  // s155 t672 Phase 5a — sync queue + conflicts REST surface
+  //
+  // Read-only view of the layered-write retry queue + soft-conflict log
+  // populated by the SyncReplayWorker. POST .../resolve removes a conflict
+  // entry (owner has triaged it). The dashboard "⚠ Conflicts" panel
+  // (Phase 5b, follow-on UI cycle) consumes these.
+  // -------------------------------------------------------------------------
+
+  app.get("/api/pm/sync-queue", async (request) => {
+    const query = request.query as { projectPath?: string };
+    const projectPath = typeof query.projectPath === "string" ? query.projectPath : "";
+    if (projectPath.length === 0) {
+      return { entries: readSyncQueue() };
+    }
+    return { entries: readSyncQueueForProject(projectPath) };
+  });
+
+  app.get("/api/pm/sync-conflicts", async (request) => {
+    const query = request.query as { projectPath?: string };
+    const projectPath = typeof query.projectPath === "string" ? query.projectPath : "";
+    if (projectPath.length === 0) {
+      return { conflicts: readSyncConflicts() };
+    }
+    return { conflicts: readSyncConflictsForProject(projectPath) };
+  });
+
+  app.post<{ Params: { id: string } }>("/api/pm/sync-conflicts/:id/resolve", async (request, reply) => {
+    const { id } = request.params;
+    if (!resolveSyncConflict(id)) {
+      return reply.code(404).send({ error: `sync conflict ${id} not found` });
+    }
+    return { resolved: id };
   });
 }
 


### PR DESCRIPTION
## Summary

Backend-only slice of Phase 5. Three routes added to /api/pm:

- \`GET /api/pm/sync-queue\` (with optional \`?projectPath=\` filter)
- \`GET /api/pm/sync-conflicts\` (with optional \`?projectPath=\` filter)
- \`POST /api/pm/sync-conflicts/:id/resolve\`

The dashboard "⚠ Conflicts" panel (Phase 5b) consumes these later. Owner can hit them now from the dashboard or test VM to inspect sync state without poking at JSONL files.

s155 t672 progresses: Phases 1+2+3+4+5a+6 + boot wire-up done. Only Phase 5b (dashboard panel UI) remains and is OPTIONAL — the substrate is fully usable headless.

## Test plan

- [x] 22 vitest cases pass via Fastify inject
- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` → no behavior change (routes added; queue is empty until layered-writes flag enabled)
- [ ] Owner: enable t672 flags + run agent flow that fails primary → \`curl http://test-vm/api/pm/sync-queue\` shows the queued entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)