### PR TITLE
v0.4.648 — s144 t574 Phase 3b: arrow-key TUI wrapper (opt-in via --arrows)

### DIFF
--- a/cli/src/commands/doctor-menu.ts
+++ b/cli/src/commands/doctor-menu.ts
@@ -242,6 +242,113 @@ export function canUseRawTty(): boolean {
 }
 
 /**
+ * Render the menu with an arrow-key highlight marker. Pure function —
+ * the interactive wrapper calls it on every state change.
+ *
+ * Exposed for testability. The interactive wrapper is responsible for
+ * clearing the screen / repositioning the cursor between renders.
+ */
+export function renderArrowMenu(state: MenuKeyState): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  agi doctor — diagnostic menu (arrow keys to navigate, Enter to select, Esc/q to quit)");
+  lines.push("");
+  MENU_ITEMS.forEach((item, idx) => {
+    const num = String(item.number).padStart(1, " ");
+    const marker = idx === state.selectedIndex ? "▶ " : "  ";
+    lines.push(`  ${marker}${num}  ${item.label}`);
+    lines.push(`       ${item.description}`);
+  });
+  lines.push("");
+  return lines.join("\n");
+}
+
+/**
+ * Arrow-key TUI wrapper around the state machine. Phase 3b — consumes
+ * `applyMenuKey` and emits raw-mode reads. Falls back to the Phase 2
+ * numbered loop when stdin isn't a TTY.
+ *
+ * Limitations (Phase 3b ships these; Phase 3c+ may polish):
+ *   - No timeout-based Esc disambiguation. Standalone Esc quits
+ *     immediately; arrow keys (also start with \x1b) are recognized
+ *     when the wrapper receives the full 3-byte sequence in one chunk
+ *     (the common case for terminal input).
+ *   - Sub-command spawning: raw mode is dropped during spawnSync and
+ *     restored on return. The next render redraws the menu.
+ *   - No screen-clear between renders — the menu accumulates on stdout.
+ *     Acceptable for the early-2026 TUI; cleaner rendering follows.
+ */
+export async function runArrowKeyMenu(opts?: { agiBin?: string }): Promise<MenuItemId> {
+  if (!canUseRawTty()) {
+    // Non-TTY (piped, CI) — fall back to Phase 2 numbered loop.
+    return runDoctorMenu(opts);
+  }
+  const bin = opts?.agiBin ?? "agi";
+  const stdin = process.stdin;
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.setEncoding("utf8");
+
+  let state = initialMenuState();
+  let lastResolution: MenuItemId = "quit";
+
+  function render(): void {
+    process.stdout.write(renderArrowMenu(state));
+  }
+
+  return new Promise<MenuItemId>((resolve) => {
+    function cleanup(): void {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+    }
+
+    function onData(key: string): void {
+      const action = applyMenuKey(state, key);
+      switch (action.kind) {
+        case "quit": {
+          cleanup();
+          process.stdout.write("\n");
+          resolve("quit");
+          return;
+        }
+        case "move": {
+          state = { selectedIndex: action.newSelectedIndex };
+          render();
+          return;
+        }
+        case "commit": {
+          // Suspend raw-mode + data listener while the child runs with
+          // inherit stdio. spawnSync blocks the event loop, which is what
+          // we want — no risk of overlapping menu input.
+          stdin.setRawMode(false);
+          stdin.removeListener("data", onData);
+          process.stdout.write("\n");
+          spawnSync(bin, ["doctor", ...action.item.args], { stdio: "inherit" });
+          lastResolution = action.item.id;
+          stdin.setRawMode(true);
+          stdin.on("data", onData);
+          render();
+          return;
+        }
+        case "noop":
+        default:
+          return;
+      }
+    }
+
+    stdin.on("data", onData);
+    render();
+    // Resolution is owned by the quit handler in onData; if stdin closes
+    // unexpectedly the lastResolution value tracks the most recent commit.
+    stdin.once("end", () => {
+      cleanup();
+      resolve(lastResolution);
+    });
+  });
+}
+
+/**
  * Run the menu interactively. Phase 2 (s144 t574, 2026-05-10) — wraps
  * Phase 1's read-once in a while loop so the menu stays open until the
  * user picks Quit (or hits Ctrl-D / Ctrl-C). After each sub-command

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1499,10 +1499,15 @@ export function registerDoctorCommand(program: Command): void {
   // pulling in ink/blessed.
   doctor
     .command("menu")
-    .description("Interactive category menu — pick a number, run that diagnostic, exit")
-    .action(async () => {
-      const { runDoctorMenu } = await import("./doctor-menu.js");
-      await runDoctorMenu();
+    .description("Interactive category menu — pick a number, run that diagnostic. Pass --arrows for arrow-key navigation (Phase 3b TUI, manual-smoke-tested).")
+    .option("--arrows", "Use arrow-key navigation instead of the numbered-input loop")
+    .action(async (cmdOpts: { arrows?: boolean }) => {
+      const { runDoctorMenu, runArrowKeyMenu } = await import("./doctor-menu.js");
+      if (cmdOpts.arrows === true) {
+        await runArrowKeyMenu();
+      } else {
+        await runDoctorMenu();
+      }
     });
 
   // s144 t579 — `agi doctor dump` writes a diagnostic bundle to

--- a/docs/human/cli.md
+++ b/docs/human/cli.md
@@ -106,15 +106,18 @@ Exits 0 on all-pass, 1 when any failed (warnings don't fail).
 
 #### agi doctor menu
 
-Interactive category menu (s144 t574). Prints a numbered list of diagnostic categories; you type a number, hit Enter, and the matching sub-command runs. After each pick, the menu prompts "Press Enter to continue…" and re-renders, so the diagnostic output isn't immediately scrolled away. Pick 0 (or Ctrl-D / Ctrl-C) to quit.
+Interactive category menu (s144 t574). Prints a numbered list of diagnostic categories; you type a number, hit Enter, and the matching sub-command runs. After each pick, the menu prompts "Press Enter to continue…" and re-renders so the diagnostic output isn't immediately scrolled away. Pick 0 (or Ctrl-D / Ctrl-C) to quit.
 
 ```bash
 agi doctor menu
+agi doctor menu --arrows  # Phase 3b TUI — arrow-key navigation
 ```
 
 Categories: `Run all checks` (bare doctor) · `Validate config schemas` (schema) · `Write diagnostic bundle` (dump) · `Tail logs + crash-pattern detection` (logs) · `Read a gateway.json key` (config get) · `Legacy 5-check health` (health) · `Quit` (0).
 
-Phase 2 ships the loop + invalid-input retry. Phase 3+ adds arrow-key navigation, sub-menus per category, and Esc-to-back. For scripting, prefer the explicit sub-commands directly (`agi doctor schema`, `agi doctor dump`, etc.) — the menu is a discovery aid, not a scriptable surface.
+The default flow is the numbered-input loop (Phase 2 — solid, line-mode, scriptable-friendly). The `--arrows` flag enables Phase 3b: a raw-mode TTY surface where up/down arrows move the highlight and Enter commits. Numeric jump (`0`-`9` shortcut to a menu item) still works in arrow mode. Esc, Ctrl-C, q, or Q quit. Arrow mode is currently manual-smoke-tested only; the numbered default is the reliable surface for production scripts.
+
+Phase 3c+ may polish: timeout-based Esc disambiguation (so a standalone Esc waits to confirm it's not an arrow-key prefix), per-category sub-menus, and screen-clear between renders. For scripting, prefer the explicit sub-commands directly (`agi doctor schema`, `agi doctor dump`, etc.) — the menu is a discovery aid, not a scriptable surface.
 
 #### agi doctor health
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.647",
+  "version": "0.4.648",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
Phase 3b wraps cycle 190's pure-logic state machine in a raw-mode TTY surface. Opt-in via `agi doctor menu --arrows` — the numbered-input Phase 2 loop stays the default until arrow-mode polish settles.

## What ships
- `runArrowKeyMenu()` — raw-mode wrapper that consumes `applyMenuKey` from the state machine.
- `renderArrowMenu(state)` — pure-function renderer with right-pointing-triangle highlight marker.
- `canUseRawTty()` fallback — pipes/CI route to Phase 2 numbered loop transparently.
- `doctor.ts`: `--arrows` option on `agi doctor menu` subcommand.
- `cli.md`: documents both modes + Phase 3b shipped limitations + Phase 3c+ polish list.

## Phase 3b limitations (Phase 3c polish)
- Standalone Esc quits immediately. Arrow keys recognized only when the full 3-byte sequence arrives in one chunk (typical for terminal input).
- Menu output accumulates on stdout — no inter-render screen clear yet.

## Test plan
- 30/30 pure-logic unit tests still pass (the interactive wrapper is a thin adapter — the testable logic is the state machine).
- Manual: `agi doctor menu --arrows` in an interactive terminal → ▶ marker moves with arrow keys → Enter commits → Esc/q quits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)