### PR TITLE
feat(pm): /pm/kanban MVP page — s139 t536 Phase 1

### DIFF
--- a/e2e/pm-kanban-page.spec.ts
+++ b/e2e/pm-kanban-page.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * /pm/kanban page (s139 t536 Phase 1).
+ *
+ * Drives the dashboard route to verify the Kanban primitive renders
+ * with all 4 visible columns (todo/now/qa/done) plus the show-hidden
+ * checkbox toggling Blocked + Archived columns.
+ */
+
+test.describe("/pm/kanban page (s139 t536 Phase 1)", () => {
+  test("renders heading + kanban panel with default columns", async ({ page }) => {
+    await page.goto("/pm/kanban", { waitUntil: "domcontentloaded" });
+    await expect(page.locator("h1", { hasText: "PM Kanban" })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId("pm-kanban-panel")).toBeVisible({ timeout: 10_000 });
+    // Default columns visible by name
+    await expect(page.locator("text=To do").first()).toBeVisible();
+    await expect(page.locator("text=Now").first()).toBeVisible();
+    await expect(page.locator("text=Done").first()).toBeVisible();
+  });
+
+  test("show-hidden checkbox surfaces Blocked + Archived columns", async ({ page }) => {
+    await page.goto("/pm/kanban", { waitUntil: "domcontentloaded" });
+    const panel = page.getByTestId("pm-kanban-panel");
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+
+    // Blocked + Archived not in DOM by default
+    expect(await page.locator("text=Blocked").count()).toBe(0);
+
+    // Toggle on; verify both surface
+    await page.locator('input[type="checkbox"]').first().check();
+    await expect(page.locator("text=Blocked").first()).toBeVisible();
+    await expect(page.locator("text=Archived").first()).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.620",
+  "version": "0.4.621",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/PmKanbanPanel.tsx
+++ b/ui/dashboard/src/components/PmKanbanPanel.tsx
@@ -1,0 +1,140 @@
+/**
+ * PmKanbanPanel — s139 t536 Phase 1.
+ *
+ * MVP kanban board: read tasks from `/api/pm/find-tasks`, bucket by
+ * status into the 6-column tynn-shape board (todo/now/qa/done +
+ * hidden blocked/archived), render via @particle-academy/react-fancy
+ * Kanban primitive.
+ *
+ * Phase 1 scope:
+ *   - Read-only render (no drag-drop persistence yet — onCardMove is
+ *     a no-op; column drag uses Kanban's built-in optimistic state)
+ *   - Tasks fetched once on mount; no realtime updates yet
+ *   - Hidden columns (blocked / archived) collapsed under a toggle
+ *
+ * Subsequent phases extend with:
+ *   - Phase 2: drag-drop persistence (call setTaskStatus on move)
+ *   - Phase 3: card editor modal
+ *   - Phase 4: filter strip (priority / labels / overdue)
+ *   - Phase 5: realtime updates via WS subscription
+ *   - Phase 6: per-project kanban embedding (this slice is system-aggregate)
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Kanban } from "@particle-academy/react-fancy";
+
+interface PmTask {
+  id: string;
+  number: number;
+  storyId: string;
+  title: string;
+  status: string;
+  description?: string;
+}
+
+interface FindTasksResponse {
+  tasks: PmTask[];
+}
+
+/** Mirrors DEFAULT_TYNN_KANBAN_CONFIG from @agi/sdk's define-pm-provider.ts. */
+const COLUMNS: { id: string; name: string; statuses: string[]; hiddenByDefault?: boolean }[] = [
+  { id: "todo", name: "To do", statuses: ["backlog"] },
+  { id: "now", name: "Now", statuses: ["starting", "doing"] },
+  { id: "qa", name: "QA", statuses: ["testing"] },
+  { id: "done", name: "Done", statuses: ["finished"] },
+  { id: "blocked", name: "Blocked", statuses: ["blocked"], hiddenByDefault: true },
+  { id: "archived", name: "Archived", statuses: ["archived"], hiddenByDefault: true },
+];
+
+export function PmKanbanPanel() {
+  const [tasks, setTasks] = useState<PmTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showHidden, setShowHidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await fetch("/api/pm/find-tasks?limit=200");
+        if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+        const body = (await r.json()) as FindTasksResponse;
+        if (!cancelled) {
+          setTasks(body.tasks ?? []);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Bucket tasks by column. A task whose status doesn't match any
+  // column lands in the first column with no statuses (catch-all);
+  // none in the default config — those tasks are silently dropped
+  // (unusual; defensive in case future PmStatus values appear).
+  const tasksByColumn = useMemo(() => {
+    const map = new Map<string, PmTask[]>();
+    for (const col of COLUMNS) map.set(col.id, []);
+    for (const task of tasks) {
+      for (const col of COLUMNS) {
+        if (col.statuses.includes(task.status)) {
+          (map.get(col.id) ?? []).push(task);
+          break;
+        }
+      }
+    }
+    return map;
+  }, [tasks]);
+
+  if (loading) return <p className="text-[12px] text-muted-foreground">Loading kanban…</p>;
+  if (error) return <p className="text-[12px] text-destructive">Error loading tasks: {error}</p>;
+
+  const visibleColumns = COLUMNS.filter((col) => showHidden || !col.hiddenByDefault);
+  const totalCards = tasks.length;
+
+  return (
+    <div className="space-y-3" data-testid="pm-kanban-panel">
+      <div className="flex items-center gap-3">
+        <span className="text-[12px] text-muted-foreground">{String(totalCards)} task{totalCards === 1 ? "" : "s"}</span>
+        <label className="flex items-center gap-1 text-[12px] text-muted-foreground cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showHidden}
+            onChange={(e) => { setShowHidden(e.target.checked); }}
+            className="cursor-pointer"
+          />
+          Show blocked + archived
+        </label>
+      </div>
+      <Kanban onCardMove={() => { /* Phase 2: persist via setTaskStatus */ }}>
+        {visibleColumns.map((col) => {
+          const columnTasks = tasksByColumn.get(col.id) ?? [];
+          return (
+            <Kanban.Column key={col.id} id={col.id}>
+              <Kanban.ColumnHandle>
+                <div className="px-2 py-1 text-[12px] font-semibold flex items-center justify-between">
+                  <span>{col.name}</span>
+                  <span className="text-muted-foreground tabular-nums">{String(columnTasks.length)}</span>
+                </div>
+              </Kanban.ColumnHandle>
+              {columnTasks.map((task) => (
+                <Kanban.Card key={task.id} id={task.id}>
+                  <div className="text-[11px] p-2 border border-border rounded bg-card" data-testid="kanban-card">
+                    <div className="font-medium truncate">{task.title}</div>
+                    <div className="text-muted-foreground text-[10px] mt-1">
+                      #{String(task.number)} · {task.status}
+                    </div>
+                  </div>
+                </Kanban.Card>
+              ))}
+            </Kanban.Column>
+          );
+        })}
+      </Kanban>
+    </div>
+  );
+}

--- a/ui/dashboard/src/lib/help-context.ts
+++ b/ui/dashboard/src/lib/help-context.ts
@@ -23,6 +23,7 @@ const STATIC_ROUTES: Record<string, string> = {
   "/pax": "PAx primitives — now repos under _aionima (redirects to /projects/_aionima)",
   "/issues": "agent-curated issue registry (system-aggregate view; per-project k/issues/)",
   "/sync-conflicts": "layered-PM sync conflict log (primary vs TynnLite divergence detected by sync-replay worker)",
+  "/pm/kanban": "PM kanban board — tasks from the active provider bucketed into the canonical 6-column tynn-shape board",
   "/comms": "comms (channels) overview",
   "/workflows": "workflow definitions",
   "/logs": "logs viewer",

--- a/ui/dashboard/src/router.tsx
+++ b/ui/dashboard/src/router.tsx
@@ -42,6 +42,7 @@ import ReportsPage from "./routes/reports.js";
 import ReportDetailPage from "./routes/report-detail.js";
 import IssuesPage from "./routes/issues.js";
 import SyncConflictsPage from "./routes/sync-conflicts.js";
+import PmKanbanPage from "./routes/pm-kanban.js";
 import ChangelogPage from "./routes/system-changelog.js";
 import IncidentsPage from "./routes/system-incidents.js";
 import VendorsPage from "./routes/system-vendors.js";
@@ -72,6 +73,7 @@ export const router = createBrowserRouter([
       { path: "reports", element: <ReportsPage /> },
       { path: "issues", element: <IssuesPage /> },
       { path: "sync-conflicts", element: <SyncConflictsPage /> },
+      { path: "pm/kanban", element: <PmKanbanPage /> },
       { path: "reports/:coaReqId", element: <ReportDetailPage /> },
       { path: "entity/:id", element: <EntityPage /> },
       { path: "projects", element: <ProjectsPage /> },

--- a/ui/dashboard/src/routes/pm-kanban.tsx
+++ b/ui/dashboard/src/routes/pm-kanban.tsx
@@ -1,0 +1,27 @@
+/**
+ * PM Kanban page — s139 t536 Phase 1.
+ *
+ * System-aggregate kanban view of the active PM provider's tasks.
+ * Mirrors the /issues + /sync-conflicts page shape.
+ */
+
+import { PmKanbanPanel } from "@/components/PmKanbanPanel.js";
+import { PageScroll } from "@/components/PageScroll.js";
+
+export default function PmKanbanPage(): JSX.Element {
+  return (
+    <PageScroll>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-[18px] font-semibold">PM Kanban</h1>
+          <p className="text-[12px] text-muted-foreground mt-1">
+            Tasks from the active PM provider bucketed into the canonical 6-column board
+            (To do / Now / QA / Done + hidden Blocked / Archived). Drag-drop persistence,
+            card editor, and per-project view land in subsequent slices.
+          </p>
+        </div>
+        <PmKanbanPanel />
+      </div>
+    </PageScroll>
+  );
+}


### PR DESCRIPTION
## Summary

Read-only kanban view at the system level. Tasks fetched from /api/pm/find-tasks; bucketed into the canonical 6-column board (todo/now/qa/done + hidden Blocked/Archived) per s139 t535's DEFAULT_TYNN_KANBAN_CONFIG. Renders via @particle-academy/react-fancy Kanban primitive (verified shipped at ^2.9.0).

Phase 1 deliberately excludes drag-drop persistence (Phase 2), card editor (Phase 3), filter strip (Phase 4), realtime WS (Phase 5), per-project view (Phase 6). Same MVP-system-page pattern as /issues (PR #130) and /sync-conflicts (PR #131).

s139 advances 3/9 done.

## Test plan

- [x] Typecheck clean
- [ ] Owner: \`agi upgrade\` → /pm/kanban renders with 4 visible columns. Toggle "Show blocked + archived" surfaces 2 more.
- [ ] Owner: \`agi test --e2e pm-kanban-page\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)