### PR TITLE
v0.4.635 — s157 drift fix: user_notes CREATE TABLE safety net

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.634",
+  "version": "0.4.635",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/db-schema/drizzle/0003_user_notes_create_safety.sql
+++ b/packages/db-schema/drizzle/0003_user_notes_create_safety.sql
@@ -1,0 +1,32 @@
+-- s157 cycle 178 — user_notes table CREATE TABLE IF NOT EXISTS safety net.
+--
+-- Drift discovery (cycle 177): user_notes was added to platform.ts in s152
+-- (2026-05-09) and referenced by notes-store.ts, but no migration ever created
+-- the table. Production may or may not have it depending on which non-tracked
+-- path created it. Migration 0002 (cycle 177) used ALTER IF EXISTS to be safe
+-- regardless. This migration ensures the table itself exists so 0002's ADD
+-- COLUMN succeeds on fresh databases too.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS — does nothing if table already
+-- present. Indices are CREATE INDEX IF NOT EXISTS for the same reason. The
+-- `kind` column is included with its default so this migration alone is
+-- sufficient on a fresh DB; on existing DBs that already received 0002, the
+-- column is already present and CREATE TABLE IF NOT EXISTS is a no-op.
+
+CREATE TABLE IF NOT EXISTS "user_notes" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_entity_id" text NOT NULL,
+  "project_path" text,
+  "title" text NOT NULL,
+  "kind" text NOT NULL DEFAULT 'markdown',
+  "body" text NOT NULL DEFAULT '',
+  "sort_order" integer NOT NULL DEFAULT 0,
+  "pinned" boolean NOT NULL DEFAULT false,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "user_notes_user_idx" ON "user_notes" ("user_entity_id");
+CREATE INDEX IF NOT EXISTS "user_notes_project_idx" ON "user_notes" ("project_path");
+CREATE INDEX IF NOT EXISTS "user_notes_pinned_idx" ON "user_notes" ("pinned");
+CREATE INDEX IF NOT EXISTS "user_notes_kind_idx" ON "user_notes" ("kind");

--- a/packages/db-schema/drizzle/meta/_journal.json
+++ b/packages/db-schema/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778760000000,
       "tag": "0002_user_notes_kind",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1778762000000,
+      "tag": "0003_user_notes_create_safety",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes the drift discovered in cycle 177: `user_notes` was defined in `platform.ts` (s152, 2026-05-09) and referenced by `notes-store` but no migration ever created the table. Cycle 177's migration 0002 used ALTER IF EXISTS to be idempotent. This migration is the safety net for fresh databases.

## Behavior matrix (idempotent guards)
| State | 0002 | 0003 | Outcome |
|-------|------|------|---------|
| Fresh DB | no-op (ALTER IF EXISTS) | CREATE TABLE | table exists with kind column |
| DB that already received 0002 | column added | CREATE IF NOT EXISTS no-op | table unchanged |
| DB that has user_notes via other path | column added if missing | CREATE IF NOT EXISTS no-op | table unchanged |

No code changes — pure migration + journal entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)