### PR TITLE
v0.4.638 — s159 t689: GET /api/taskmaster/queue diagnostic surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.637",
+  "version": "0.4.638",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -81,6 +81,8 @@ import {
   type IssueIndexEntry,
   type IssueStatus,
 } from "./issues/index.js";
+import { dispatchJobsDir } from "./dispatch-paths.js";
+import { summarizeQueue, type DispatchJobLike } from "./taskmaster-queue-diagnostic.js";
 import type { IterativeWorkScheduler } from "./iterative-work/scheduler.js";
 import { cadenceToStaggeredCron } from "./iterative-work/cron.js";
 import {
@@ -2227,6 +2229,53 @@ export async function createGatewayRuntimeState(
       }
     }
     return reply.send({ issues: aggregated });
+  });
+
+  // s159 t689 — Taskmaster queue diagnostic surface (private network
+  // only). Reads dispatch job files from `~/.agi/{slug}/dispatch/jobs/`
+  // and rolls them up into a status-count summary + duplicate-group
+  // detection (same {planRef.planId, planRef.stepId} or same description
+  // hash across 2+ non-terminal jobs). Observability before action —
+  // operators can see queue-stacking forming BEFORE it's a crisis,
+  // ahead of the t695/t696/t697 idempotency/cooldown/breaker gates
+  // (which are blocked pending reproducer t694).
+  fastify.get("/api/taskmaster/queue", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) {
+      return reply.code(403).send({ error: "Taskmaster queue API only allowed from private network" });
+    }
+    const projectDirs = deps.workspaceProjects ?? [];
+    const query = request.query as Record<string, string>;
+    const pathParam = query["path"];
+    if (!pathParam) {
+      return reply.code(400).send({ error: "path query parameter is required" });
+    }
+    const targetPath = resolvePath(pathParam);
+    const isInWorkspace = projectDirs.some((dir) => targetPath.startsWith(resolvePath(dir)));
+    if (!isInWorkspace) {
+      return reply.code(403).send({ error: "Path is not inside a configured workspace.projects directory" });
+    }
+    const jobsDir = dispatchJobsDir(targetPath);
+    const jobs: DispatchJobLike[] = [];
+    try {
+      const files = readdirSync(jobsDir).filter((f) => f.endsWith(".json"));
+      for (const file of files) {
+        try {
+          const raw = readFileSync(`${jobsDir}/${file}`, "utf-8");
+          const parsed = JSON.parse(raw) as DispatchJobLike;
+          if (typeof parsed.id === "string") jobs.push(parsed);
+        } catch {
+          // Skip unreadable job files
+        }
+      }
+    } catch (err) {
+      const isNotFound = err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT";
+      if (!isNotFound) {
+        return reply.code(500).send({ error: `Failed to read jobs directory: ${err instanceof Error ? err.message : String(err)}` });
+      }
+      // ENOENT → empty queue
+    }
+    return reply.send({ projectPath: targetPath, summary: summarizeQueue(jobs), jobCount: jobs.length });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/gateway-core/src/taskmaster-queue-diagnostic.test.ts
+++ b/packages/gateway-core/src/taskmaster-queue-diagnostic.test.ts
@@ -1,0 +1,156 @@
+/**
+ * taskmaster-queue-diagnostic pure-logic tests (s159 t689).
+ *
+ * Covers idempotency-key derivation, duplicate-group detection,
+ * and queue summarization. No I/O — every test builds in-memory
+ * DispatchJobLike fixtures.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  detectDuplicateGroups,
+  idempotencyKey,
+  summarizeQueue,
+  type DispatchJobLike,
+} from "./taskmaster-queue-diagnostic.js";
+
+function job(overrides: Partial<DispatchJobLike> & { id: string }): DispatchJobLike {
+  return {
+    description: "do thing",
+    status: "pending",
+    projectPath: "/proj/a",
+    createdAt: "2026-05-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("idempotencyKey (s159 t689)", () => {
+  it("returns plan:<id>:<step> when planRef is present", () => {
+    expect(idempotencyKey({ id: "j1", planRef: { planId: "p1", stepId: "s2" } })).toBe("plan:p1:s2");
+  });
+
+  it("falls back to desc:<sha1-12> when planRef missing", () => {
+    const k = idempotencyKey({ id: "j2", description: "hello world" });
+    expect(k).toMatch(/^desc:[0-9a-f]{12}$/);
+  });
+
+  it("same description yields same desc-key (stable hashing)", () => {
+    const a = idempotencyKey({ id: "j1", description: "alpha" });
+    const b = idempotencyKey({ id: "j2", description: "alpha" });
+    expect(a).toBe(b);
+  });
+
+  it("different descriptions yield different desc-keys", () => {
+    const a = idempotencyKey({ id: "j1", description: "alpha" });
+    const b = idempotencyKey({ id: "j2", description: "beta" });
+    expect(a).not.toBe(b);
+  });
+
+  it("empty description gives a stable empty-string sha1 prefix", () => {
+    expect(idempotencyKey({ id: "j1", description: "" })).toMatch(/^desc:[0-9a-f]{12}$/);
+  });
+
+  it("planRef with only planId (no stepId) falls back to desc key", () => {
+    const k = idempotencyKey({ id: "j1", description: "x", planRef: { planId: "p1" } });
+    expect(k).toMatch(/^desc:/);
+  });
+});
+
+describe("detectDuplicateGroups (s159 t689)", () => {
+  it("returns empty for empty input", () => {
+    expect(detectDuplicateGroups([])).toEqual([]);
+  });
+
+  it("returns empty when no duplicates", () => {
+    const jobs = [
+      job({ id: "j1", description: "a" }),
+      job({ id: "j2", description: "b" }),
+    ];
+    expect(detectDuplicateGroups(jobs)).toEqual([]);
+  });
+
+  it("groups two same-description pending jobs", () => {
+    const jobs = [
+      job({ id: "j1", description: "ship that thing", createdAt: "2026-05-10T01:00:00.000Z" }),
+      job({ id: "j2", description: "ship that thing", createdAt: "2026-05-10T00:00:00.000Z" }),
+    ];
+    const groups = detectDuplicateGroups(jobs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.count).toBe(2);
+    expect(groups[0]?.jobIds).toEqual(["j1", "j2"]);
+    expect(groups[0]?.earliest).toBe("2026-05-10T00:00:00.000Z");
+  });
+
+  it("groups by planRef when both jobs share it", () => {
+    const jobs = [
+      job({ id: "j1", description: "diff text 1", planRef: { planId: "p", stepId: "s" } }),
+      job({ id: "j2", description: "diff text 2", planRef: { planId: "p", stepId: "s" } }),
+    ];
+    const groups = detectDuplicateGroups(jobs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.key).toBe("plan:p:s");
+  });
+
+  it("ignores terminal-status jobs (completed/error/cancelled/failed)", () => {
+    const jobs = [
+      job({ id: "j1", description: "x", status: "completed" }),
+      job({ id: "j2", description: "x", status: "error" }),
+      job({ id: "j3", description: "x", status: "cancelled" }),
+      job({ id: "j4", description: "x", status: "failed" }),
+      job({ id: "j5", description: "x", status: "pending" }),
+    ];
+    expect(detectDuplicateGroups(jobs)).toEqual([]);
+  });
+
+  it("sorts groups by count descending", () => {
+    const jobs = [
+      job({ id: "a1", description: "alpha" }),
+      job({ id: "a2", description: "alpha" }),
+      job({ id: "b1", description: "beta" }),
+      job({ id: "b2", description: "beta" }),
+      job({ id: "b3", description: "beta" }),
+    ];
+    const groups = detectDuplicateGroups(jobs);
+    expect(groups[0]?.count).toBe(3);
+    expect(groups[1]?.count).toBe(2);
+  });
+});
+
+describe("summarizeQueue (s159 t689)", () => {
+  it("counts by status", () => {
+    const jobs = [
+      job({ id: "j1", status: "pending" }),
+      job({ id: "j2", status: "running" }),
+      job({ id: "j3", status: "running" }),
+      job({ id: "j4", status: "completed" }),
+    ];
+    const s = summarizeQueue(jobs);
+    expect(s.total).toBe(4);
+    expect(s.byStatus).toEqual({ pending: 1, running: 2, completed: 1 });
+  });
+
+  it("oldestActiveAt skips terminal jobs", () => {
+    const jobs = [
+      job({ id: "j1", status: "completed", createdAt: "2026-05-10T00:00:00.000Z" }),
+      job({ id: "j2", status: "pending", createdAt: "2026-05-10T02:00:00.000Z" }),
+      job({ id: "j3", status: "running", createdAt: "2026-05-10T03:00:00.000Z" }),
+    ];
+    expect(summarizeQueue(jobs).oldestActiveAt).toBe("2026-05-10T02:00:00.000Z");
+  });
+
+  it("oldestActiveAt is null when no active jobs", () => {
+    const jobs = [
+      job({ id: "j1", status: "completed" }),
+      job({ id: "j2", status: "error" }),
+    ];
+    expect(summarizeQueue(jobs).oldestActiveAt).toBeNull();
+  });
+
+  it("exposes duplicate groups through summary", () => {
+    const jobs = [
+      job({ id: "j1", description: "x" }),
+      job({ id: "j2", description: "x" }),
+    ];
+    expect(summarizeQueue(jobs).duplicates).toHaveLength(1);
+  });
+});

--- a/packages/gateway-core/src/taskmaster-queue-diagnostic.ts
+++ b/packages/gateway-core/src/taskmaster-queue-diagnostic.ts
@@ -1,0 +1,138 @@
+/**
+ * Taskmaster queue diagnostic (s159 t689, 2026-05-10).
+ *
+ * Pure-logic helpers for inspecting the dispatch jobs directory. Used by
+ * the `GET /api/taskmaster/queue` endpoint to give operators visibility
+ * into the queue BEFORE it's a crisis — see same-keyed pending jobs
+ * stacking up, oldest pending age, total counts by status.
+ *
+ * Idempotency-key shape (s159 t695, pending reproducer): `{projectPath,
+ * planRef.planId, planRef.stepId}` when planRef is present. Without
+ * planRef, falls back to a stable description hash so same-text
+ * dispatches still cluster together in the duplicate detector. This is
+ * observability-only — the actual idempotency *gate* on enqueue waits
+ * for the reproducer to confirm the bug's exact path.
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * Shape of a dispatch job file as read from
+ * `~/.agi/{projectSlug}/dispatch/jobs/{jobId}.json`. Trimmed to the
+ * fields this module actually reads — extras are ignored.
+ */
+export interface DispatchJobLike {
+  id: string;
+  description?: string;
+  status?: string;
+  projectPath?: string;
+  createdAt?: string;
+  planRef?: { planId?: string; stepId?: string } | null;
+}
+
+/** One group of dispatch jobs that share an idempotency-key. */
+export interface DuplicateGroup {
+  /** The shared key — either `plan:<planId>:<stepId>` or `desc:<sha1-12>`. */
+  key: string;
+  /** Number of jobs in this group. Always ≥ 2 (groups of 1 are filtered). */
+  count: number;
+  /** Job ids in the group, in input order. */
+  jobIds: string[];
+  /** Earliest createdAt in the group, ISO string. */
+  earliest: string | null;
+}
+
+export interface QueueSummary {
+  /** Total jobs read. */
+  total: number;
+  /** Count by status (`pending`, `running`, `completed`, `error`, etc). */
+  byStatus: Record<string, number>;
+  /** Oldest non-terminal (pending/running) job's createdAt ISO. */
+  oldestActiveAt: string | null;
+  /** Duplicate groups — same idempotency key on 2+ jobs. */
+  duplicates: DuplicateGroup[];
+}
+
+const TERMINAL_STATUSES = new Set<string>(["completed", "error", "cancelled", "failed"]);
+
+/**
+ * Compute the idempotency-key candidate for one job. Matches the t695
+ * spec: `{projectPath, taskId, phase}` →
+ *   - `plan:<planId>:<stepId>` when planRef present
+ *   - `desc:<sha1-12>` fallback (12-char sha1 of description) when no planRef
+ *
+ * Pure: same input → same output. Exported so tests can pin the
+ * key-shape without re-deriving via group-detection.
+ */
+export function idempotencyKey(job: DispatchJobLike): string {
+  const planId = job.planRef?.planId;
+  const stepId = job.planRef?.stepId;
+  if (typeof planId === "string" && planId.length > 0 && typeof stepId === "string" && stepId.length > 0) {
+    return `plan:${planId}:${stepId}`;
+  }
+  const desc = typeof job.description === "string" ? job.description : "";
+  const hash = createHash("sha1").update(desc).digest("hex").slice(0, 12);
+  return `desc:${hash}`;
+}
+
+/**
+ * Find groups of 2+ jobs sharing an idempotency-key. Only considers
+ * non-terminal jobs (pending/running) — completed/error/cancelled past
+ * jobs are noise for queue-stacking detection.
+ *
+ * Pure function — no I/O, no side effects.
+ */
+export function detectDuplicateGroups(jobs: readonly DispatchJobLike[]): DuplicateGroup[] {
+  const groups = new Map<string, DispatchJobLike[]>();
+  for (const job of jobs) {
+    const status = typeof job.status === "string" ? job.status : "pending";
+    if (TERMINAL_STATUSES.has(status)) continue;
+    const key = idempotencyKey(job);
+    const bucket = groups.get(key) ?? [];
+    bucket.push(job);
+    groups.set(key, bucket);
+  }
+  const out: DuplicateGroup[] = [];
+  for (const [key, members] of groups) {
+    if (members.length < 2) continue;
+    const earliest = members
+      .map((m) => (typeof m.createdAt === "string" ? m.createdAt : null))
+      .filter((s): s is string => s !== null)
+      .sort()[0] ?? null;
+    out.push({
+      key,
+      count: members.length,
+      jobIds: members.map((m) => m.id),
+      earliest,
+    });
+  }
+  // Sort by count descending so the worst offender is first.
+  out.sort((a, b) => b.count - a.count);
+  return out;
+}
+
+/**
+ * Roll up jobs into a full queue summary. Used by the
+ * `GET /api/taskmaster/queue` endpoint payload.
+ *
+ * Pure function — no I/O, no side effects.
+ */
+export function summarizeQueue(jobs: readonly DispatchJobLike[]): QueueSummary {
+  const byStatus: Record<string, number> = {};
+  let oldestActiveAt: string | null = null;
+  for (const job of jobs) {
+    const status = typeof job.status === "string" ? job.status : "pending";
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+    if (!TERMINAL_STATUSES.has(status) && typeof job.createdAt === "string") {
+      if (oldestActiveAt === null || job.createdAt < oldestActiveAt) {
+        oldestActiveAt = job.createdAt;
+      }
+    }
+  }
+  return {
+    total: jobs.length,
+    byStatus,
+    oldestActiveAt,
+    duplicates: detectDuplicateGroups(jobs),
+  };
+}


