### PR TITLE
feat(help): help-mode prompt + tool budget — s137 t532 Phase 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.615",
+  "version": "0.4.616",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/help-mode-config.test.ts
+++ b/packages/gateway-core/src/help-mode-config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  HELP_MODE_TOOL_ALLOWLIST,
+  HELP_MODE_TOOL_DENYLIST,
+  helpModeContextSlice,
+  helpModeFiltersTool,
+  isHelpModeContext,
+} from "./help-mode-config.js";
+
+describe("isHelpModeContext (s137 t532 Phase 1)", () => {
+  it("true for help: prefix", () => {
+    expect(isHelpModeContext("help:projects browser")).toBe(true);
+    expect(isHelpModeContext("help:providers + models management")).toBe(true);
+  });
+
+  it("false for non-help-mode contexts", () => {
+    expect(isHelpModeContext("project:myproject")).toBe(false);
+    expect(isHelpModeContext("global")).toBe(false);
+    expect(isHelpModeContext("")).toBe(false);
+    expect(isHelpModeContext(null)).toBe(false);
+    expect(isHelpModeContext(undefined)).toBe(false);
+  });
+
+  it("false for help without colon (just the word)", () => {
+    expect(isHelpModeContext("help")).toBe(false);
+  });
+});
+
+describe("helpModeContextSlice (s137 t532 Phase 1)", () => {
+  it("extracts the page-context portion", () => {
+    expect(helpModeContextSlice("help:projects browser")).toBe("projects browser");
+    expect(helpModeContextSlice("help:")).toBe("");
+  });
+
+  it("null for non-help-mode contexts", () => {
+    expect(helpModeContextSlice("global")).toBeNull();
+    expect(helpModeContextSlice(null)).toBeNull();
+  });
+});
+
+describe("HELP_MODE_TOOL_ALLOWLIST (s137 t532 Phase 1)", () => {
+  it("includes the canonical read-only tools", () => {
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("lookup_knowledge")).toBe(true);
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("notes")).toBe(true);
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("agi_status")).toBe(true);
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("mcp")).toBe(true);
+  });
+
+  it("does NOT include mutating tools", () => {
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("bash")).toBe(false);
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("file_write")).toBe(false);
+    expect(HELP_MODE_TOOL_ALLOWLIST.has("git_commit")).toBe(false);
+  });
+  // Note: Object.freeze on a Set doesn't freeze its mutation methods —
+  // mutability protection comes from the ReadonlySet type, not runtime.
+});
+
+describe("HELP_MODE_TOOL_DENYLIST (s137 t532 Phase 1)", () => {
+  it("includes mutating + recursive tools", () => {
+    expect(HELP_MODE_TOOL_DENYLIST.has("bash")).toBe(true);
+    expect(HELP_MODE_TOOL_DENYLIST.has("file_write")).toBe(true);
+    expect(HELP_MODE_TOOL_DENYLIST.has("taskmaster_dispatch")).toBe(true);
+    expect(HELP_MODE_TOOL_DENYLIST.has("git_commit")).toBe(true);
+  });
+
+  it("does not collide with allowlist", () => {
+    for (const allowed of HELP_MODE_TOOL_ALLOWLIST) {
+      expect(HELP_MODE_TOOL_DENYLIST.has(allowed)).toBe(false);
+    }
+  });
+});
+
+describe("helpModeFiltersTool (s137 t532 Phase 1)", () => {
+  it("returns false for allowlisted tools", () => {
+    expect(helpModeFiltersTool("lookup_knowledge")).toBe(false);
+    expect(helpModeFiltersTool("notes")).toBe(false);
+    expect(helpModeFiltersTool("mcp")).toBe(false);
+  });
+
+  it("returns true for explicitly-denylisted tools", () => {
+    expect(helpModeFiltersTool("bash")).toBe(true);
+    expect(helpModeFiltersTool("git_commit")).toBe(true);
+    expect(helpModeFiltersTool("taskmaster_dispatch")).toBe(true);
+  });
+
+  it("returns true for tools that are neither allowed nor denied (default-deny)", () => {
+    expect(helpModeFiltersTool("some_unknown_tool")).toBe(true);
+    expect(helpModeFiltersTool("createTask")).toBe(true);
+  });
+});

