### PR TITLE
feat(issues): system-level Issues page — Wish #21 Slice 4 Phase 1

### DIFF
--- a/e2e/issues-page.spec.ts
+++ b/e2e/issues-page.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * /issues system-aggregate page (Wish #21 Slice 4 Phase 1).
+ *
+ * Drives the dashboard route to verify it renders without error and
+ * either shows the empty-state message or the populated issues table.
+ * Both states are valid (the registry may be empty on a fresh test
+ * VM); spec asserts shape, not specific content.
+ */
+
+test.describe("/issues page (Wish #21 Slice 4 Phase 1)", () => {
+  test("renders heading + either empty-state or issues panel", async ({ page }) => {
+    await page.goto("/issues", { waitUntil: "domcontentloaded" });
+
+    // Page heading present
+    await expect(page.locator("h1", { hasText: "Issues" })).toBeVisible({ timeout: 10_000 });
+
+    // Either empty-state copy OR the issues-panel data-testid renders
+    const emptyState = page.locator("text=No issues yet");
+    const panel = page.getByTestId("issues-panel");
+    const eitherVisible = await Promise.race([
+      emptyState.waitFor({ state: "visible", timeout: 10_000 }).then(() => true).catch(() => false),
+      panel.waitFor({ state: "visible", timeout: 10_000 }).then(() => true).catch(() => false),
+    ]);
+    expect(eitherVisible).toBe(true);
+  });
+
+  test("populated panel shows issue rows when /api/issues returns data", async ({ page }) => {
+    // Pre-load API; if the registry has any issues, the populated panel
+    // should expose `issue-row` rows. If empty, this test is a no-op.
+    const apiR = await page.request.get("/api/issues");
+    if (!apiR.ok()) test.skip(true, "API not reachable in this environment");
+    const body = await apiR.json() as { issues: { id: string }[] };
+    if (body.issues.length === 0) {
+      test.skip(true, "No issues to assert against — empty registry");
+    }
+
+    await page.goto("/issues", { waitUntil: "domcontentloaded" });
+    const rows = page.getByTestId("issue-row");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+    expect(await rows.count()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.618",
+  "version": "0.4.619",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/IssuesPanel.tsx
+++ b/ui/dashboard/src/components/IssuesPanel.tsx
@@ -1,0 +1,137 @@
+/**
+ * IssuesPanel — Wish #21 Slice 4 Phase 1.
+ *
+ * System-level aggregate view of the per-project issue registry. Reads
+ * from `/api/issues` (Slice 1's GET aggregate) and renders an unstyled
+ * table per row: id / project / title / status / occurrences /
+ * last_occurrence.
+ *
+ * Phase 1 scope:
+ *   - Read-only list (no filters, no detail view, no filing form)
+ *   - Empty + loading + error states
+ *   - Grouped-by-project layout
+ *
+ * Subsequent phases extend with:
+ *   - Phase 2: filter strip (by tag, status, project)
+ *   - Phase 3: click-row → detail panel (uses /api/projects/issues/:id)
+ *   - Phase 4: file-issue button + form modal
+ *   - Phase 5: search bar (uses Slice 2's /api/projects/issues/search)
+ *   - Phase 6: raw-tier promote affordance (uses Slice 5 routes)
+ */
+
+import { useEffect, useState } from "react";
+
+interface IssueIndexEntry {
+  id: string;
+  status: string;
+  symptom_hash: string;
+  tags: string[];
+  title: string;
+  occurrences: number;
+  last_occurrence: string;
+  /** Project the issue lives in — present on the aggregate /api/issues response. */
+  project?: string;
+}
+
+interface AggregateResponse {
+  issues: IssueIndexEntry[];
+}
+
+export function IssuesPanel() {
+  const [issues, setIssues] = useState<IssueIndexEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await fetch("/api/issues");
+        if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+        const body = (await r.json()) as AggregateResponse;
+        if (!cancelled) {
+          setIssues(body.issues ?? []);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) {
+    return <p className="text-[12px] text-muted-foreground">Loading issues…</p>;
+  }
+  if (error) {
+    return <p className="text-[12px] text-destructive">Error loading issues: {error}</p>;
+  }
+  if (issues.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[13px] text-muted-foreground">
+          No issues yet. Issues are filed via{" "}
+          <code className="text-[12px] bg-secondary px-1 py-0.5 rounded">agi issue file</code>{" "}
+          or by the agent when an expected action fails.
+        </p>
+      </div>
+    );
+  }
+
+  // Group by project (entries without a `project` field group under "(global)")
+  const groups = new Map<string, IssueIndexEntry[]>();
+  for (const issue of issues) {
+    const key = issue.project ?? "(unknown)";
+    const existing = groups.get(key) ?? [];
+    existing.push(issue);
+    groups.set(key, existing);
+  }
+
+  return (
+    <div className="space-y-6" data-testid="issues-panel">
+      <div className="text-[12px] text-muted-foreground">
+        {String(issues.length)} issue{issues.length === 1 ? "" : "s"} across {String(groups.size)} project{groups.size === 1 ? "" : "s"}
+      </div>
+      {[...groups.entries()].map(([project, projectIssues]) => (
+        <section key={project} data-project={project}>
+          <h3 className="text-[14px] font-semibold mb-2">{project}</h3>
+          <table className="w-full border-collapse text-[12px]">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-1 px-2 font-medium text-muted-foreground">ID</th>
+                <th className="text-left py-1 px-2 font-medium text-muted-foreground">Title</th>
+                <th className="text-left py-1 px-2 font-medium text-muted-foreground">Status</th>
+                <th className="text-right py-1 px-2 font-medium text-muted-foreground">×</th>
+                <th className="text-left py-1 px-2 font-medium text-muted-foreground">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projectIssues.map((issue) => (
+                <tr key={`${project}/${issue.id}`} className="border-b border-border/50" data-testid="issue-row">
+                  <td className="py-1 px-2 font-mono text-muted-foreground">{issue.id}</td>
+                  <td className="py-1 px-2">{issue.title}</td>
+                  <td className="py-1 px-2">
+                    <span
+                      className={
+                        issue.status === "fixed" ? "text-green-500" :
+                        issue.status === "wont-fix" ? "text-muted-foreground" :
+                        issue.status === "known" ? "text-yellow-500" :
+                        ""
+                      }
+                    >
+                      {issue.status}
+                    </span>
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">{String(issue.occurrences)}</td>
+                  <td className="py-1 px-2 text-muted-foreground">{issue.last_occurrence.slice(0, 10)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/help-context.ts
+++ b/ui/dashboard/src/lib/help-context.ts
@@ -21,6 +21,7 @@ const STATIC_ROUTES: Record<string, string> = {
   "/marketplace/mapps": "MApp Marketplace catalog",
   "/aionima": "Aionima self-managed project (redirects to /projects/_aionima)",
   "/pax": "PAx primitives — now repos under _aionima (redirects to /projects/_aionima)",
+  "/issues": "agent-curated issue registry (system-aggregate view; per-project k/issues/)",
   "/comms": "comms (channels) overview",
   "/workflows": "workflow definitions",
   "/logs": "logs viewer",

--- a/ui/dashboard/src/router.tsx
+++ b/ui/dashboard/src/router.tsx
@@ -40,6 +40,7 @@ import { OnboardingPage } from "./routes/onboarding.js";
 import { GatewayOnboardingPage } from "./routes/gateway-onboarding.js";
 import ReportsPage from "./routes/reports.js";
 import ReportDetailPage from "./routes/report-detail.js";
+import IssuesPage from "./routes/issues.js";
 import ChangelogPage from "./routes/system-changelog.js";
 import IncidentsPage from "./routes/system-incidents.js";
 import VendorsPage from "./routes/system-vendors.js";
@@ -68,6 +69,7 @@ export const router = createBrowserRouter([
       { index: true, element: <OverviewPage /> },
       { path: "coa", element: <COAPage /> },
       { path: "reports", element: <ReportsPage /> },
+      { path: "issues", element: <IssuesPage /> },
       { path: "reports/:coaReqId", element: <ReportDetailPage /> },
       { path: "entity/:id", element: <EntityPage /> },
       { path: "projects", element: <ProjectsPage /> },

--- a/ui/dashboard/src/routes/issues.tsx
+++ b/ui/dashboard/src/routes/issues.tsx
@@ -1,0 +1,27 @@
+/**
+ * Issues page — Wish #21 Slice 4 Phase 1.
+ *
+ * System-level aggregate view of all per-project issue registries.
+ * Mirrors /reports's shape (PageScroll wrapper around a list panel).
+ */
+
+import { IssuesPanel } from "@/components/IssuesPanel.js";
+import { PageScroll } from "@/components/PageScroll.js";
+
+export default function IssuesPage(): JSX.Element {
+  return (
+    <PageScroll>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-[18px] font-semibold">Issues</h1>
+          <p className="text-[12px] text-muted-foreground mt-1">
+            Agent-curated registry of failures Aion (or Claude Code) hit when attempting
+            expected actions. File via <code className="text-[11px] bg-secondary px-1 py-0.5 rounded">agi issue file</code> or
+            via the <code className="text-[11px] bg-secondary px-1 py-0.5 rounded">issue</code> agent tool.
+          </p>
+        </div>
+        <IssuesPanel />
+      </div>
+    </PageScroll>
+  );
+}


### PR DESCRIPTION
## Summary

System-level \`/issues\` route that aggregates per-project \`k/issues/\` registries. MVP shape: read-only list grouped by project, with empty/loading/error states. data-testid hooks for e2e.

Phase 1 deliberately excludes filters, detail view, file form, search bar, raw-tier promote — those are Phases 2-6 follow-ups. The CLI + agent tool already cover those; this slice gives owners a glanceable browser-side view.

Wish #21 trajectory: Slices 1+2+3+5+6+7 + this Phase 1 = the substrate + activations are all shipped; Slice 4 has multi-phase UI scope remaining.

## Test plan

- [x] Typecheck clean; docs-vs-help clean
- [ ] Owner: \`agi upgrade\` then navigate to /issues — verify either empty state or populated table
- [ ] Owner: \`agi test --e2e issues-page\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)