### PR DESCRIPTION
s159 t689 — Taskmaster queue diagnostic surface. Reads dispatch job files from `~/.agi/{slug}/dispatch/jobs/`, rolls up status-count summary + duplicate-group detection (same `planRef:planId:stepId` OR same description-hash across 2+ non-terminal jobs). Observability before action — operators can see queue-stacking forming BEFORE it's a crisis, ahead of the t695/t696/t697 idempotency/cooldown/breaker gates (blocked on reproducer t694).

## Endpoint
`GET /api/taskmaster/queue?path=<projectPath>` — private network only. Returns:
- `summary.total` — total jobs read
- `summary.byStatus` — count map
- `summary.oldestActiveAt` — ISO timestamp of oldest non-terminal job
- `summary.duplicates[]` — `{key, count, jobIds, earliest}` for groups of 2+

## Idempotency-key shape
- `plan:<planId>:<stepId>` when both planRef parts present
- `desc:<sha1-12>` fallback (12-char sha1 of description)

Aligns with t695's planned key shape so the diagnostic and the eventual gate read the same shape.

## Test plan
- 16/16 pure-logic unit tests pass.
- Typecheck on `packages/gateway-core` green.
- Manual: hit endpoint with a project path → see jobs grouped.

## Doesn't fix the bug (yet)
This is observability only. The actual idempotency gate (t695), cooldown (t696), and circuit breaker (t697) wait for the live reproducer (t694) to confirm the exact path. Shipping the gate without the reproducer risks masking the real symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)