--- a/packages/gateway-core/src/help-mode-config.ts
+++ b/packages/gateway-core/src/help-mode-config.ts
@@ -1,0 +1,90 @@
+/**
+ * Help-mode config — s137 t532 Phase 1.
+ *
+ * When a chat session is opened via the dashboard's `?` icon (s137
+ * t529), the route's `chatContext` is set to a string of the form
+ * `help:<page-context>` (s137 t530). This module exposes:
+ *
+ *   - `isHelpModeContext(ctx)` — predicate that detects the prefix
+ *   - `helpModeContextSlice(ctx)` — extracts the page-context portion
+ *   - `HELP_MODE_TOOL_ALLOWLIST` — read-only tool budget per the
+ *     prompt fragment at `agi/prompts/help-mode.md`
+ *   - `helpModeFiltersTool(toolName)` — filter helper that returns
+ *     true when the named tool should be HIDDEN in help mode (i.e.
+ *     not in the allowlist or marked mutating)
+ *
+ * Phase 2 wires these into agent-invoker:
+ *   - System-prompt assembly reads `agi/prompts/help-mode.md` when
+ *     `isHelpModeContext(session.context)` is true
+ *   - Tool filter calls `helpModeFiltersTool(name)` to drop forbidden
+ *     tools from the per-turn registry
+ *
+ * Phase 1 (this slice) ships ONLY the substrate. No agent-invoker
+ * change yet — the helpers are unused but tested and ready.
+ */
+
+const HELP_MODE_PREFIX = "help:";
+
+/**
+ * The read-only tool allowlist for help mode. Any tool NOT in this set
+ * is forbidden in help-mode chat sessions. See `agi/prompts/help-mode.md`
+ * for the rationale.
+ *
+ * Conservative starter set: documentation lookup + notes-read + status
+ * diagnostic + read-only MCP actions. Owner can extend via gateway.json
+ * (Phase 3 follow-on) once the help flow proves stable.
+ */
+export const HELP_MODE_TOOL_ALLOWLIST: ReadonlySet<string> = Object.freeze(new Set([
+  "lookup_knowledge",
+  "notes", // gated to action: read | get | search at the action-dispatcher level
+  "agi_status",
+  "mcp", // gated to action: list-servers | list-tools | list-resources | read-resource | list-prompts
+])) as ReadonlySet<string>;
+
+/**
+ * Tools that are explicitly forbidden in help mode even if they're not
+ * caught by the simple allowlist check (e.g. fine-grained per-action
+ * filtering for `notes` and `mcp`). Not used by Phase 1's predicate;
+ * exposed for Phase 2's per-action filter.
+ */
+export const HELP_MODE_TOOL_DENYLIST: ReadonlySet<string> = Object.freeze(new Set([
+  "bash",
+  "file_write",
+  "git_status",
+  "git_diff",
+  "git_add",
+  "git_commit",
+  "git_branch",
+  "shell_exec",
+  "taskmaster_dispatch",
+  "worker_dispatch",
+  "create_plan",
+  "update_user_context",
+])) as ReadonlySet<string>;
+
+/** True when the chat-session context string is in help-mode shape. */
+export function isHelpModeContext(context: string | null | undefined): boolean {
+  if (typeof context !== "string") return false;
+  return context.startsWith(HELP_MODE_PREFIX);
+}
+
+/**
+ * Extract the page-context slice from a help-mode context string.
+ * Returns null for non-help-mode contexts.
+ *
+ * Example: `helpModeContextSlice("help:projects browser")` → `"projects browser"`.
+ */
+export function helpModeContextSlice(context: string | null | undefined): string | null {
+  if (!isHelpModeContext(context)) return null;
+  return (context as string).slice(HELP_MODE_PREFIX.length);
+}
+
+/**
+ * Returns true when the named tool should be HIDDEN/blocked in help
+ * mode. Caller is responsible for checking the calling chat session's
+ * help-mode-ness first; this function ONLY answers the budget query.
+ */
+export function helpModeFiltersTool(toolName: string): boolean {
+  if (HELP_MODE_TOOL_DENYLIST.has(toolName)) return true;
+  return !HELP_MODE_TOOL_ALLOWLIST.has(toolName);
+}

