### PR TITLE
v0.4.643 — typecheck drift broom 4: hf-marketplace cluster (type unions + cleanup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.642",
+  "version": "0.4.643",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/hooks.ts
+++ b/ui/dashboard/src/hooks.ts
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { DashboardEvent, LogEntry, AionimaConfig, ReportSummary, ReportDetail, HFModelSearchResult, CoreForkStatus } from "./types.js";
+import type { DashboardEvent, LogEntry, AionimaConfig, HFModelSearchResult, CoreForkStatus } from "./types.js";
 import {
   fetchOverview, fetchConfig, saveConfig,
   fetchProjects, createProject, updateProject, deleteProject,

--- a/ui/dashboard/src/routes/hf-marketplace.tsx
+++ b/ui/dashboard/src/routes/hf-marketplace.tsx
@@ -26,7 +26,6 @@ import {
   useHFHardwareProfile,
   useHFModels,
   useHFInstalledModels,
-  useHFRunningModels,
   useHFDatasets,
   useHFInstalledDatasets,
   useFineTuneJobs,
@@ -49,7 +48,6 @@ import {
 import type {
   HFModelSearchResult,
   HFInstalledModel,
-  HFRunningModel,
   HFCompatibility,
   HFModelStatus,
   HFModelDetail,
@@ -168,6 +166,7 @@ function getStatusLabel(s: HFModelStatus): string {
     case "running": return "Running";
     case "stopping": return "Stopping...";
     case "error": return "Error";
+    case "failed": return "Failed";
     case "removing": return "Removing...";
   }
 }
@@ -181,15 +180,6 @@ function getTierColor(tier: HFHardwareTier): string {
   }
 }
 
-function formatUptime(startedAt: string): string {
-  const ms = Date.now() - new Date(startedAt).getTime();
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ${s % 60}s`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${m % 60}m`;
-}
 
 /** Returns a plain-English quality label for a quantization level. */
 function getQuantLabel(q: HFQuantization | null): string {
@@ -515,7 +505,7 @@ function ModelWizardDialog({
                   <p className="text-[11px] text-muted-foreground">
                     {(analysis.customDefinition["description"] as string | undefined) ?? "This model uses a custom container runtime."}
                   </p>
-                  {analysis.customDefinition["sourceRepo"] && (
+                  {Boolean(analysis.customDefinition["sourceRepo"]) && (
                     <p className="text-[10px] text-muted-foreground">
                       Source: <span className="font-mono">{analysis.customDefinition["sourceRepo"] as string}</span>
                     </p>
@@ -539,7 +529,7 @@ function ModelWizardDialog({
                   <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2">
                     {analysis.customDefinition && (
                       <>
-                        {analysis.customDefinition["sourceRepo"] && (
+                        {Boolean(analysis.customDefinition["sourceRepo"]) && (
                           <div>
                             <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Source Repository</p>
                             <p className="text-[12px] font-mono mt-0.5">{analysis.customDefinition["sourceRepo"] as string}</p>

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -1438,7 +1438,7 @@ export interface ScanProvider {
 // ---------------------------------------------------------------------------
 
 export type HFCompatibility = "compatible" | "limited" | "incompatible";
-export type HFModelStatus = "downloading" | "ready" | "starting" | "running" | "stopping" | "error" | "removing";
+export type HFModelStatus = "downloading" | "ready" | "starting" | "running" | "stopping" | "error" | "failed" | "removing";
 export type HFModelFormat = "gguf" | "safetensors" | "pytorch" | "onnx" | "tensorflow";
 export type HFQuantization = "Q2_K" | "Q3_K_S" | "Q3_K_M" | "Q3_K_L" | "Q4_0" | "Q4_K_S" | "Q4_K_M" | "Q5_0" | "Q5_K_S" | "Q5_K_M" | "Q6_K" | "Q8_0" | "F16" | "F32";
 export type HFCapabilityStatus = "on" | "limited" | "off";
@@ -1534,7 +1534,7 @@ export interface HFInstalledModel {
   revision: string;
   displayName: string;
   pipelineTag: string;
-  runtimeType: "llm" | "diffusion" | "general";
+  runtimeType: "llm" | "diffusion" | "general" | "ollama" | "custom";
   filePath: string;
   modelFilename?: string;
   fileSizeBytes: number;
@@ -1553,7 +1553,7 @@ export interface HFRunningModel {
   containerId: string;
   containerName: string;
   port: number;
-  runtimeType: "llm" | "diffusion" | "general";
+  runtimeType: "llm" | "diffusion" | "general" | "ollama" | "custom";
   startedAt: string;
   status: "running" | "stopped" | "error";
   /** Result of a live /health probe at the moment this record was fetched. */


### PR DESCRIPTION
Drift broom continues. Investigation per cycle 185's plan: the hf-marketplace consumer checks `model.status === 'failed'` and `model.runtimeType === 'ollama' / 'custom'` — but the type unions in types.ts excluded those values. Resolution: the unions were too narrow (consumer's substantive UI paths handle the missing cases).

## Type union extensions
- **`HFModelStatus`** — adds `failed` alongside `error` (per-container fail-vs-error distinction observable in podman).
- **`HFInstalledModel.runtimeType`** + **`HFRunningModel.runtimeType`** — adds `ollama` and `custom`. UI already routes both: ollama renders `Available via Ollama` span; custom drives the `isCustom` flow + Custom Runtime Detected callout.

## Consumer cleanup
- **`hf-marketplace.tsx`**: removed dead-code `useHFRunningModels` + `HFRunningModel` + `formatUptime` imports.
- **`hf-marketplace.tsx`**: `getStatusLabel` exhaustive switch gains `failed` case.
- **`hf-marketplace.tsx`**: 3× `customDefinition[...]` truthiness checks wrapped in `Boolean()` to coerce `unknown` to `boolean` for JSX.
- **`hooks.ts`**: removed orphan `ReportSummary` / `ReportDetail` imports.

## Out of scope (next broom slice)
13 unrelated errors remain in dialog/table/tabs UI wrappers, markdown.tsx, sacred-projects.ts, theme-provider.tsx, component-contracts.test.ts, admin-dashboard.tsx.

## Test plan
- `npx tsc --noEmit -p ui/dashboard` — the hf-marketplace + hooks errors are gone.
- No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)