### PR TITLE
v0.4.637 — s144 t574 Phase 2: looped doctor menu + press-Enter-to-continue

### DIFF
--- a/cli/src/commands/doctor-menu.test.ts
+++ b/cli/src/commands/doctor-menu.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { MENU_ITEMS, pickMenuItem, renderMenu } from "./doctor-menu.js";
+import { MENU_ITEMS, classifyMenuTurn, pickMenuItem, renderMenu } from "./doctor-menu.js";
 
 describe("MENU_ITEMS (s144 t574)", () => {
   it("includes a quit option at number 0", () => {
@@ -67,6 +67,36 @@ describe("pickMenuItem (s144 t574)", () => {
   it("returns null for out-of-range numbers", () => {
     expect(pickMenuItem("99")).toBeNull();
     expect(pickMenuItem("-1")).toBeNull();
+  });
+});
+
+describe("classifyMenuTurn (s144 t574 Phase 2)", () => {
+  it("classifies '0' as quit", () => {
+    expect(classifyMenuTurn("0")).toEqual({ kind: "quit" });
+  });
+
+  it("classifies a known number as ran", () => {
+    const outcome = classifyMenuTurn("2");
+    expect(outcome.kind).toBe("ran");
+    if (outcome.kind === "ran") {
+      expect(outcome.item.id).toBe("schema");
+    }
+  });
+
+  it("classifies unknown input as invalid with raw preserved", () => {
+    expect(classifyMenuTurn("xyz")).toEqual({ kind: "invalid", raw: "xyz" });
+  });
+
+  it("classifies empty input as invalid", () => {
+    expect(classifyMenuTurn("")).toEqual({ kind: "invalid", raw: "" });
+  });
+
+  it("classifies out-of-range as invalid", () => {
+    expect(classifyMenuTurn("99")).toEqual({ kind: "invalid", raw: "99" });
+  });
+
+  it("tolerates whitespace around quit", () => {
+    expect(classifyMenuTurn("  0  ")).toEqual({ kind: "quit" });
   });
 });
 

--- a/cli/src/commands/doctor-menu.ts
+++ b/cli/src/commands/doctor-menu.ts
@@ -133,10 +133,30 @@ export function renderMenu(): string {
   return lines.join("\n");
 }
 
+/** Classification of one menu turn's outcome — exposed for unit tests. */
+export type MenuTurnOutcome =
+  | { kind: "quit" }
+  | { kind: "invalid"; raw: string }
+  | { kind: "ran"; item: MenuItem };
+
 /**
- * Run the menu interactively. Reads one selection from stdin, routes
- * to the matching `agi doctor <args>` call via spawnSync, then returns.
- * Returns the picked item id (or "quit" if the user picked 0 / EOF / invalid).
+ * Pure classifier — turn one user input string into a menu-turn outcome.
+ * Used by both the interactive loop and the unit tests for invalid /
+ * valid / quit branches.
+ */
+export function classifyMenuTurn(input: string): MenuTurnOutcome {
+  const item = pickMenuItem(input);
+  if (!item) return { kind: "invalid", raw: input };
+  if (item.id === "quit") return { kind: "quit" };
+  return { kind: "ran", item };
+}
+
+/**
+ * Run the menu interactively. Phase 2 (s144 t574, 2026-05-10) — wraps
+ * Phase 1's read-once in a while loop so the menu stays open until the
+ * user picks Quit (or hits Ctrl-D / Ctrl-C). After each sub-command
+ * finishes, prompts "Press Enter to continue…" before re-rendering the
+ * menu, so the diagnostic output isn't immediately scrolled away.
  *
  * Spawns the same `agi` binary that's currently running so the routing
  * goes back through the existing CLI surface (bash → TS commander).
@@ -144,18 +164,38 @@ export function renderMenu(): string {
  */
 export async function runDoctorMenu(opts?: { agiBin?: string }): Promise<MenuItemId> {
   const bin = opts?.agiBin ?? "agi";
-  process.stdout.write(renderMenu());
   const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let lastRan: MenuItemId = "quit";
   try {
-    const answer = await rl.question("  Pick a number (0 to quit): ");
-    const item = pickMenuItem(answer);
-    if (!item || item.id === "quit") {
+    while (true) {
+      process.stdout.write(renderMenu());
+      let answer: string;
+      try {
+        answer = await rl.question("  Pick a number (0 to quit): ");
+      } catch {
+        // EOF / Ctrl-D / Ctrl-C abort — treat as quit.
+        process.stdout.write("\n");
+        return lastRan;
+      }
+      const outcome = classifyMenuTurn(answer);
+      if (outcome.kind === "quit") {
+        process.stdout.write("\n");
+        return "quit";
+      }
+      if (outcome.kind === "invalid") {
+        process.stdout.write(`\n  Unknown selection: ${JSON.stringify(answer)}. Try again.\n`);
+        continue;
+      }
       process.stdout.write("\n");
-      return "quit";
+      spawnSync(bin, ["doctor", ...outcome.item.args], { stdio: "inherit" });
+      lastRan = outcome.item.id;
+      try {
+        await rl.question("\n  Press Enter to continue… ");
+      } catch {
+        process.stdout.write("\n");
+        return lastRan;
+      }
     }
-    process.stdout.write("\n");
-    spawnSync(bin, ["doctor", ...item.args], { stdio: "inherit" });
-    return item.id;
   } finally {
     rl.close();
   }

--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -106,7 +106,7 @@ Exits 0 on all-pass, 1 when any failed (warnings don't fail).
 
 #### agi doctor menu
 
-Interactive category menu (s144 t574 Phase 1). Prints a numbered list of diagnostic categories; you type a number, hit Enter, and the matching sub-command runs once before the menu exits.
+Interactive category menu (s144 t574). Prints a numbered list of diagnostic categories; you type a number, hit Enter, and the matching sub-command runs. After each pick, the menu prompts "Press Enter to continue…" and re-renders, so the diagnostic output isn't immediately scrolled away. Pick 0 (or Ctrl-D / Ctrl-C) to quit.
 
 ```bash
 agi doctor menu
@@ -114,7 +114,7 @@ agi doctor menu
 
 Categories: `Run all checks` (bare doctor) · `Validate config schemas` (schema) · `Write diagnostic bundle` (dump) · `Tail logs + crash-pattern detection` (logs) · `Read a gateway.json key` (config get) · `Legacy 5-check health` (health) · `Quit` (0).
 
-Phase 1 is read-once-and-exit. Phase 2+ adds arrow-key navigation, sub-menus, looped re-prompt, and Esc-to-back. For scripting, prefer the explicit sub-commands directly (`agi doctor schema`, `agi doctor dump`, etc.) — the menu is a discovery aid, not a scriptable surface.
+Phase 2 ships the loop + invalid-input retry. Phase 3+ adds arrow-key navigation, sub-menus per category, and Esc-to-back. For scripting, prefer the explicit sub-commands directly (`agi doctor schema`, `agi doctor dump`, etc.) — the menu is a discovery aid, not a scriptable surface.
 
 #### agi doctor health
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.636",
+  "version": "0.4.637",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
s144 t574 Phase 2 — wraps Phase 1 read-once menu in a while-loop. After each pick, prompts "Press Enter to continue..." then re-renders so the diagnostic output isn't immediately scrolled away. Invalid selections print an error and re-prompt; EOF / Ctrl-C abort cleanly as quit.

## Changes
- `doctor-menu.ts`: while-loop in `runDoctorMenu` + new `classifyMenuTurn` pure helper (testable)
- `doctor-menu.test.ts`: 6 new tests for `classifyMenuTurn` (quit / ran / invalid / empty / out-of-range / whitespace branches)
- `cli.md`: documents loop + retry behavior

## Test plan
- 19/19 unit tests pass (was 13, +6 for classifyMenuTurn).
- Manual: `agi doctor menu` → pick 2 → schema runs → "Press Enter to continue..." → re-renders → pick xyz → "Unknown selection" → re-prompts → pick 0 → exits.

## Phase 3+ (separate cycles)
Arrow-key nav, sub-menus per category, Esc-to-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)