### PR TITLE
v0.4.633 — s161 path-A: default issue projectPath to `_aionima`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.632",
+  "version": "0.4.633",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -130,7 +130,7 @@ import { ImageBlobStore } from "./image-blob-store.js";
 import { WorkerPromptLoader } from "./worker-prompt-loader.js";
 import { ChatGarbageCollector } from "./chat-garbage-collector.js";
 import { buildTynnSyncPrompt } from "./plan-tynn-mapper.js";
-import { ensureAionimaSystemProject, ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-path.js";
+import { aionimaSystemProjectPath, ensureAionimaSystemProject, ensureWorkspaceSkeleton, projectConfigPath } from "./project-config-path.js";
 import { migrateAionimaSystemForks } from "./aionima-system-migration.js";
 import { migrateAionimaMemoryDir } from "./aionima-memory-migration.js";
 import { HostingManager } from "./hosting-manager.js";
@@ -2899,6 +2899,14 @@ export async function startGatewayServer(
     ISSUE_TOOL_MANIFEST,
     createIssueHandler({
       workspaceProjects: () => Array.isArray(config.workspace?.projects) ? config.workspace.projects : [],
+      // s161 path-A — default to `<workspaceRoot>/_aionima` when caller
+      // omits projectPath. The first configured workspace.projects dir
+      // is the conventional workspaceRoot; fall through to null when
+      // nothing is configured (handler returns the standard error).
+      defaultProjectPath: () => {
+        const projects = Array.isArray(config.workspace?.projects) ? config.workspace.projects : [];
+        return projects.length > 0 ? aionimaSystemProjectPath(projects[0]!) : null;
+      },
     }),
     ISSUE_TOOL_INPUT_SCHEMA,
   );

--- a/packages/gateway-core/src/tools/issue-tools.test.ts
+++ b/packages/gateway-core/src/tools/issue-tools.test.ts
@@ -38,7 +38,7 @@ describe("issue tool — input validation (Wish #21 Slice 3)", () => {
     expect((r as { error?: string }).error).toMatch(/action must be one of/);
   });
 
-  it("rejects missing projectPath", async () => {
+  it("rejects missing projectPath when no default configured", async () => {
     const r = await call({ action: "list" });
     expect((r as { error?: string }).error).toMatch(/projectPath is required/);
   });
@@ -46,6 +46,31 @@ describe("issue tool — input validation (Wish #21 Slice 3)", () => {
   it("rejects projectPath outside workspace", async () => {
     const r = await call({ action: "list", projectPath: "/tmp/not-in-workspace" });
     expect((r as { error?: string }).error).toMatch(/not inside a configured workspace/);
+  });
+
+  // s161 path-A — defaultProjectPath fallback for project-less callers
+  it("falls back to defaultProjectPath when projectPath omitted", async () => {
+    const fallback = join(workspace, "_aionima");
+    mkdirSync(fallback, { recursive: true });
+    const handlerWithDefault = createIssueHandler({
+      workspaceProjects: () => [workspace],
+      defaultProjectPath: () => fallback,
+    });
+    const out = await Promise.resolve(handlerWithDefault({ action: "list" }));
+    const r = JSON.parse(out) as { action?: string; issues?: unknown[]; error?: string };
+    expect(r.error).toBeUndefined();
+    expect(r.action).toBe("list");
+    expect(Array.isArray(r.issues)).toBe(true);
+  });
+
+  it("rejects when defaultProjectPath returns null", async () => {
+    const handlerWithNullDefault = createIssueHandler({
+      workspaceProjects: () => [workspace],
+      defaultProjectPath: () => null,
+    });
+    const out = await Promise.resolve(handlerWithNullDefault({ action: "list" }));
+    const r = JSON.parse(out) as { error?: string };
+    expect(r.error).toMatch(/projectPath is required/);
   });
 });
 

--- a/packages/gateway-core/src/tools/issue-tools.ts
+++ b/packages/gateway-core/src/tools/issue-tools.ts
@@ -38,6 +38,16 @@ import {
 export interface CreateIssueHandlerConfig {
   /** Workspace project paths used to validate `projectPath` input. */
   workspaceProjects: () => string[];
+  /**
+   * Optional default project path used when caller omits `projectPath`.
+   * s161 path-A — when Aion fires this tool from a chat without project
+   * context (or explicitly wants the system-fallback bucket), the call
+   * defaults to `<workspaceRoot>/_aionima` so the issue lands in the
+   * always-present meta-project's k/issues/ registry rather than failing.
+   * Mirrors the canonical s130/s150/s160 architecture: per-project for
+   * projects + `_aionima` as the system-fallback project.
+   */
+  defaultProjectPath?: () => string | null;
   /** Optional override for resolve+normalize behavior; defaults to identity. */
   normalizePath?: (p: string) => string;
 }
@@ -62,9 +72,15 @@ export function createIssueHandler(config: CreateIssueHandlerConfig): ToolHandle
     if (!VALID_ACTIONS.has(action)) {
       return err(`action must be one of ${[...VALID_ACTIONS].join(", ")}`);
     }
-    const projectPath = typeof input.projectPath === "string" ? input.projectPath.trim() : "";
+    let projectPath = typeof input.projectPath === "string" ? input.projectPath.trim() : "";
     if (!projectPath) {
-      return err("projectPath is required");
+      // s161 path-A — fall back to `<workspaceRoot>/_aionima` when caller
+      // omits projectPath. Project-less callers (chat without project
+      // context, system-level Aion tool fires) land in the always-present
+      // meta-project's k/issues/ rather than erroring.
+      const fallback = config.defaultProjectPath?.() ?? null;
+      if (!fallback) return err("projectPath is required");
+      projectPath = fallback;
     }
     if (!isInWorkspace(projectPath)) {
       return err("projectPath is not inside a configured workspace.projects directory");
@@ -143,7 +159,7 @@ export const ISSUE_TOOL_INPUT_SCHEMA = {
     },
     projectPath: {
       type: "string",
-      description: "Absolute path of the project whose registry to operate on. Must be inside a workspace.projects directory.",
+      description: "Absolute path of the project whose registry to operate on. Must be inside a workspace.projects directory. Optional: when omitted, defaults to <workspaceRoot>/_aionima (the always-present meta-project's k/issues/) so project-less callers don't error.",
     },
     query: {
       type: "string",
@@ -188,5 +204,5 @@ export const ISSUE_TOOL_INPUT_SCHEMA = {
       description: "(fix) Optional resolution note appended to the issue body.",
     },
   },
-  required: ["action", "projectPath"],
+  required: ["action"],
 };


### PR DESCRIPTION
CLOSES s161. Tiny enhancement materializing the canonical s130/s150/s160 architecture: per-project k/issues/ for projects + `_aionima` as the system-fallback project for callers without project context.

Wish #21 shipped per-project k/issues/ end-to-end this run (substrate + REST + CLI + Aion tool + dashboard). s161 path-A adds:
- `defaultProjectPath` config callback on `createIssueHandler`
- server.ts wires it to `aionimaSystemProjectPath(projects[0])`
- tool input schema: projectPath optional
- 2 new unit tests (20/20 pass) covering fallback + null-default cases

Project-less Aion fires (chat without project context, system diagnostic captures) now land in `<workspaceRoot>/_aionima/k/issues/`.

## Test plan
- 20/20 unit tests pass.
- Aion can fire `issue.list` without projectPath → returns _aionima's index.
- Explicit projectPath continues to scope to that project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)