### PR TITLE
v0.4.642 — typecheck drift broom 3: 8 errors fixed across dashboard routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.641",
+  "version": "0.4.642",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/routes/issues.tsx
+++ b/ui/dashboard/src/routes/issues.tsx
@@ -5,10 +5,11 @@
  * Mirrors /reports's shape (PageScroll wrapper around a list panel).
  */
 
+import type { ReactElement } from "react";
 import { IssuesPanel } from "@/components/IssuesPanel.js";
 import { PageScroll } from "@/components/PageScroll.js";
 
-export default function IssuesPage(): JSX.Element {
+export default function IssuesPage(): ReactElement {
   return (
     <PageScroll>
       <div className="space-y-4">

--- a/ui/dashboard/src/routes/magic-app-detail.tsx
+++ b/ui/dashboard/src/routes/magic-app-detail.tsx
@@ -59,11 +59,11 @@ export default function MagicAppDetailPage() {
       <div className="grid grid-cols-2 gap-4 mb-6">
         <Card className="p-4">
           <div className="text-xs text-muted-foreground mb-1">Project Types</div>
-          <div className="text-sm font-semibold">{app.projectTypes.join(", ") || "None"}</div>
+          <div className="text-sm font-semibold">{(app.projectTypes ?? []).join(", ") || "None"}</div>
         </Card>
         <Card className="p-4">
           <div className="text-xs text-muted-foreground mb-1">Categories</div>
-          <div className="text-sm font-semibold">{app.projectCategories.join(", ") || "None"}</div>
+          <div className="text-sm font-semibold">{(app.projectCategories ?? []).join(", ") || "None"}</div>
         </Card>
         <Card className="p-4">
           <div className="text-xs text-muted-foreground mb-1">Agent Prompts</div>

--- a/ui/dashboard/src/routes/marketplace.tsx
+++ b/ui/dashboard/src/routes/marketplace.tsx
@@ -438,7 +438,7 @@ function PluginDetailDialog({
           )}
         </div>
 
-        <DialogFooter showCloseButton>
+        <DialogFooter>
           {onAction && actionLabel && (
             <Button
               variant={actionLabel === "Uninstall" ? "destructive" : "default"}
@@ -672,7 +672,7 @@ function InstalledTab() {
   const { toast } = useToast();
   const [items, setItems] = useState<PluginMarketplaceInstalledItem[]>([]);
   const [updates, setUpdates] = useState<PluginMarketplaceUpdate[]>([]);
-  const [newInMarketplace, setNewInMarketplace] = useState<{ pluginName: string; version: string; description: string }[]>([]);
+  const [, setNewInMarketplace] = useState<{ pluginName: string; version: string; description: string }[]>([]);
   const [catalog, setCatalog] = useState<PluginMarketplaceCatalogItem[]>([]);
   const [sources, setSources] = useState<PluginMarketplaceSource[]>([]);
   const [uninstalling, setUninstalling] = useState<string | null>(null);

--- a/ui/dashboard/src/routes/overview.tsx
+++ b/ui/dashboard/src/routes/overview.tsx
@@ -38,7 +38,7 @@ export default function OverviewPage() {
   return (
     <PageScroll>
       <Tabs defaultValue="usage">
-        <TabsList variant="line">
+        <TabsList>
           <TabsTrigger value="usage">Usage &amp; Cost</TabsTrigger>
           <TabsTrigger value="impactinomics">Impactinomics</TabsTrigger>
         </TabsList>

--- a/ui/dashboard/src/routes/pm-kanban.tsx
+++ b/ui/dashboard/src/routes/pm-kanban.tsx
@@ -5,10 +5,11 @@
  * Mirrors the /issues + /sync-conflicts page shape.
  */
 
+import type { ReactElement } from "react";
 import { PmKanbanPanel } from "@/components/PmKanbanPanel.js";
 import { PageScroll } from "@/components/PageScroll.js";
 
-export default function PmKanbanPage(): JSX.Element {
+export default function PmKanbanPage(): ReactElement {
   return (
     <PageScroll>
       <div className="space-y-4">

--- a/ui/dashboard/src/routes/project-detail.tsx
+++ b/ui/dashboard/src/routes/project-detail.tsx
@@ -5,7 +5,6 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
 import { ProjectDetail } from "@/components/ProjectDetail.js";
-import { PageScroll } from "@/components/PageScroll.js";
 import { useRootContext } from "./root.js";
 import { useIsTestVm } from "@/hooks/useRuntimeMode.js";
 import { formatSecurityFixPrompt } from "@/lib/security-fix-prompt.js";


### PR DESCRIPTION
Continues PR #151/#152's drift broom. Eight typecheck errors resolved across dashboard routes.

## Fixes
- **`issues.tsx`, `pm-kanban.tsx`** — `JSX.Element` global gone in React 19 → `ReactElement` import.
- **`magic-app-detail.tsx`** — `app.projectTypes` / `app.projectCategories` typed as optional; wrapped in `?? []` for safe iteration.
- **`overview.tsx`** — `TabsList variant="line"` prop removed in newer react-fancy.
- **`project-detail.tsx`** — removed unused `PageScroll` import.
- **`marketplace.tsx`** — `newInMarketplace` destructure-dropped (setter still drives state for future readers); `DialogFooter showCloseButton` prop removed (not in upstream Modal.Footer props).

## Remaining iceberg (next slice)
- `hf-marketplace.tsx` — ~7 type-drift errors (status union missing `failed`, kind union missing `ollama`/`custom`). Source-of-truth type investigation needed, not mechanical fix.
- `admin-dashboard.tsx` — `ServiceInfo.type` drift.

## Test plan
- `npx tsc --noEmit -p ui/dashboard` — the 8 targeted errors are gone (hf-marketplace cluster remains).
- No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)