### PR TITLE
feat(pm): /sync-conflicts dashboard page — s155 t672 Phase 5b

### DIFF
--- a/e2e/sync-conflicts-page.spec.ts
+++ b/e2e/sync-conflicts-page.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * /sync-conflicts page (s155 t672 Phase 5b).
+ *
+ * Drives the dashboard route to verify it renders + either shows the
+ * empty-state copy or the populated conflicts table. Both states are
+ * valid (the conflict log is empty until layered-writes is enabled
+ * AND the sync-replay worker detects divergence).
+ */
+
+test.describe("/sync-conflicts page (s155 t672 Phase 5b)", () => {
+  test("renders heading + either empty-state or conflicts panel", async ({ page }) => {
+    await page.goto("/sync-conflicts", { waitUntil: "domcontentloaded" });
+
+    await expect(page.locator("h1", { hasText: "Sync Conflicts" })).toBeVisible({ timeout: 10_000 });
+
+    const emptyState = page.locator("text=No conflicts yet");
+    const panel = page.getByTestId("sync-conflicts-panel");
+    const eitherVisible = await Promise.race([
+      emptyState.waitFor({ state: "visible", timeout: 10_000 }).then(() => true).catch(() => false),
+      panel.waitFor({ state: "visible", timeout: 10_000 }).then(() => true).catch(() => false),
+    ]);
+    expect(eitherVisible).toBe(true);
+  });
+
+  test("populated panel shows conflict-row entries when API returns data", async ({ page }) => {
+    const apiR = await page.request.get("/api/pm/sync-conflicts");
+    if (!apiR.ok()) test.skip(true, "API not reachable in this environment");
+    const body = await apiR.json() as { conflicts: { id: string }[] };
+    if (body.conflicts.length === 0) {
+      test.skip(true, "No conflicts to assert against — empty log");
+    }
+
+    await page.goto("/sync-conflicts", { waitUntil: "domcontentloaded" });
+    const rows = page.getByTestId("conflict-row");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+    expect(await rows.count()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.619",
+  "version": "0.4.620",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/SyncConflictsPanel.tsx
+++ b/ui/dashboard/src/components/SyncConflictsPanel.tsx
@@ -1,0 +1,174 @@
+/**
+ * SyncConflictsPanel — s155 t672 Phase 5b.
+ *
+ * Read + resolve view of the layered-PM-write conflict log. Reads
+ * `/api/pm/sync-conflicts` (Phase 5a) and renders per-row descriptors
+ * with a "Resolve" affordance that POSTs to .../resolve.
+ *
+ * Phase 5b scope (this slice):
+ *   - Read-only list (no field-level diff explorer yet)
+ *   - Resolve button removes from log (LWW resolution outside this UI;
+ *     this just signals "owner reviewed it")
+ *   - Empty + loading + error states
+ *
+ * Subsequent phases extend with:
+ *   - Field-level diff explorer (Phase 5c)
+ *   - "Accept primary" / "Accept lite" affordance (writes back to TynnLite)
+ *   - Hard-conflict-only filter
+ *
+ * Note: resolution at this surface is a TRIAGE signal — the underlying
+ * LWW resolution per the t669 ADR happens in the sync-replay worker
+ * (Phase 6) when it writes back to TynnLite. This UI is for the operator
+ * to mark "I've seen this and accepted whatever resolution happened."
+ */
+
+import { useEffect, useState } from "react";
+
+interface SyncConflictEntry {
+  id: string;
+  ts: string;
+  projectPath: string;
+  entityType: string;
+  entityId: string;
+  field: string;
+  primaryValue: unknown;
+  liteValue: unknown;
+  primaryUpdatedAt?: string;
+  liteUpdatedAt?: string;
+  hard: boolean;
+}
+
+interface ConflictsResponse {
+  conflicts: SyncConflictEntry[];
+}
+
+function formatValue(v: unknown): string {
+  if (v === null) return "(null)";
+  if (v === undefined) return "(undefined)";
+  if (typeof v === "string") return v.length > 80 ? `${v.slice(0, 77)}…` : v;
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  return JSON.stringify(v).slice(0, 80);
+}
+
+export function SyncConflictsPanel() {
+  const [conflicts, setConflicts] = useState<SyncConflictEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [resolving, setResolving] = useState<Set<string>>(new Set());
+
+  const reload = async (): Promise<void> => {
+    try {
+      const r = await fetch("/api/pm/sync-conflicts");
+      if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+      const body = (await r.json()) as ConflictsResponse;
+      setConflicts(body.conflicts ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (cancelled) return;
+      await reload();
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const onResolve = async (id: string): Promise<void> => {
+    setResolving((prev) => new Set(prev).add(id));
+    try {
+      await fetch(`/api/pm/sync-conflicts/${id}/resolve`, { method: "POST" });
+      await reload();
+    } finally {
+      setResolving((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  if (loading) {
+    return <p className="text-[12px] text-muted-foreground">Loading conflicts…</p>;
+  }
+  if (error) {
+    return <p className="text-[12px] text-destructive">Error loading conflicts: {error}</p>;
+  }
+  if (conflicts.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-[13px] text-muted-foreground">
+          No conflicts yet. Conflicts surface when{" "}
+          <code className="text-[12px] bg-secondary px-1 py-0.5 rounded">agent.pm.enableLayeredWrites</code>{" "}
+          is on AND the sync-replay worker detects divergence between primary + TynnLite on read-back.
+        </p>
+      </div>
+    );
+  }
+
+  const hardCount = conflicts.filter((c) => c.hard).length;
+
+  return (
+    <div className="space-y-4" data-testid="sync-conflicts-panel">
+      <div className="text-[12px] text-muted-foreground">
+        {String(conflicts.length)} conflict{conflicts.length === 1 ? "" : "s"}
+        {hardCount > 0 && (
+          <span className="ml-2 text-yellow-500">⚠ {String(hardCount)} hard</span>
+        )}
+      </div>
+      <table className="w-full border-collapse text-[12px]">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">When</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Project</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Entity</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Field</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Primary</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Lite</th>
+            <th className="text-left py-1 px-2 font-medium text-muted-foreground">Type</th>
+            <th className="py-1 px-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {conflicts.map((c) => (
+            <tr
+              key={c.id}
+              className="border-b border-border/50"
+              data-testid="conflict-row"
+              data-conflict-hard={c.hard ? "true" : "false"}
+            >
+              <td className="py-1 px-2 text-muted-foreground">{c.ts.slice(11, 19)}</td>
+              <td className="py-1 px-2 truncate max-w-[200px]">{c.projectPath}</td>
+              <td className="py-1 px-2 font-mono">{c.entityType} {c.entityId}</td>
+              <td className="py-1 px-2 font-medium">{c.field}</td>
+              <td className="py-1 px-2 truncate max-w-[200px]">{formatValue(c.primaryValue)}</td>
+              <td className="py-1 px-2 truncate max-w-[200px]">{formatValue(c.liteValue)}</td>
+              <td className="py-1 px-2">
+                {c.hard ? (
+                  <span className="text-yellow-500">⚠ hard</span>
+                ) : (
+                  <span className="text-muted-foreground">soft</span>
+                )}
+              </td>
+              <td className="py-1 px-2 text-right">
+                <button
+                  onClick={() => { void onResolve(c.id); }}
+                  disabled={resolving.has(c.id)}
+                  className="text-[11px] px-2 py-0.5 rounded border border-border hover:bg-secondary disabled:opacity-50"
+                  data-testid="resolve-button"
+                >
+                  {resolving.has(c.id) ? "…" : "Resolve"}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/help-context.ts
+++ b/ui/dashboard/src/lib/help-context.ts
@@ -22,6 +22,7 @@ const STATIC_ROUTES: Record<string, string> = {
   "/aionima": "Aionima self-managed project (redirects to /projects/_aionima)",
   "/pax": "PAx primitives — now repos under _aionima (redirects to /projects/_aionima)",
   "/issues": "agent-curated issue registry (system-aggregate view; per-project k/issues/)",
+  "/sync-conflicts": "layered-PM sync conflict log (primary vs TynnLite divergence detected by sync-replay worker)",
   "/comms": "comms (channels) overview",
   "/workflows": "workflow definitions",
   "/logs": "logs viewer",

--- a/ui/dashboard/src/router.tsx
+++ b/ui/dashboard/src/router.tsx
@@ -41,6 +41,7 @@ import { GatewayOnboardingPage } from "./routes/gateway-onboarding.js";
 import ReportsPage from "./routes/reports.js";
 import ReportDetailPage from "./routes/report-detail.js";
 import IssuesPage from "./routes/issues.js";
+import SyncConflictsPage from "./routes/sync-conflicts.js";
 import ChangelogPage from "./routes/system-changelog.js";
 import IncidentsPage from "./routes/system-incidents.js";
 import VendorsPage from "./routes/system-vendors.js";
@@ -70,6 +71,7 @@ export const router = createBrowserRouter([
       { path: "coa", element: <COAPage /> },
       { path: "reports", element: <ReportsPage /> },
       { path: "issues", element: <IssuesPage /> },
+      { path: "sync-conflicts", element: <SyncConflictsPage /> },
       { path: "reports/:coaReqId", element: <ReportDetailPage /> },
       { path: "entity/:id", element: <EntityPage /> },
       { path: "projects", element: <ProjectsPage /> },

--- a/ui/dashboard/src/routes/sync-conflicts.tsx
+++ b/ui/dashboard/src/routes/sync-conflicts.tsx
@@ -1,0 +1,28 @@
+/**
+ * Sync Conflicts page — s155 t672 Phase 5b.
+ *
+ * System-level view of the layered-PM-write conflict log populated by
+ * the SyncReplayWorker. Mirror of /issues's shape.
+ */
+
+import { SyncConflictsPanel } from "@/components/SyncConflictsPanel.js";
+import { PageScroll } from "@/components/PageScroll.js";
+
+export default function SyncConflictsPage(): JSX.Element {
+  return (
+    <PageScroll>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-[18px] font-semibold">Sync Conflicts</h1>
+          <p className="text-[12px] text-muted-foreground mt-1">
+            Divergences detected between primary PM and TynnLite by the sync-replay worker.
+            Soft conflicts auto-resolve via per-field LWW; hard conflicts (status state-graph
+            violations) require operator review. See{" "}
+            <code className="text-[11px] bg-secondary px-1 py-0.5 rounded">agi/docs/agents/adr-layered-pm-conflict-resolution.md</code>.
+          </p>
+        </div>
+        <SyncConflictsPanel />
+      </div>
+    </PageScroll>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the optional UI surface for t672. System-level \`/sync-conflicts\` page mirrors \`/issues\`'s shape from PR #130. Read /api/pm/sync-conflicts (Phase 5a) and render rows with primary/lite values + hard-flag indicator + Resolve action.

t672 phases shipped this cron run: 1+2+3+4+5a+5b+6 + boot wire-up. The substrate is fully usable BOTH headless (CLI/REST) AND via dashboard.

## Test plan

- [x] Typecheck clean; docs-vs-help clean
- [ ] Owner: \`agi upgrade\` → navigate to /sync-conflicts. Empty registry shows the explainer; populated shows the table.
- [ ] Owner: enable layered-writes flag + run agent flow that diverges → verify conflict surfaces; click Resolve → conflict disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)