### PR TITLE
v0.4.641 — typecheck drift broom 2: root.tsx 8 errors + OwnerChannels index sig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.640",
+  "version": "0.4.641",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ProfileCard.tsx
+++ b/ui/dashboard/src/components/ProfileCard.tsx
@@ -76,7 +76,12 @@ export interface ProfileCardTheme {
 export interface ProfileCardProps {
   displayName: string;
   tagline?: string;
-  channels?: Record<string, string | undefined>;
+  /** Channel id → display value. Accepts both the named-key `OwnerChannels`
+   *  interface (telegram/discord/signal/whatsapp/email) and the generic
+   *  index-signature shape via overlapping intersection. The component
+   *  iterates entries indiscriminately, so any object with string-or-undefined
+   *  values is safe. */
+  channels?: { readonly [key: string]: string | undefined };
   dmPolicy?: "pairing" | "open";
   theme?: ProfileCardTheme;
   className?: string;

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -33,7 +33,7 @@ import { ProfileCard } from "@/components/ProfileCard.js";
 import { useConfig, useDashboardWS, useHosting, useIsMobile, useLogStream, useOverview, useProjectConfigWS, useProjects } from "@/hooks.js";
 import { useTheme } from "@/lib/theme-provider";
 import { Chart, Icon } from "@particle-academy/react-fancy";
-import { checkForUpdates, startUpgrade, fetchUpgradeLog, fetchNotifications, markNotificationsRead, markAllNotificationsRead, executeProjectTool, fetchOnboardingState, fetchAuthStatus, fetchCurrentUser, logoutDashboard, fetchProviderBalances, fetchBalanceHistory } from "@/api.js";
+import { checkForUpdates, startUpgrade, fetchUpgradeLog, fetchNotifications, markNotificationsRead, markAllNotificationsRead, executeProjectTool, fetchOnboardingState, fetchAuthStatus, fetchCurrentUser, fetchProviderBalances, fetchBalanceHistory } from "@/api.js";
 import type { ProviderBalance } from "@/api.js";
 import { LoginPage } from "@/components/LoginPage.js";
 import type { ActivityEntry, DashboardEvent, Notification, ProjectActivity, TimeBucket, UpdateCheck } from "@/types.js";
@@ -262,8 +262,8 @@ export default function RootLayout() {
   // If a recent upgrade happened, restore logs so the user sees the full history.
   useEffect(() => {
     fetchUpgradeLog().then((entries) => {
-      if (entries.length === 0) return;
       const last = entries[entries.length - 1];
+      if (!last) return;
       // Skip stale logs (older than 5 minutes)
       const lastTs = new Date(last.timestamp).getTime();
       if (Date.now() - lastTs > 5 * 60_000) return;
@@ -372,13 +372,6 @@ export default function RootLayout() {
     setUnreadCount(0);
   }, []);
 
-  const handleLogout = useCallback(() => {
-    logoutDashboard().then(() => {
-      setAuthenticated(false);
-      setCurrentUser(null);
-    }).catch(() => {});
-  }, []);
-
   // Real-time WebSocket updates
   const handleEvent = useCallback((event: DashboardEvent) => {
     if (event.type === "impact:recorded") {
@@ -477,8 +470,8 @@ export default function RootLayout() {
     const poll = setInterval(() => {
       fetchUpgradeLog()
         .then((entries) => {
-          if (entries.length === 0) return;
           const last = entries[entries.length - 1];
+          if (!last) return;
           if (last.step === "complete" && last.status === "done") {
             clearInterval(poll);
             upgradePollRef.current = null;

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -575,6 +575,11 @@ export interface OwnerChannels {
   signal?: string;
   whatsapp?: string;
   email?: string;
+  /** Index signature lets the shape interop with `Record<string, string | undefined>`
+   *  consumers (e.g. ProfileCard) without per-call casts. Future channels added
+   *  to the named-key list are still type-checked via the explicit optional
+   *  properties above. */
+  [key: string]: string | undefined;
 }
 
 export interface OwnerConfig {


### PR DESCRIPTION
Continues PR #151's drift broom. Eight tsc errors in `root.tsx` + the related `OwnerChannels`/`ProfileCard` channel-shape mismatch.

## Fixes
- **`root.tsx`** — 7× `'last' is possibly undefined`. Switched to `const last = entries[entries.length - 1]; if (!last) return;` pattern at both `fetchUpgradeLog().then` sites (matches `noUncheckedIndexedAccess` semantics).
- **`root.tsx`** — removed dead-code `handleLogout` callback + its now-unused `logoutDashboard` import.
- **`types.ts`** — added index signature `[key: string]: string | undefined` to `OwnerChannels` interface. Lets the shape interop with `Record<string, string | undefined>` consumers (e.g. `ProfileCard`) without per-call casts. Named keys (telegram/discord/signal/whatsapp/email) remain explicitly typed.
- **`ProfileCard.tsx`** — tightened `channels` prop type from `Record<...>` to a readonly index signature.

## Out of scope (next broom slice)
8 unrelated tsc errors remain (issues/pm-kanban JSX namespace, marketplace `newInMarketplace` + Modal `showCloseButton`, magic-app-detail nullable narrowing, overview TabsList variant, project-detail unused PageScroll).

## Test plan
- `npx tsc --noEmit -p ui/dashboard` — the 8 root.tsx errors are gone (8 unrelated errors remain).
- No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)