### PR TITLE
v0.4.644 — typecheck drift broom 5: UI wrappers + lib + admin-dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.643",
+  "version": "0.4.644",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/ui/dialog.tsx
+++ b/ui/dashboard/src/components/ui/dialog.tsx
@@ -7,7 +7,7 @@
 
 import { Modal } from "@particle-academy/react-fancy";
 import { cn } from "@particle-academy/react-fancy";
-import type { ComponentProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface DialogProps {
   open?: boolean;
@@ -17,7 +17,7 @@ interface DialogProps {
 
 function Dialog({ open, onOpenChange, children }: DialogProps) {
   return (
-    <Modal open={open} onClose={() => onOpenChange?.(false)}>
+    <Modal open={open ?? false} onClose={() => onOpenChange?.(false)}>
       {children}
     </Modal>
   );

--- a/ui/dashboard/src/components/ui/table.tsx
+++ b/ui/dashboard/src/components/ui/table.tsx
@@ -9,6 +9,9 @@ const TableBody = Table.Body;
 const TableRow = Table.Row;
 const TableHead = Table.Column;
 const TableCell = Table.Cell;
-const TableFooter = Table.Footer;
 
-export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableFooter };
+// Note: `Table.Footer` was removed in a newer @particle-academy/react-fancy
+// release. No consumers reference the previously-exported `TableFooter`, so
+// the re-export is dropped (rather than substituting a hand-rolled <tfoot>).
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/ui/dashboard/src/components/ui/tabs.tsx
+++ b/ui/dashboard/src/components/ui/tabs.tsx
@@ -13,8 +13,21 @@ interface TabsProps {
   children?: ReactNode;
 }
 
-function TabsRoot({ defaultValue, value, onValueChange, ...props }: TabsProps) {
-  return <Tabs defaultTab={defaultValue} activeTab={value} onTabChange={onValueChange} {...props} />;
+function TabsRoot({ defaultValue, value, onValueChange, children, className }: TabsProps) {
+  // react-fancy@2.9 `Tabs` requires `children` as a non-optional prop. Pass it
+  // explicitly (rather than relying on the rest-spread to forward) so the
+  // wrapper's optional `children?: ReactNode` shape stays compatible with
+  // the upstream's required signature without `as any` casts.
+  return (
+    <Tabs
+      defaultTab={defaultValue}
+      activeTab={value}
+      onTabChange={onValueChange}
+      className={className}
+    >
+      {children}
+    </Tabs>
+  );
 }
 
 const TabsList = Tabs.List;

--- a/ui/dashboard/src/lib/component-contracts.test.ts
+++ b/ui/dashboard/src/lib/component-contracts.test.ts
@@ -11,8 +11,8 @@
  * (no jsdom needed) — validates prop shapes against known contracts.
  */
 
-import { describe, it, expect } from "vitest";
-import { readFileSync, readdirSync, statSync } from "node:fs";
+import { describe, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
 import { join, extname } from "node:path";
 
 // ---------------------------------------------------------------------------

--- a/ui/dashboard/src/lib/markdown.tsx
+++ b/ui/dashboard/src/lib/markdown.tsx
@@ -100,7 +100,7 @@ function MockupBlock({ json }: { json: string }) {
           </div>
         </div>
       </div>
-      {data.description && (
+      {Boolean(data.description) && (
         <p style={{ fontSize: "12px", color: "var(--color-subtext0)", margin: "4px 0 8px" }}>{String(data.description)}</p>
       )}
       <div style={{ fontSize: "10px", color: "var(--color-muted-foreground)", fontFamily: "monospace", background: "var(--color-surface0)", borderRadius: "4px", padding: "6px 8px", maxHeight: "200px", overflow: "auto" }}>

--- a/ui/dashboard/src/lib/sacred-projects.ts
+++ b/ui/dashboard/src/lib/sacred-projects.ts
@@ -20,8 +20,10 @@ export const PAX_SACRED_PROJECTS = [
   { id: "fancy-echarts", name: "fancy-echarts" },
 ] as const;
 
-const SACRED_IDS = new Set(SACRED_PROJECTS.map((p) => p.id));
-const PAX_IDS = new Set(PAX_SACRED_PROJECTS.map((p) => p.id));
+// Widen Set element type to string so .has(arbitraryString) typechecks
+// against the literal-typed `as const` source arrays.
+const SACRED_IDS = new Set<string>(SACRED_PROJECTS.map((p) => p.id));
+const PAX_IDS = new Set<string>(PAX_SACRED_PROJECTS.map((p) => p.id));
 
 function normalize(value: string | undefined | null): string {
   return (value ?? "").trim().toLowerCase();

--- a/ui/dashboard/src/lib/theme-provider.tsx
+++ b/ui/dashboard/src/lib/theme-provider.tsx
@@ -9,7 +9,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { builtInThemes, SEMANTIC_KEYS } from "../themes/index.js";
-import type { BuiltInTheme } from "../themes/index.js";
 import { safeArray } from "./utils.js";
 
 // ---------------------------------------------------------------------------

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -711,6 +711,9 @@ export interface ServiceInfo {
   enabled: boolean;
   /** When false, the container image is not locally available. Omitting the field is treated as true (backward compat). */
   imageAvailable?: boolean;
+  /** Optional service-kind label (e.g., "database", "cache"). Consumer
+   *  defaults to "service" when absent. */
+  type?: string;
   /** Extension capabilities provided by this service (e.g. pgvector, PostGIS). */
   extensions?: string[];
 }


### PR DESCRIPTION
Drift broom continues. 13 errors fixed across UI re-export wrappers, lib helpers, and types.ts.

## Fixes
- **`ui/tabs.tsx`** — `TabsRoot` passes `children` explicitly (react-fancy@2.9 `Tabs` requires children as non-optional).
- **`ui/dialog.tsx`** — Modal `open` prop now strict boolean; coerced via `open ?? false`. Removed unused `ComponentProps` import.
- **`ui/table.tsx`** — `Table.Footer` removed in newer react-fancy; dropped unused `TableFooter` re-export (no consumers).
- **`lib/sacred-projects.ts`** — `SACRED_IDS` / `PAX_IDS` widened to `Set<string>` so `.has(arbitraryString)` typechecks against literal-typed `as const` source arrays.
- **`lib/theme-provider.tsx`** — removed orphan `BuiltInTheme` import.
- **`lib/markdown.tsx`** — `Boolean()` wrap on unknown-truthiness JSX expression.
- **`lib/component-contracts.test.ts`** — removed unused `expect` + `statSync` imports.
- **`types.ts`** — `ServiceInfo` gains optional `type?: string` (admin-dashboard's defensive `svc.type ?? 'service'` fallback now typed).

## Remaining drift (~8 errors, next broom)
- `components/settings/DevSettings.tsx` — missing `Link` import; an index-narrowing issue at line 462.
- `components/settings/GatewayNetworkSettings.tsx` — refs `autoSyncMarketplace`, `maxToolLoops` not in `GatewayConfig` (likely schema rename).
- `components/settings/ServiceControlSection.tsx` — unused `allInstalled`.
- `components/ui/badge.tsx` — unused `ReactNode`.
- `components/ui/button.tsx` — Button variant union missing `"outline"` and `"link"` (react-fancy shape changed).

## Test plan
- `npx tsc --noEmit -p ui/dashboard` — these 13 errors gone.
- No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)