### PR TITLE
v0.4.639 — s134 t517: extract project mode-narrowing into pure helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.638",
+  "version": "0.4.639",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router";
 import { cn } from "@/lib/utils";
+import { computeVisibleModes, fallbackModeForCategory } from "@/lib/project-mode-narrowing";
 import { Callout } from "@particle-academy/react-fancy";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -241,17 +242,13 @@ export function ProjectDetail({
   }, [currentMode]);
 
   // s134 t517 slice 4 — auto-redirect when the default mode is hidden
-  // by the project's category (literature/media/administration). Pick
-  // the first visible mode for that category.
+  // by the project's category. See lib/project-mode-narrowing.ts for
+  // the rule (literature/media/administration hide develop; literature
+  // and media also hide operate).
   useEffect(() => {
     const cat = project?.category ?? project?.projectType?.category;
-    const hideDevelop = cat === "literature" || cat === "media" || cat === "administration";
-    const hideOperate = cat === "literature" || cat === "media";
-    if (currentMode === "develop" && hideDevelop) {
-      setCurrentMode(hideOperate ? "coordinate" : "operate");
-    } else if (currentMode === "operate" && hideOperate) {
-      setCurrentMode("coordinate");
-    }
+    const fallback = fallbackModeForCategory(currentMode, cat);
+    if (fallback !== null) setCurrentMode(fallback);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [project?.category, project?.projectType?.category]);
 
@@ -598,13 +595,7 @@ export function ProjectDetail({
           - Otherwise (web/app/monorepo/ops): all 4 modes visible */}
       {!isCoreFork && (() => {
         const cat = project.category ?? project.projectType?.category;
-        const hideDevelop = cat === "literature" || cat === "media" || cat === "administration";
-        const hideOperate = cat === "literature" || cat === "media";
-        const visibleModes = (["develop", "operate", "coordinate", "insight"] as const).filter((m) => {
-          if (m === "develop" && hideDevelop) return false;
-          if (m === "operate" && hideOperate) return false;
-          return true;
-        });
+        const visibleModes = computeVisibleModes(cat);
         return (
           <div className="flex items-center gap-1 mb-3 border-b border-border" data-testid="project-mode-picker">
             {visibleModes.map((mode) => (

--- a/ui/dashboard/src/lib/project-mode-narrowing.test.ts
+++ b/ui/dashboard/src/lib/project-mode-narrowing.test.ts
@@ -1,0 +1,84 @@
+/**
+ * project-mode-narrowing pure-logic tests (s134 t517 item 8 follow-up).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ALL_PROJECT_MODES,
+  computeVisibleModes,
+  fallbackModeForCategory,
+  isModeHiddenForCategory,
+} from "./project-mode-narrowing.js";
+
+describe("isModeHiddenForCategory (s134 t517)", () => {
+  it("hides develop for literature/media/administration", () => {
+    expect(isModeHiddenForCategory("develop", "literature")).toBe(true);
+    expect(isModeHiddenForCategory("develop", "media")).toBe(true);
+    expect(isModeHiddenForCategory("develop", "administration")).toBe(true);
+  });
+
+  it("hides operate for literature/media but NOT administration", () => {
+    expect(isModeHiddenForCategory("operate", "literature")).toBe(true);
+    expect(isModeHiddenForCategory("operate", "media")).toBe(true);
+    expect(isModeHiddenForCategory("operate", "administration")).toBe(false);
+  });
+
+  it("never hides coordinate or insight", () => {
+    for (const cat of ["literature", "media", "administration", "app", "web", "ops"]) {
+      expect(isModeHiddenForCategory("coordinate", cat)).toBe(false);
+      expect(isModeHiddenForCategory("insight", cat)).toBe(false);
+    }
+  });
+
+  it("treats null/undefined/unknown category as no narrowing", () => {
+    for (const mode of ALL_PROJECT_MODES) {
+      expect(isModeHiddenForCategory(mode, null)).toBe(false);
+      expect(isModeHiddenForCategory(mode, undefined)).toBe(false);
+      expect(isModeHiddenForCategory(mode, "anything-else")).toBe(false);
+    }
+  });
+});
+
+describe("computeVisibleModes (s134 t517)", () => {
+  it("returns all 4 modes for app/web/ops/unknown", () => {
+    for (const cat of ["app", "web", "ops", null, undefined, "made-up"]) {
+      expect(computeVisibleModes(cat)).toEqual(["develop", "operate", "coordinate", "insight"]);
+    }
+  });
+
+  it("returns coordinate+insight for literature/media", () => {
+    expect(computeVisibleModes("literature")).toEqual(["coordinate", "insight"]);
+    expect(computeVisibleModes("media")).toEqual(["coordinate", "insight"]);
+  });
+
+  it("returns operate+coordinate+insight for administration", () => {
+    expect(computeVisibleModes("administration")).toEqual(["operate", "coordinate", "insight"]);
+  });
+
+  it("always preserves ALL_PROJECT_MODES order", () => {
+    const modes = computeVisibleModes("administration");
+    expect(modes.indexOf("operate")).toBeLessThan(modes.indexOf("coordinate"));
+    expect(modes.indexOf("coordinate")).toBeLessThan(modes.indexOf("insight"));
+  });
+});
+
+describe("fallbackModeForCategory (s134 t517)", () => {
+  it("returns null when current mode is still visible", () => {
+    expect(fallbackModeForCategory("coordinate", "literature")).toBeNull();
+    expect(fallbackModeForCategory("develop", "app")).toBeNull();
+  });
+
+  it("redirects develop to operate when only develop is hidden", () => {
+    expect(fallbackModeForCategory("develop", "administration")).toBe("operate");
+  });
+
+  it("redirects develop to coordinate for literature/media", () => {
+    expect(fallbackModeForCategory("develop", "literature")).toBe("coordinate");
+    expect(fallbackModeForCategory("develop", "media")).toBe("coordinate");
+  });
+
+  it("redirects operate to coordinate for literature/media", () => {
+    expect(fallbackModeForCategory("operate", "literature")).toBe("coordinate");
+    expect(fallbackModeForCategory("operate", "media")).toBe("coordinate");
+  });
+});

--- a/ui/dashboard/src/lib/project-mode-narrowing.ts
+++ b/ui/dashboard/src/lib/project-mode-narrowing.ts
@@ -1,0 +1,83 @@
+/**
+ * Project mode narrowing (s134 t517 item 8 follow-up, 2026-05-10).
+ *
+ * Centralizes the per-category mode-visibility rule that was previously
+ * inlined at two call sites in ProjectDetail.tsx. Keeping it in one
+ * place + unit-testable means future category additions (or rule
+ * tweaks) don't need to be replicated and don't drift between the
+ * auto-redirect useEffect and the mode-picker render.
+ *
+ * Rule (per s134 t517 slice 4):
+ *   - `literature` and `media` projects hide `develop` and `operate` modes.
+ *   - `administration` projects hide `develop` mode (operate is still visible).
+ *   - All other categories show every mode.
+ *
+ * The category itself can be sourced from either `project.category`
+ * (top-level, set by ops mode) or `project.projectType.category`
+ * (declared by the project type registry). Both call sites use the
+ * same `cat ?? projectType.category` resolution.
+ */
+
+export type ProjectMode = "develop" | "operate" | "coordinate" | "insight";
+
+export const ALL_PROJECT_MODES: readonly ProjectMode[] = [
+  "develop",
+  "operate",
+  "coordinate",
+  "insight",
+] as const;
+
+/**
+ * The four content-category labels that narrow the visible-modes set.
+ * Other categories (web, app, etc.) leave all modes visible.
+ */
+export type NarrowingCategory = "literature" | "media" | "administration";
+
+/**
+ * Is the given mode hidden for the project's category? Pure function;
+ * mirrored exactly from the inline check in ProjectDetail.tsx.
+ *
+ *   literature → hide develop + operate
+ *   media → hide develop + operate
+ *   administration → hide develop
+ *   anything else → hide nothing
+ */
+export function isModeHiddenForCategory(
+  mode: ProjectMode,
+  category: string | null | undefined,
+): boolean {
+  if (mode === "develop") {
+    return category === "literature" || category === "media" || category === "administration";
+  }
+  if (mode === "operate") {
+    return category === "literature" || category === "media";
+  }
+  return false;
+}
+
+/**
+ * Compute the ordered list of modes visible for a category. Always
+ * preserves `ALL_PROJECT_MODES` order; just filters out the hidden
+ * ones. Returns at least `coordinate` and `insight` for every input
+ * (those two are never narrowed).
+ */
+export function computeVisibleModes(category: string | null | undefined): ProjectMode[] {
+  return ALL_PROJECT_MODES.filter((m) => !isModeHiddenForCategory(m, category));
+}
+
+/**
+ * Pick the first visible mode when the current selection got narrowed
+ * out. Returns the next selection or null if `current` is still
+ * visible (caller should keep the current mode).
+ *
+ * Useful for the auto-redirect useEffect that flips selection when the
+ * project's category changes.
+ */
+export function fallbackModeForCategory(
+  current: ProjectMode,
+  category: string | null | undefined,
+): ProjectMode | null {
+  if (!isModeHiddenForCategory(current, category)) return null;
+  const visible = computeVisibleModes(category);
+  return visible[0] ?? "coordinate";
+}


### PR DESCRIPTION
s134 t517 small slice — DRY out the per-category mode-visibility rule that was inlined at two sites in ProjectDetail.tsx (auto-redirect useEffect + mode-picker render). Extracted to `ui/dashboard/src/lib/project-mode-narrowing.ts`.

## Pure helpers
- `isModeHiddenForCategory(mode, category)` — boolean predicate
- `computeVisibleModes(category)` — ordered ProjectMode[]
- `fallbackModeForCategory(current, category)` — next mode when current is hidden, else null

## Rule (mirrored exactly from inline)
- `literature`, `media` → hide develop + operate
- `administration` → hide develop
- anything else → all 4 modes visible

## Test plan
- 12 new pure-logic unit tests pass (all 4 modes × all 4 categories + null/undefined/unknown).
- ProjectDetail.tsx auto-redirect + mode-picker render now call helpers — no duplication.

Pre-existing typecheck errors in unrelated files (`system-agents.tsx`, `system-incidents.tsx`, `workflows.tsx`) are NOT introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)