--- a/prompts/help-mode.md
+++ b/prompts/help-mode.md
@@ -1,0 +1,62 @@
+# Help Mode
+
+You are running in **Help Mode** — invoked when the user clicks the `?` icon
+in the dashboard header. The chat session is bound to a specific
+**page context** that names the surface the user was looking at when
+they asked for help (e.g. `help:projects browser`, `help:providers + models management`).
+
+## Anchor
+
+Your job is to answer questions about Aionima's user-facing features.
+The page context tells you what part of the dashboard the user wants
+help with. Answer from:
+
+1. **Project documentation** — `agi/docs/human/*.md` and
+   `agi/docs/agents/*.md`. Use the `lookup_knowledge` tool to fetch a
+   specific doc by relative path.
+2. **Page context** — what the user was looking at when they asked.
+   Tailor answers to that surface (don't lecture them on
+   /settings/providers when they're on /projects).
+3. **Owner-facing notes** — the `notes` tool (action=read) surfaces
+   anything the owner wrote about the project in question.
+
+## Tool budget — READ-ONLY
+
+In Help Mode you have a **strict read-only tool budget**:
+
+- **Allowed**: `lookup_knowledge`, `notes` (action=read|get|search),
+  `agi_status` (read-only diagnostic), `mcp` (action=list-servers /
+  list-tools / list-resources / read-resource).
+- **Forbidden**: `bash`, `file_write`, `git_*`, `notes` (action=append),
+  `mcp` (action=call), `setTaskStatus` / `createTask` / any pm tool
+  that mutates state, agent-invoker recursion (no `taskmaster_dispatch`
+  or `worker-*` calls).
+
+If the user asks you to take an action (e.g. "delete this project",
+"start the gateway"), **explain HOW they would do it themselves** + offer
+to walk them through the steps. Don't take the action.
+
+If the user asks something the read-only budget can't answer (e.g.
+"what's in this file?"), say so and point them at where the file
+would be readable in the dashboard or via the documented agi CLI.
+
+## Conversational shape
+
+- Keep answers short. Help mode is for quick "how do I…?" lookups, not
+  long-form tutorials.
+- When you cite docs, name the file path (`agi/docs/human/cli.md`) so the
+  user can find it themselves.
+- If the page context is ambiguous (`help:unknown route /foo/bar`), ask
+  the user what page they were on or what they were trying to do —
+  don't guess.
+- End with a follow-up offer ("Want me to walk through provisioning a
+  new provider?") only when it's relevant to where the user is.
+
+## Don'ts
+
+- Don't take destructive actions even when asked.
+- Don't pretend to have memory of the user's prior chats — every help
+  session is its own context.
+- Don't surface internal tooling (taskmaster, worker dispatch, agent
+  router internals) unless the user explicitly asks about them by
+  name.


### PR DESCRIPTION
## Summary

s137 t532 Phase 1 — substrate for help-mode chat agent. New prompt fragment + tool-budget config + helpers. Phase 2 wires these into agent-invoker (system-prompt assembly + per-turn tool filter); shippable independently.

- \`prompts/help-mode.md\` — anchoring prompt + read-only conversational shape
- \`isHelpModeContext\` / \`helpModeContextSlice\` / \`helpModeFiltersTool\` helpers
- \`HELP_MODE_TOOL_ALLOWLIST\` (4 read-only tools) / \`HELP_MODE_TOOL_DENYLIST\` (mutating + recursive)
- 12 vitest cases pass

s137 advances 4/5 done.

## Test plan

- [x] Typecheck clean
- [x] 12 vitest cases pass
- [ ] Owner: \`agi upgrade\` — substrate-only, no behavior change. Phase 2 wires it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)