### PR TITLE
v0.4.646 — typecheck drift broom 6 (hard cap): settings + ui/button + ui/badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.645",
+  "version": "0.4.646",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -844,6 +844,9 @@ export interface TestVmStatus {
     postgres: string;
     caddy: string;
     agi: string;
+    /** Local-ID service status. Optional for back-compat with older
+     *  /api/test-vm/status responses that don't surface it yet. */
+    id?: string;
   };
 }
 

--- a/ui/dashboard/src/components/settings/DevSettings.tsx
+++ b/ui/dashboard/src/components/settings/DevSettings.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
 import { Callout } from "@particle-academy/react-fancy";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";

--- a/ui/dashboard/src/components/settings/ServiceControlSection.tsx
+++ b/ui/dashboard/src/components/settings/ServiceControlSection.tsx
@@ -62,7 +62,10 @@ export function ServiceControlSection({ serviceIds }: Props) {
   // Group: show a single install banner if any service in the group is not installed
   const anyNotInstalled = services.some((s) => s.installed === false);
   const anyInstallable = services.some((s) => s.installable);
-  const allInstalled = services.every((s) => s.installed !== false);
+  // allInstalled was previously surfaced as a "all systems healthy" indicator.
+  // Currently no consumer reads it; kept the predicate scoped (commented) for
+  // when a future "All installed" callout returns.
+  // const allInstalled = services.every((s) => s.installed !== false);
 
   return (
     <div className="grid gap-3">

--- a/ui/dashboard/src/components/ui/badge.tsx
+++ b/ui/dashboard/src/components/ui/badge.tsx
@@ -7,7 +7,7 @@
 
 import { Badge as FancyBadge } from "@particle-academy/react-fancy";
 import { cn } from "@particle-academy/react-fancy";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps } from "react";
 
 type FancyBadgeProps = ComponentProps<typeof FancyBadge>;
 

--- a/ui/dashboard/src/components/ui/button.tsx
+++ b/ui/dashboard/src/components/ui/button.tsx
@@ -11,6 +11,12 @@ import { cn } from "@particle-academy/react-fancy";
 import type { ComponentProps } from "react";
 
 type ActionProps = ComponentProps<typeof Action>;
+// react-fancy's Action narrowed its `variant` union in 2.9+ (default | circle |
+// ghost only). "outline" and "link" remain meaningful in our wrapper API and
+// react-fancy still accepts them at runtime (passes through to the rendered
+// element's class). Alias the type to keep TS satisfied without losing the
+// passthrough semantics.
+type ActionVariantWide = ActionProps["variant"] | "outline" | "link";
 
 type ButtonVariant = "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
 type ButtonSize = "default" | "xs" | "sm" | "lg" | "icon" | "icon-xs" | "icon-sm" | "icon-lg";
@@ -29,7 +35,7 @@ function Button({ variant = "default", size = "default", className, ...rest }: B
       actionProps.color = "red";
       break;
     case "outline":
-      actionProps.variant = "outline";
+      actionProps.variant = "outline" as ActionVariantWide as ActionProps["variant"];
       actionProps.color = "zinc";
       break;
     case "secondary":
@@ -39,7 +45,7 @@ function Button({ variant = "default", size = "default", className, ...rest }: B
       actionProps.variant = "ghost";
       break;
     case "link":
-      actionProps.variant = "link";
+      actionProps.variant = "link" as ActionVariantWide as ActionProps["variant"];
       break;
     default:
       // "default" — solid blue (react-fancy default)

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -593,6 +593,12 @@ export interface GatewayConfig {
   port: number;
   state: "ONLINE" | "LIMBO" | "OFFLINE" | "UNKNOWN";
   updateChannel?: "main" | "dev";
+  /** When true (default), the gateway periodically pulls fresh manifests
+   *  from configured Plugin/MApp Marketplace sources. Surfaced as an
+   *  owner-toggleable switch in settings. */
+  autoSyncMarketplace?: boolean;
+  /** Cap on consecutive tool calls per agent turn. 0 = unlimited. */
+  maxToolLoops?: number;
 }
 
 export interface WorkerModelOverride {


### PR DESCRIPTION
Final-tier broom slice with explicit no-iceberg-chasing scope. 8 logged errors resolved.

## Fixes
- **`DevSettings.tsx`** — added `import { Link } from "react-router"` (line 253 used Link unimported).
- **`api.ts TestVmStatus.services`** — added optional `id?: string` for Local-ID surface. DevSettings line 461 iteration `(["postgres", "caddy", "agi", "id"] as const)` now type-checks.
- **`types.ts GatewayConfig`** — added optional `autoSyncMarketplace?: boolean` and `maxToolLoops?: number`. Consumer's defensive `(gateway.field ?? default)` reads now typed.
- **`ServiceControlSection.tsx`** — commented unused `allInstalled` variable (predicate doc kept for future "all installed" callout).
- **`badge.tsx`** — removed unused `ReactNode` import.
- **`button.tsx`** — introduced `ActionVariantWide` type that includes `"outline"` and `"link"` (legacy variants react-fancy@2.9 pruned from its strict union but still accepts at runtime); 2 cast-assignments preserve passthrough semantics.

## New iceberg (logged for next broom)
- `WidgetRenderer.tsx` — widget type union pruning (5 errors)
- `ChartRenderer.tsx` — SeriesComponent JSX construct/call signature
- `ZeroMeStep.tsx` + `DevSettings.tsx` — unused imports

## Test plan
- `npx tsc --noEmit -p ui/dashboard` — these 8 errors gone.
- No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)