### PR TITLE
v0.4.636 — s144 t574 Phase 1: `agi doctor menu` (numbered category picker)

### DIFF
--- a/cli/src/commands/doctor-menu.test.ts
+++ b/cli/src/commands/doctor-menu.test.ts
@@ -1,0 +1,88 @@
+/**
+ * doctor-menu pure-logic tests (s144 t574 Phase 1).
+ *
+ * Covers the menu→command mapping and renderer. The interactive
+ * `runDoctorMenu` itself spawns a child process and reads stdin so it's
+ * exercised by the manual recipe, not unit tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { MENU_ITEMS, pickMenuItem, renderMenu } from "./doctor-menu.js";
+
+describe("MENU_ITEMS (s144 t574)", () => {
+  it("includes a quit option at number 0", () => {
+    const quit = MENU_ITEMS.find((m) => m.id === "quit");
+    expect(quit).toBeDefined();
+    expect(quit?.number).toBe(0);
+  });
+
+  it("has unique numeric labels", () => {
+    const numbers = MENU_ITEMS.map((m) => m.number);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  it("has unique ids", () => {
+    const ids = MENU_ITEMS.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every non-quit item carries args", () => {
+    for (const item of MENU_ITEMS) {
+      if (item.id === "quit") continue;
+      // run-all maps to bare `agi doctor` so empty args is correct
+      if (item.id === "run-all") {
+        expect(item.args).toEqual([]);
+        continue;
+      }
+      expect(item.args.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("pickMenuItem (s144 t574)", () => {
+  it("resolves the schema item from '2'", () => {
+    const item = pickMenuItem("2");
+    expect(item?.id).toBe("schema");
+  });
+
+  it("resolves with surrounding whitespace", () => {
+    expect(pickMenuItem("  3  ")?.id).toBe("dump");
+  });
+
+  it("resolves quit from '0'", () => {
+    expect(pickMenuItem("0")?.id).toBe("quit");
+  });
+
+  it("returns null for empty input", () => {
+    expect(pickMenuItem("")).toBeNull();
+    expect(pickMenuItem("   ")).toBeNull();
+  });
+
+  it("returns null for non-integer", () => {
+    expect(pickMenuItem("abc")).toBeNull();
+    expect(pickMenuItem("1.5")).toBeNull();
+    expect(pickMenuItem("schema")).toBeNull();
+  });
+
+  it("returns null for out-of-range numbers", () => {
+    expect(pickMenuItem("99")).toBeNull();
+    expect(pickMenuItem("-1")).toBeNull();
+  });
+});
+
+describe("renderMenu (s144 t574)", () => {
+  it("includes every menu item label", () => {
+    const out = renderMenu();
+    for (const item of MENU_ITEMS) {
+      expect(out).toContain(item.label);
+    }
+  });
+
+  it("opens with the menu heading", () => {
+    expect(renderMenu()).toContain("agi doctor — diagnostic menu");
+  });
+
+  it("ends with a trailing newline", () => {
+    expect(renderMenu()).toMatch(/\n$/);
+  });
+});

--- a/cli/src/commands/doctor-menu.ts
+++ b/cli/src/commands/doctor-menu.ts
@@ -1,0 +1,162 @@
+/**
+ * `agi doctor menu` — Phase 1 of s144 t574 (TUI shell).
+ *
+ * Owner directive (t574): "interactive `agi doctor` with category menu …
+ * Arrow-keys + Enter navigation, Esc to back out." Phase 1 ships the
+ * smallest meaningful primitive — a numbered menu read via Node's
+ * built-in readline (no ink/blessed dep). The user types a number, hits
+ * Enter, the matching sub-command runs once, the menu exits.
+ *
+ * Phase 2+ adds: arrow-key navigation, sub-menus, looped re-prompt,
+ * Esc-to-back. Those slices either pull in a TUI library or implement
+ * raw-mode keypress handling. Phase 1 deliberately uses the same
+ * readline/promises pattern as setup.ts so Phase 1 is shippable in
+ * isolation without dep churn.
+ *
+ * Routing: each menu item is one of the existing `agi doctor <sub>`
+ * surfaces (schema/dump/logs/config/health/run-all). The menu is just
+ * navigation — implementations live where they already do.
+ */
+
+import { createInterface } from "node:readline/promises";
+import { spawnSync } from "node:child_process";
+
+/**
+ * Stable id for a menu pick. Each id maps to an `agi doctor <id>` call
+ * (or to no-op for `quit`). Keeps the menu→command relation explicit
+ * and unit-testable without spinning up a child process.
+ */
+export type MenuItemId =
+  | "run-all"
+  | "schema"
+  | "dump"
+  | "logs"
+  | "config-get"
+  | "health"
+  | "quit";
+
+export interface MenuItem {
+  /** Numeric label printed in the menu — 0 reserved for quit. */
+  number: number;
+  /** Stable id used by routing + tests. */
+  id: MenuItemId;
+  /** Short label printed alongside the number. */
+  label: string;
+  /** One-line description shown beneath the label. */
+  description: string;
+  /** Sub-command args passed to `agi doctor <args>`. Empty for run-all. Empty for quit. */
+  args: string[];
+}
+
+export const MENU_ITEMS: readonly MenuItem[] = [
+  {
+    number: 1,
+    id: "run-all",
+    label: "Run all checks",
+    description: "Full grouped diagnostic — every check group end-to-end",
+    args: [],
+  },
+  {
+    number: 2,
+    id: "schema",
+    label: "Validate config schemas",
+    description: "Walk every on-disk gateway-loaded config through its Zod schema",
+    args: ["schema"],
+  },
+  {
+    number: 3,
+    id: "dump",
+    label: "Write diagnostic bundle",
+    description: "Redacted config + recent logs + check results to ~/.agi/doctor-dumps/",
+    args: ["dump"],
+  },
+  {
+    number: 4,
+    id: "logs",
+    label: "Tail logs + crash-pattern detection",
+    description: "Surface known crash patterns (ZodError, EADDRINUSE, OOM, container exit, …)",
+    args: ["logs"],
+  },
+  {
+    number: 5,
+    id: "config-get",
+    label: "Read a gateway.json config key",
+    description: "Prompts for the dotted key path and prints the validated value",
+    args: ["config", "get"],
+  },
+  {
+    number: 6,
+    id: "health",
+    label: "Legacy 5-check infra health",
+    description: "Node / pnpm / Caddy / podman / hosted-projects / flapping",
+    args: ["health"],
+  },
+  {
+    number: 0,
+    id: "quit",
+    label: "Quit",
+    description: "Exit the menu without running anything",
+    args: [],
+  },
+] as const;
+
+/**
+ * Resolve a user-typed selection string to a menu item. Pure function
+ * — exposed for unit tests so the menu→command mapping is verifiable
+ * without a TTY.
+ *
+ * Accepts the numeric label as a string. Whitespace is trimmed. Returns
+ * null for any input that doesn't match a known number.
+ */
+export function pickMenuItem(input: string): MenuItem | null {
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n)) return null;
+  return MENU_ITEMS.find((m) => m.number === n) ?? null;
+}
+
+/**
+ * Print the menu in a stable, narrow format. Exposed for tests.
+ */
+export function renderMenu(): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  agi doctor — diagnostic menu");
+  lines.push("");
+  for (const item of MENU_ITEMS) {
+    const num = String(item.number).padStart(1, " ");
+    lines.push(`  ${num}  ${item.label}`);
+    lines.push(`     ${item.description}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Run the menu interactively. Reads one selection from stdin, routes
+ * to the matching `agi doctor <args>` call via spawnSync, then returns.
+ * Returns the picked item id (or "quit" if the user picked 0 / EOF / invalid).
+ *
+ * Spawns the same `agi` binary that's currently running so the routing
+ * goes back through the existing CLI surface (bash → TS commander).
+ * No reentrancy with this same Node process.
+ */
+export async function runDoctorMenu(opts?: { agiBin?: string }): Promise<MenuItemId> {
+  const bin = opts?.agiBin ?? "agi";
+  process.stdout.write(renderMenu());
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question("  Pick a number (0 to quit): ");
+    const item = pickMenuItem(answer);
+    if (!item || item.id === "quit") {
+      process.stdout.write("\n");
+      return "quit";
+    }
+    process.stdout.write("\n");
+    spawnSync(bin, ["doctor", ...item.args], { stdio: "inherit" });
+    return item.id;
+  } finally {
+    rl.close();
+  }
+}

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1492,6 +1492,19 @@ export function registerDoctorCommand(program: Command): void {
       if (totalFailed > 0) process.exitCode = 1;
     });
 
+  // s144 t574 Phase 1 — `agi doctor menu` interactive category picker.
+  // Reads one selection via Node readline, routes to the matching
+  // sub-command. Phase 2+ adds arrow-key nav + sub-menus + looped
+  // re-prompt; Phase 1 ships the smallest meaningful primitive without
+  // pulling in ink/blessed.
+  doctor
+    .command("menu")
+    .description("Interactive category menu — pick a number, run that diagnostic, exit")
+    .action(async () => {
+      const { runDoctorMenu } = await import("./doctor-menu.js");
+      await runDoctorMenu();
+    });
+
   // s144 t579 — `agi doctor dump` writes a diagnostic bundle to
   // ~/.agi/doctor-dumps/dump-<timestamp>.json. Hands the path back so an
   // operator can attach it to a bug report or share it with support.

--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -104,6 +104,18 @@ Check groups: **core** (config file + Zod validation), **auth** (Local-ID reacha
 
 Exits 0 on all-pass, 1 when any failed (warnings don't fail).
 
+#### agi doctor menu
+
+Interactive category menu (s144 t574 Phase 1). Prints a numbered list of diagnostic categories; you type a number, hit Enter, and the matching sub-command runs once before the menu exits.
+
+```bash
+agi doctor menu
+```
+
+Categories: `Run all checks` (bare doctor) · `Validate config schemas` (schema) · `Write diagnostic bundle` (dump) · `Tail logs + crash-pattern detection` (logs) · `Read a gateway.json key` (config get) · `Legacy 5-check health` (health) · `Quit` (0).
+
+Phase 1 is read-once-and-exit. Phase 2+ adds arrow-key navigation, sub-menus, looped re-prompt, and Esc-to-back. For scripting, prefer the explicit sub-commands directly (`agi doctor schema`, `agi doctor dump`, etc.) — the menu is a discovery aid, not a scriptable surface.
+
 #### agi doctor health
 
 The legacy 5-check infra health surface (Node.js / pnpm / Caddy / podman / hosted projects / flapping). Pre-s144-t582 this was the bare-form behavior; kept available for scripts/CI continuity that depended on the older shape.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.635",
+  "version": "0.4.636",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -2173,6 +2173,7 @@ cmd_help() {
   echo "                    (no arg)                     Full grouped self-diagnostic (core/auth/repos/git/plugins/network/containers/hosting/dev/gateway/lemonade)"
   echo "                    [--json]                     Bare-form supports JSON output for scripting"
   echo "                    [--with-aion]                Bare-form supports aion-micro-powered analysis"
+  echo "                    menu                         Interactive category menu (Phase 1 — number-pick once)"
   echo "                    health                       Legacy 5-check infra health (Node, podman, hosted projects, flapping)"
   echo "                    schema [--json]              Validate every gateway-loaded config against its Zod schema"
   echo "                    dump                         Write redacted diagnostic bundle to ~/.agi/doctor-dumps/"
@@ -2265,13 +2266,10 @@ case "${1:-help}" in
         shift; shift
         cd "$DEPLOY_DIR" && exec npx tsx cli/src/index.ts schema validate "$@"
         ;;
-      dump|logs|config)
+      dump|logs|config|menu)
         # s144 t582 forward-compat — route the TS commander subcommands
-        # (dump t579, logs t581, config t578) through bash to the cli/src/
-        # commander surface where they live. Pre-t582 they were
-        # silently routed to bare-form cmd_doctor (which doesn't know
-        # about them) — drift caught while shipping t583's spec. Bash
-        # is now the bridge; TS cli is the canonical entrypoint.
+        # (dump t579, logs t581, config t578, menu t574 Phase 1) through
+        # bash to the cli/src/ commander surface where they live.
         local _doctor_sub="${2:-}"
         shift; shift
         cd "$DEPLOY_DIR" && exec npx tsx cli/src/index.ts doctor "$_doctor_sub" "$@"


### PR DESCRIPTION
s144 t574 Phase 1 — smallest meaningful TUI primitive. Numbered menu read via Node `readline/promises` (matches `setup.ts` pattern; no ink/blessed dep). User picks a number, the matching `agi doctor <sub>` runs once via `spawnSync`, menu exits.

## What ships
- `cli/src/commands/doctor-menu.ts` — `MENU_ITEMS`, `pickMenuItem` (pure), `renderMenu` (pure), `runDoctorMenu` (interactive)
- `cli/src/commands/doctor.ts` — registers `menu` subcommand
- `scripts/agi-cli.sh` — adds `menu` to bash → TS commander router
- `docs/human/cli.md` — documents the surface
- 13 new pure-logic unit tests (13/13 pass)

## Test plan
- 13/13 unit tests cover MENU_ITEMS uniqueness, pickMenuItem trimming/integer-validation/range, renderMenu output shape.
- Manual: `agi doctor menu` → numbered list → type "2" → schema validator runs → exits.

## Phase 2+ (separate cycles)
Arrow-key nav · sub-menus · looped re-prompt · Esc-to-back. Will pull in a TUI library or implement raw-mode keypress handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)