### PR TITLE
feat(help): chat-layer wiring activates help-mode end-to-end (s137 t532 follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.617",
+  "version": "0.4.618",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -3716,8 +3716,14 @@ export async function startGatewayServer(
         const chatContextRaw = chatPayload?.context ?? "general";
         const isBuilderMode = chatContextRaw.startsWith("builder:");
         const isMappContext = chatContextRaw.startsWith("mapp:");
+        // s137 t532 chat-layer wiring — `help:<page>` context activates
+        // help-mode at the agent-invoker layer (Phase 2 PR #128). The
+        // raw value flows through unchanged — agent-invoker reads the
+        // `help:` prefix via isHelpModeContext().
+        const isHelpMode = chatContextRaw.startsWith("help:");
         const builderMode = isBuilderMode ? chatContextRaw.split(":")[1] as "create" | "update" | "review" : undefined;
-        let chatProjectPath = (!isBuilderMode && !isMappContext && chatContextRaw !== "general") ? chatContextRaw : undefined;
+        const helpContext = isHelpMode ? chatContextRaw : undefined;
+        let chatProjectPath = (!isBuilderMode && !isMappContext && !isHelpMode && chatContextRaw !== "general") ? chatContextRaw : undefined;
 
         // Emit invocation_start to project activity indicators.
         if (chatProjectPath !== undefined) {
@@ -3901,6 +3907,7 @@ export async function startGatewayServer(
             sessionKey,
             projectContext: chatProjectPath,
             builderMode,
+            helpContext,
             imageRefs: chatImageRefs.length > 0 ? chatImageRefs : undefined,
             chatSessionId,
             abortSignal: abortController.signal,


### PR DESCRIPTION
## Summary

Threads the chat session's \`chatContext\` into \`agentInvoker.process()\`'s \`helpContext\` field when the prefix is \`help:\`. Mirrors the existing builderMode wiring shape.

Effect: clicking the dashboard \`?\` icon now activates help-mode at the agent-invoker layer (PR #128 Phase 2 wired this). Tool budget restricts to read-only allowlist; system prompt swaps to \`prompts/help-mode.md\` with the page-context appended.

Also excludes \`help:\` contexts from being mistaken for project paths.

t532 was closed in PR #128 (substrate + agent-invoker integration). This is the chat-layer activation that makes the substrate visible end-to-end.

## Test plan

- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` — click \`?\` icon on /projects → chat opens with \`chatContext: "help:projects browser"\`. Verify the agent uses tools from the read-only allowlist (no bash, no file_write, no taskmaster_dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)