### PR TITLE
feat(pm): kanban drag-drop persistence — s139 t536 Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.621",
+  "version": "0.4.622",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/pm-api.test.ts
+++ b/packages/gateway-core/src/pm-api.test.ts
@@ -280,4 +280,66 @@ describe("pm-api routes", () => {
       expect(body.error).toContain("not found");
     });
   });
+
+  describe("s139 t536 Phase 2 — POST /api/pm/tasks/:id/status", () => {
+    it("returns 200 + updated task on valid status", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/pm/tasks/t-1/status",
+        payload: { status: "doing" },
+      });
+      expect(r.statusCode).toBe(200);
+      const body = r.json() as { task: { id: string; status: string } };
+      expect(body.task.id).toBe("t-1");
+      expect(body.task.status).toBe("doing");
+    });
+
+    it("returns 400 on missing status", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/pm/tasks/t-1/status",
+        payload: {},
+      });
+      expect(r.statusCode).toBe(400);
+    });
+
+    it("returns 400 on invalid status", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/pm/tasks/t-1/status",
+        payload: { status: "totally-bogus" },
+      });
+      expect(r.statusCode).toBe(400);
+    });
+
+    it("forwards optional note to setTaskStatus", async () => {
+      const r = await app.inject({
+        method: "POST",
+        url: "/api/pm/tasks/t-1/status",
+        payload: { status: "finished", note: "shipped via PR #X" },
+      });
+      expect(r.statusCode).toBe(200);
+    });
+
+    it("returns 404 when provider throws 'unknown task'", async () => {
+      // Re-create the app with a provider that throws
+      const failApp = Fastify();
+      const failProvider = makeProvider({
+        setTaskStatus: async () => { throw new Error("tynn-lite: unknown task t-bogus"); },
+      });
+      registerPmRoutes(failApp, {
+        pmProvider: failProvider,
+        planStore,
+        workspaceProjects: [workspace],
+      });
+      await failApp.ready();
+      const r = await failApp.inject({
+        method: "POST",
+        url: "/api/pm/tasks/t-bogus/status",
+        payload: { status: "doing" },
+      });
+      expect(r.statusCode).toBe(404);
+      await failApp.close();
+    });
+  });
 });

--- a/packages/gateway-core/src/pm-api.ts
+++ b/packages/gateway-core/src/pm-api.ts
@@ -212,6 +212,36 @@ export function registerPmRoutes(app: FastifyInstance, deps: PmApiDeps): void {
     }
     return { resolved: id };
   });
+
+  // -------------------------------------------------------------------------
+  // s139 t536 Phase 2 — task status mutation REST surface
+  //
+  // Used by the /pm/kanban page's drag-drop handler to persist column
+  // moves. Body: { status: PmStatus, note?: string }. Returns the
+  // updated task. 404 when task is unknown; 400 on invalid status.
+  // -------------------------------------------------------------------------
+
+  const VALID_STATUSES: PmStatus[] = ["backlog", "starting", "doing", "testing", "finished", "blocked", "archived"];
+
+  app.post<{ Params: { id: string } }>("/api/pm/tasks/:id/status", async (request, reply) => {
+    const { id } = request.params;
+    const body = (request.body as Record<string, unknown> | null) ?? {};
+    const statusRaw = body["status"];
+    if (typeof statusRaw !== "string" || !(VALID_STATUSES as string[]).includes(statusRaw)) {
+      return reply.code(400).send({ error: `status must be one of ${VALID_STATUSES.join(", ")}` });
+    }
+    const note = typeof body["note"] === "string" ? body["note"] : undefined;
+    try {
+      const updated = await deps.pmProvider.setTaskStatus(id, statusRaw as PmStatus, note);
+      return { task: updated };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes("unknown task") || msg.includes("not found")) {
+        return reply.code(404).send({ error: msg });
+      }
+      return reply.code(500).send({ error: msg });
+    }
+  });
 }
 
 function isInsideWorkspace(projectPath: string, workspaceProjects: readonly string[]): boolean {

--- a/ui/dashboard/src/components/PmKanbanPanel.tsx
+++ b/ui/dashboard/src/components/PmKanbanPanel.tsx
@@ -110,7 +110,40 @@ export function PmKanbanPanel() {
           Show blocked + archived
         </label>
       </div>
-      <Kanban onCardMove={() => { /* Phase 2: persist via setTaskStatus */ }}>
+      <Kanban
+        onCardMove={(cardId, fromColumn, toColumn) => {
+          // s139 t536 Phase 2 — persist column moves via setTaskStatus.
+          // Map target column to its first canonical status (per
+          // DEFAULT_TYNN_KANBAN_CONFIG buckets); within-column moves
+          // (fromColumn === toColumn) skip the API call.
+          if (fromColumn === toColumn) return;
+          const target = COLUMNS.find((c) => c.id === toColumn);
+          if (!target || target.statuses.length === 0) return;
+          const newStatus = target.statuses[0];
+          // Optimistic update
+          setTasks((prev) => prev.map((t) => (t.id === cardId ? { ...t, status: newStatus! } : t)));
+          // Persist; on error, revert (pull tasks fresh from API)
+          void (async () => {
+            try {
+              const r = await fetch(`/api/pm/tasks/${cardId}/status`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ status: newStatus }),
+              });
+              if (!r.ok) throw new Error(`HTTP ${String(r.status)}`);
+            } catch {
+              // Revert: refetch
+              try {
+                const r = await fetch("/api/pm/find-tasks?limit=200");
+                if (r.ok) {
+                  const body = (await r.json()) as FindTasksResponse;
+                  setTasks(body.tasks ?? []);
+                }
+              } catch { /* swallow */ }
+            }
+          })();
+        }}
+      >
         {visibleColumns.map((col) => {
           const columnTasks = tasksByColumn.get(col.id) ?? [];
           return (


### PR DESCRIPTION
## Summary

Adds the missing setTaskStatus REST surface + wires kanban's onCardMove to call it. Drag a card between columns now persists the status change.

- POST /api/pm/tasks/:id/status (body: {status, note?})
- onCardMove: optimistic local update + revert-on-error
- 5 new vitest cases (27 total in pm-api.test.ts)

s139 t536 Phase 2 done. Phases 3-6 (card editor, filter strip, WS realtime, per-project view) follow.

## Test plan

- [x] Typecheck clean; 27 vitest cases pass
- [ ] Owner: \`agi upgrade\` → /pm/kanban; drag card between columns; verify status persists across page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)