### PR TITLE
test(pm): kanban e2e from per-project Operate tab — s139 t542

### DIFF
--- a/e2e/pm-kanban-page.spec.ts
+++ b/e2e/pm-kanban-page.spec.ts
@@ -50,3 +50,38 @@ test.describe("/pm/kanban page (s139 t536 Phase 1)", () => {
     expect(await page.getByTestId("pm-kanban-list").count()).toBe(0);
   });
 });
+
+/**
+ * s139 t542 — kanban e2e from per-project Operate sub-surface.
+ *
+ * The /pm/kanban system-aggregate page is already covered above. This
+ * suite drives the same panel from inside a project's coordinate-mode
+ * tab strip (s139 t538 wired the PM tab there). Skips when no project
+ * with the PM tab visible exists in the test environment.
+ */
+test.describe("PM kanban from per-project Operate tab (s139 t542)", () => {
+  test("Operate → PM tab renders the kanban panel", async ({ page }) => {
+    const apiR = await page.request.get("/api/projects");
+    if (!apiR.ok()) test.skip(true, "API not reachable");
+    const list = await apiR.json() as { name: string }[] | { projects?: { name: string }[] };
+    const projects = Array.isArray(list) ? list : (list.projects ?? []);
+    if (projects.length === 0) test.skip(true, "No projects in workspace");
+
+    const firstProject = projects[0]?.name;
+    if (!firstProject) test.skip(true, "No project name available");
+    await page.goto(`/projects/${firstProject}`, { waitUntil: "domcontentloaded" });
+
+    const pmTab = page.getByTestId("project-tab-pm");
+    if (!(await pmTab.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      const coordinateMode = page.locator('[aria-pressed]').filter({ hasText: /coordinate/i }).first();
+      if (await coordinateMode.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await coordinateMode.click();
+      }
+    }
+    if (!(await pmTab.isVisible({ timeout: 5_000 }).catch(() => false))) {
+      test.skip(true, "PM tab not visible on this project (mode/category restrictions)");
+    }
+    await pmTab.click();
+    await expect(page.getByTestId("pm-kanban-panel")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.628",
+  "version": "0.4.629",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
## Summary

Extends pm-kanban-page.spec.ts with one new describe block: Operate → PM tab navigation from a workspace project (the s139 t538 wiring).

Existing tests already cover the system-aggregate /pm/kanban surface (heading + columns + show-hidden + view-toggle). Card-creation + filter-strip e2e cases follow when t539 + t540 ship.

s139 advances 7/9.

## Test plan

- [x] Typecheck clean
- [ ] Owner: \`agi test --e2e pm-kanban-page\` after merge — new operate-tab navigation test should pass (or skip cleanly if no project meets the PM-tab visibility rules in the test env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)