### PR TITLE
v0.4.651 — typecheck drift broom 7: unused-import cleanup + WidgetRenderer investigation note

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.650",
+  "version": "0.4.651",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/onboarding/ZeroMeStep.tsx
+++ b/ui/dashboard/src/components/onboarding/ZeroMeStep.tsx
@@ -19,11 +19,14 @@ interface Message {
   content: string;
 }
 
-const DOMAIN_LABELS: Record<"MIND" | "SOUL" | "SKILL", string> = {
-  MIND: "Intellectual Interests",
-  SOUL: "Purpose & Values",
-  SKILL: "Skills & Expertise",
-};
+// DOMAIN_LABELS was previously shown beneath the wizard step. Kept commented
+// in case the UI surfaces the long-form labels again — the inline short labels
+// are sufficient today.
+// const DOMAIN_LABELS: Record<"MIND" | "SOUL" | "SKILL", string> = {
+//   MIND: "Intellectual Interests",
+//   SOUL: "Purpose & Values",
+//   SKILL: "Skills & Expertise",
+// };
 
 const DOMAIN_COPY: Record<"MIND" | "SOUL" | "SKILL", { headline: string; subtitle: string }> = {
   MIND: {

--- a/ui/dashboard/src/components/settings/DevSettings.tsx
+++ b/ui/dashboard/src/components/settings/DevSettings.tsx
@@ -7,9 +7,8 @@ import { Link } from "react-router";
 import { Callout } from "@particle-academy/react-fancy";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { SectionHeading, FieldGroup } from "./SettingsShared.js";
+import { SectionHeading } from "./SettingsShared.js";
 import { fetchDevStatus, switchDevMode, fetchTestVmStatus, runTestVmCommand, fetchTestResults } from "../../api.js";
 import type { TestVmStatus, TestResults } from "../../api.js";
 import type { DevStatus, AionimaConfig } from "../../types.js";
@@ -38,10 +37,13 @@ function RepoCard({ name, remote, branch, entries, isOwnerFork }: {
   );
 }
 
-export function DevSettings({ config, update }: {
+export function DevSettings(_props: {
   config: AionimaConfig;
   update: (fn: (prev: AionimaConfig) => AionimaConfig) => void;
 }) {
+  // config + update were used by an earlier inline form. Today the page is
+  // status + repo cards only; the props remain in the signature for
+  // call-site contract stability.
   const [devStatus, setDevStatus] = useState<DevStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [switching, setSwitching] = useState(false);

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -1105,6 +1105,13 @@ export type PanelWidget =
   | { type: "code-editor"; language?: string; defaultValue?: string; readOnly?: boolean; height?: string; maxHeight?: string }
   | { type: "tree-nav"; dataEndpoint?: string; title?: string }
   | { type: "layout"; direction: "horizontal" | "vertical" | "grid"; sizes?: string[]; gap?: string; height?: string; children: PanelWidget[] };
+  // Future widgets (chart, timeline, kanban, editor, diagram) are PARTIALLY
+  // implemented in WidgetRenderer but their bodies reference react-fancy
+  // primitives whose props have drifted (e.g., Timeline.Item without `title`,
+  // Kanban.Card with `id` instead of children). The type union deliberately
+  // omits them until the widget bodies are realigned with react-fancy@2.9 —
+  // adding the union variants without fixing the bodies caused a 4-error
+  // cascade in cycle 194's drift broom 7 attempt.
 
 export interface PluginPanel {
   id: string;


### PR DESCRIPTION
Drift broom 7 attempt — investigated the WidgetRenderer 5-error cluster (chart/timeline/kanban/editor/diagram NOT in `PanelWidget` union) and found a deeper layer: extending the union triggered a 4-error cascade in the widget bodies because they reference react-fancy@2.9 primitives whose props have drifted.

## Investigation finding
- `Timeline.Item` no longer accepts `title` prop
- `Kanban.Card` no longer accepts `title` prop (probably wants children)
- `Kanban.Column` requires `id` field
- `Diagram` requires `DiagramSchema` shape (entities + relations) rather than `unknown`
- Editor `outputFormat` narrowed to `markdown | html` (was wider)

Realigning the widget bodies is substantive Phase work, not drift cleanup. Reverted the PanelWidget extension; documented in types.ts as a deliberate narrowing pending body realignment.

## Shipped this cycle
- `ZeroMeStep.tsx`: `DOMAIN_LABELS` const commented (unused since copy was inlined)
- `DevSettings.tsx`: removed unused `Input` + `FieldGroup` imports; props destructure switched to `_props` to silence the all-elements-unused warning while preserving call-site contract
- `types.ts`: deliberate-narrowing note on `PanelWidget` explaining why chart/timeline/kanban/editor/diagram are intentionally out

## Logged drift
- WidgetRenderer chart/timeline/kanban/editor/diagram bodies need react-fancy@2.9 API alignment
- ChartRenderer SeriesComponent JSX issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)