### PR TITLE
feat(pm): kanban list-view toggle — s139 t537

### DIFF
--- a/e2e/pm-kanban-page.spec.ts
+++ b/e2e/pm-kanban-page.spec.ts
@@ -32,4 +32,21 @@ test.describe("/pm/kanban page (s139 t536 Phase 1)", () => {
     await expect(page.locator("text=Blocked").first()).toBeVisible();
     await expect(page.locator("text=Archived").first()).toBeVisible();
   });
+
+  test("Phase 3 — view-mode toggle swaps between Kanban + List", async ({ page }) => {
+    await page.goto("/pm/kanban", { waitUntil: "domcontentloaded" });
+    const panel = page.getByTestId("pm-kanban-panel");
+    await expect(panel).toBeVisible({ timeout: 10_000 });
+
+    // Default: kanban view; List variant not rendered
+    expect(await page.getByTestId("pm-kanban-list").count()).toBe(0);
+
+    // Click List → table renders
+    await page.getByTestId("view-mode-list").click();
+    await expect(page.getByTestId("pm-kanban-list")).toBeVisible();
+
+    // Click Kanban → table goes away
+    await page.getByTestId("view-mode-kanban").click();
+    expect(await page.getByTestId("pm-kanban-list").count()).toBe(0);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.625",
+  "version": "0.4.626",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/PmKanbanPanel.tsx
+++ b/ui/dashboard/src/components/PmKanbanPanel.tsx
@@ -46,11 +46,16 @@ const COLUMNS: { id: string; name: string; statuses: string[]; hiddenByDefault?:
   { id: "archived", name: "Archived", statuses: ["archived"], hiddenByDefault: true },
 ];
 
+type ViewMode = "kanban" | "list";
+
 export function PmKanbanPanel() {
   const [tasks, setTasks] = useState<PmTask[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showHidden, setShowHidden] = useState(false);
+  // s139 t537 — list-view toggle. Defaults to kanban; swaps to table
+  // when the user wants a denser scannable view.
+  const [viewMode, setViewMode] = useState<ViewMode>("kanban");
 
   useEffect(() => {
     let cancelled = false;
@@ -109,7 +114,59 @@ export function PmKanbanPanel() {
           />
           Show blocked + archived
         </label>
+        {/* s139 t537 — view mode toggle */}
+        <div className="ml-auto flex items-center gap-1 text-[11px]" data-testid="view-mode-toggle">
+          <button
+            onClick={() => { setViewMode("kanban"); }}
+            className={`px-2 py-0.5 rounded border ${
+              viewMode === "kanban"
+                ? "border-yellow bg-yellow/15 text-yellow"
+                : "border-border text-muted-foreground hover:bg-secondary"
+            }`}
+            data-testid="view-mode-kanban"
+          >
+            Kanban
+          </button>
+          <button
+            onClick={() => { setViewMode("list"); }}
+            className={`px-2 py-0.5 rounded border ${
+              viewMode === "list"
+                ? "border-yellow bg-yellow/15 text-yellow"
+                : "border-border text-muted-foreground hover:bg-secondary"
+            }`}
+            data-testid="view-mode-list"
+          >
+            List
+          </button>
+        </div>
       </div>
+
+      {viewMode === "list" && (
+        <table className="w-full border-collapse text-[12px]" data-testid="pm-kanban-list">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="text-left py-1 px-2 font-medium text-muted-foreground">#</th>
+              <th className="text-left py-1 px-2 font-medium text-muted-foreground">Title</th>
+              <th className="text-left py-1 px-2 font-medium text-muted-foreground">Column</th>
+              <th className="text-left py-1 px-2 font-medium text-muted-foreground">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleColumns.flatMap((col) =>
+              (tasksByColumn.get(col.id) ?? []).map((task) => (
+                <tr key={task.id} className="border-b border-border/50" data-testid="pm-kanban-list-row">
+                  <td className="py-1 px-2 font-mono text-muted-foreground tabular-nums">#{String(task.number)}</td>
+                  <td className="py-1 px-2 truncate max-w-[400px]">{task.title}</td>
+                  <td className="py-1 px-2">{col.name}</td>
+                  <td className="py-1 px-2 text-muted-foreground">{task.status}</td>
+                </tr>
+              )),
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {viewMode === "kanban" && (
       <Kanban
         onCardMove={(cardId, fromColumn, toColumn) => {
           // s139 t536 Phase 2 — persist column moves via setTaskStatus.
@@ -168,6 +225,7 @@ export function PmKanbanPanel() {
           );
         })}
       </Kanban>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

View-mode toggle on PmKanbanPanel: Kanban (default) | List. Same task data; List renders flat as a table. Show-hidden checkbox affects both views identically.

s139 advances 4/9.

## Test plan

- [x] Typecheck clean
- [x] 1 new e2e case (toggle swap)
- [ ] Owner: \`agi upgrade\` → /pm/kanban → click List → table; click Kanban → cards back

🤖 Generated with [Claude Code](https://claude.com/claude-code)