### PR TITLE
v0.4.647 — s144 t574 Phase 3a: keypress state machine for arrow-key nav

### DIFF
--- a/cli/src/commands/doctor-menu.test.ts
+++ b/cli/src/commands/doctor-menu.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { MENU_ITEMS, classifyMenuTurn, pickMenuItem, renderMenu } from "./doctor-menu.js";
+import {
+  MENU_ITEMS,
+  applyMenuKey,
+  classifyMenuTurn,
+  initialMenuState,
+  pickMenuItem,
+  renderMenu,
+} from "./doctor-menu.js";
 
 describe("MENU_ITEMS (s144 t574)", () => {
   it("includes a quit option at number 0", () => {
@@ -114,5 +121,75 @@ describe("renderMenu (s144 t574)", () => {
 
   it("ends with a trailing newline", () => {
     expect(renderMenu()).toMatch(/\n$/);
+  });
+});
+
+describe("initialMenuState (s144 t574 Phase 3a)", () => {
+  it("selects the first non-quit menu item", () => {
+    const state = initialMenuState();
+    const item = MENU_ITEMS[state.selectedIndex];
+    expect(item?.id).not.toBe("quit");
+  });
+});
+
+describe("applyMenuKey (s144 t574 Phase 3a)", () => {
+  it("up arrow moves selection back, wrapping at top", () => {
+    const action = applyMenuKey({ selectedIndex: 0 }, "\x1b[A");
+    expect(action).toEqual({ kind: "move", newSelectedIndex: MENU_ITEMS.length - 1 });
+  });
+
+  it("down arrow moves selection forward, wrapping at bottom", () => {
+    const action = applyMenuKey({ selectedIndex: MENU_ITEMS.length - 1 }, "\x1b[B");
+    expect(action).toEqual({ kind: "move", newSelectedIndex: 0 });
+  });
+
+  it("down arrow increments selectedIndex by 1 mid-list", () => {
+    const action = applyMenuKey({ selectedIndex: 2 }, "\x1b[B");
+    expect(action).toEqual({ kind: "move", newSelectedIndex: 3 });
+  });
+
+  it("Enter commits the highlighted non-quit item", () => {
+    // MENU_ITEMS[0] is run-all per the items array; commit returns that item.
+    const action = applyMenuKey({ selectedIndex: 0 }, "\r");
+    expect(action.kind).toBe("commit");
+    if (action.kind === "commit") {
+      expect(action.item.id).toBe("run-all");
+    }
+  });
+
+  it("Enter on quit-highlight emits quit (not commit)", () => {
+    const quitIdx = MENU_ITEMS.findIndex((m) => m.id === "quit");
+    const action = applyMenuKey({ selectedIndex: quitIdx }, "\r");
+    expect(action).toEqual({ kind: "quit" });
+  });
+
+  it("'\\n' is treated as Enter", () => {
+    const action = applyMenuKey({ selectedIndex: 0 }, "\n");
+    expect(action.kind).toBe("commit");
+  });
+
+  it("Esc, Ctrl-C, 'q', 'Q' all quit", () => {
+    expect(applyMenuKey({ selectedIndex: 0 }, "\x1b")).toEqual({ kind: "quit" });
+    expect(applyMenuKey({ selectedIndex: 0 }, "\x03")).toEqual({ kind: "quit" });
+    expect(applyMenuKey({ selectedIndex: 0 }, "q")).toEqual({ kind: "quit" });
+    expect(applyMenuKey({ selectedIndex: 0 }, "Q")).toEqual({ kind: "quit" });
+  });
+
+  it("numeric key jumps highlight to that MenuItem.number", () => {
+    const action = applyMenuKey({ selectedIndex: 0 }, "3");
+    expect(action.kind).toBe("move");
+    if (action.kind === "move") {
+      const target = MENU_ITEMS[action.newSelectedIndex];
+      expect(target?.number).toBe(3);
+    }
+  });
+
+  it("numeric jump to out-of-range number is noop", () => {
+    expect(applyMenuKey({ selectedIndex: 0 }, "9")).toEqual({ kind: "noop" });
+  });
+
+  it("unknown sequence is noop (e.g., left arrow)", () => {
+    expect(applyMenuKey({ selectedIndex: 0 }, "\x1b[D")).toEqual({ kind: "noop" });
+    expect(applyMenuKey({ selectedIndex: 0 }, "x")).toEqual({ kind: "noop" });
   });
 });

--- a/cli/src/commands/doctor-menu.ts
+++ b/cli/src/commands/doctor-menu.ts
@@ -151,6 +151,96 @@ export function classifyMenuTurn(input: string): MenuTurnOutcome {
   return { kind: "ran", item };
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3a — arrow-key keypress state machine (pure logic; s144 t574)
+//
+// The interactive raw-mode wrapper that consumes this state machine lands in
+// Phase 3b. Keeping the byte-sequence → action mapping as a pure function
+// means the keymap is testable without a TTY fixture, and the wrapper code
+// stays a thin adapter over stdin's data event.
+//
+// Byte sequences recognized:
+//   "\x1b[A" — up arrow
+//   "\x1b[B" — down arrow
+//   "\r" or "\n" — Enter (commit current selection)
+//   "0".."9" — direct numeric jump (matches a MenuItem.number)
+//   "\x1b" (alone, immediate) — Escape (quit). Escape sequences for arrows
+//     start with "\x1b" too — the wrapper distinguishes by reading the
+//     follow-up bytes within a short timeout.
+//   "\x03" — Ctrl-C (quit, mirrors EOF semantics from Phase 2)
+//   "q", "Q" — letter quit (defensive; some terminals don't pass Esc cleanly)
+//
+// The state machine doesn't own the timeout-based Esc disambiguation — that's
+// the wrapper's job. The pure function classifies finished sequences only.
+// ---------------------------------------------------------------------------
+
+export interface MenuKeyState {
+  /** Index into MENU_ITEMS for the currently-highlighted entry. */
+  selectedIndex: number;
+}
+
+/** Action emitted by the state machine for one finished keypress sequence. */
+export type MenuKeyAction =
+  | { kind: "noop" }
+  | { kind: "move"; newSelectedIndex: number }
+  | { kind: "commit"; item: MenuItem }
+  | { kind: "quit" };
+
+/**
+ * Initialize the menu state. Default selection lands on the first non-quit
+ * item (i.e., the most prominent "Run all checks" option).
+ */
+export function initialMenuState(): MenuKeyState {
+  const idx = MENU_ITEMS.findIndex((m) => m.id !== "quit");
+  return { selectedIndex: idx < 0 ? 0 : idx };
+}
+
+/**
+ * Apply one finished key sequence to the menu state. Returns the action the
+ * wrapper should take (no-op / move highlight / commit selection / quit).
+ *
+ * Bounds the selectedIndex within MENU_ITEMS — wrapping at both ends so
+ * the menu feels predictable on long lists. Up/down skip nothing; even if
+ * the highlight lands on Quit, that's a valid commit (== quit).
+ */
+export function applyMenuKey(state: MenuKeyState, key: string): MenuKeyAction {
+  if (key === "\x1b" || key === "q" || key === "Q" || key === "\x03") {
+    return { kind: "quit" };
+  }
+  if (key === "\x1b[A") {
+    const next = (state.selectedIndex - 1 + MENU_ITEMS.length) % MENU_ITEMS.length;
+    return { kind: "move", newSelectedIndex: next };
+  }
+  if (key === "\x1b[B") {
+    const next = (state.selectedIndex + 1) % MENU_ITEMS.length;
+    return { kind: "move", newSelectedIndex: next };
+  }
+  if (key === "\r" || key === "\n") {
+    const item = MENU_ITEMS[state.selectedIndex];
+    if (!item) return { kind: "noop" };
+    if (item.id === "quit") return { kind: "quit" };
+    return { kind: "commit", item };
+  }
+  // Numeric jump: "0".."9" hops the highlight to that MenuItem.number.
+  if (/^\d$/.test(key)) {
+    const n = Number(key);
+    const targetIdx = MENU_ITEMS.findIndex((m) => m.number === n);
+    if (targetIdx < 0) return { kind: "noop" };
+    return { kind: "move", newSelectedIndex: targetIdx };
+  }
+  return { kind: "noop" };
+}
+
+/**
+ * Detect whether the current process can support arrow-key TTY navigation.
+ * False when stdin isn't a TTY (piped input, CI, non-interactive shell).
+ * The interactive wrapper falls back to the Phase 2 numbered-input flow
+ * when this returns false.
+ */
+export function canUseRawTty(): boolean {
+  return process.stdin.isTTY === true;
+}
+
 /**
  * Run the menu interactively. Phase 2 (s144 t574, 2026-05-10) — wraps
  * Phase 1's read-once in a while loop so the menu stays open until the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.646",
+  "version": "0.4.647",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
Pure-logic foundation for Phase 3 arrow-key navigation in `agi doctor menu`. Extracts the byte-sequence → action mapping into a pure function so the keymap is testable without TTY fixtures. Phase 3b will ship the raw-mode wrapper that consumes this state machine.

## Exports
- `MenuKeyState` — `{ selectedIndex }`
- `MenuKeyAction` — `noop | move | commit | quit`
- `initialMenuState()` — picks first non-quit item
- `applyMenuKey(state, key)` — pure state transition
- `canUseRawTty()` — checks `process.stdin.isTTY`

## Recognized keys
- `\x1b[A` / `\x1b[B` — up/down arrows (wrapping nav)
- `\r` / `\n` — Enter (commit highlighted item; or quit if highlighted is Quit)
- `\x1b`, `\x03`, `q`, `Q` — all quit
- `0`..`9` — direct numeric jump to that `MenuItem.number`
- Unknown sequences = noop

## Test plan
- 11 new pure-logic unit tests pass (30/30 total in doctor-menu.test.ts).
- No interactive surface change — `agi doctor menu` still uses Phase 2 numbered-input flow until Phase 3b wires the raw-mode loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)