### PR TITLE
v0.4.632 — s144 t582 cutover: bare `agi doctor` → TS commander

### DIFF
--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -92,15 +92,25 @@ agi stop        # stop the service
 
 ### agi doctor
 
-Run infrastructure health checks.
+Run grouped self-diagnostic checks (s144 t582 — bare form now routes to the TS commander surface).
 
 ```bash
-agi doctor
+agi doctor              # full grouped diagnostic
+agi doctor --json       # machine-readable for scripting / CI
+agi doctor --with-aion  # appends aion-micro-powered analysis of failures
 ```
 
-Checks: Node.js version, pnpm, deploy directory, config file, Caddy, Podman (rootless), Ollama, dnsmasq, gateway HTTP response, NPU readiness (when available), Lemonade backend, disk usage, **hosted-project state** (`N/M up` summary with names of any down projects — see `agi projects` for the full list), **flapping projects** (running but with `RestartCount > 3` — surfaces containers that are technically "up" but crash-looping under podman's `--restart=always` policy).
+Check groups: **core** (config file + Zod validation), **auth** (Local-ID reachable, sealed credentials), **repos** (per-project clone state), **git state** (branch + remotes per repo), **plugins** (cache integrity), **network** (ports / certificates / Caddy parse-errors), **containers** (running + flapping + orphan analysis), **hosting** (per-project hostname + breaker state), **project shape** (s150 t641 per-project layout validation), **dev** (PAx fork checkouts when contributing mode active), **gateway** (HTTP reachability + state), **lemonade** (backend reachable + model cache).
 
-Exits with the issue count as a one-line summary at the bottom.
+Exits 0 on all-pass, 1 when any failed (warnings don't fail).
+
+#### agi doctor health
+
+The legacy 5-check infra health surface (Node.js / pnpm / Caddy / podman / hosted projects / flapping). Pre-s144-t582 this was the bare-form behavior; kept available for scripts/CI continuity that depended on the older shape.
+
+```bash
+agi doctor health
+```
 
 #### agi doctor schema
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.631",
+  "version": "0.4.632",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -2170,8 +2170,10 @@ cmd_help() {
   echo "  start           Start the gateway service"
   echo "  stop            Stop the gateway service"
   echo "  doctor [CMD]    Diagnostic commands (s144):"
-  echo "                    (no arg)                     Infra health check (Node, podman, hosted projects)"
-  echo "                    health                       Explicit form of the bare-form check (forward-compat)"
+  echo "                    (no arg)                     Full grouped self-diagnostic (core/auth/repos/git/plugins/network/containers/hosting/dev/gateway/lemonade)"
+  echo "                    [--json]                     Bare-form supports JSON output for scripting"
+  echo "                    [--with-aion]                Bare-form supports aion-micro-powered analysis"
+  echo "                    health                       Legacy 5-check infra health (Node, podman, hosted projects, flapping)"
   echo "                    schema [--json]              Validate every gateway-loaded config against its Zod schema"
   echo "                    dump                         Write redacted diagnostic bundle to ~/.agi/doctor-dumps/"
   echo "                    logs [--lines N]             Tail recent logs + surface known crash patterns"
@@ -2275,15 +2277,21 @@ case "${1:-help}" in
         cd "$DEPLOY_DIR" && exec npx tsx cli/src/index.ts doctor "$_doctor_sub" "$@"
         ;;
       health)
-        # s144 t582 forward-compat alias — `agi doctor health` is the
-        # explicit name for today's bare-form health check (Node /
-        # pnpm / Caddy / hosted-projects / flapping). When t574 lands
-        # the TUI shell, the bare `agi doctor` flips to TUI-open and
-        # this alias remains as the explicit-form for scripts/CI.
+        # s144 t582 — `agi doctor health` is the legacy bash 5-check
+        # form (Node / pnpm / Caddy / hosted-projects / flapping). Kept
+        # as the explicit-form for scripts/CI continuity now that bare
+        # `agi doctor` runs the full TS commander surface.
         cmd_doctor
         ;;
       *)
-        cmd_doctor
+        # s144 t582 cutover — bare `agi doctor` routes to the TS
+        # commander grouped diagnostic (core / auth / repos / git /
+        # plugins / network / containers / hosting / project-shape /
+        # dev / gateway / lemonade). Replaces the legacy 5-check bash
+        # form which is now reachable via `agi doctor health`. Flag
+        # passthrough (--json, --with-aion) preserved.
+        shift
+        cd "$DEPLOY_DIR" && exec npx tsx cli/src/index.ts doctor "$@"
         ;;
     esac
     ;;


### PR DESCRIPTION
CLOSES s144 t582. Bare `agi doctor` flips to the TS commander grouped diagnostic surface (core/auth/repos/git/plugins/network/containers/hosting/project-shape/dev/gateway/lemonade). The legacy 5-check bash form remains reachable as `agi doctor health` for scripts/CI continuity. Flag passthrough preserved (`--json`, `--with-aion`).

s144 progress: 9/10 done. Only t574 (TUI shell — interactive `agi doctor` with category menu) remains.

## Test plan
- `agi doctor` runs all check groups + summary line (full TS surface).
- `agi doctor --json` emits structured JSON for CI scripting.
- `agi doctor health` runs the legacy 5-check infra status (Node / pnpm / Caddy / podman / hosted-projects / flapping).
- `agi doctor schema/dump/logs/config` continue to route to TS commander unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)