### PR TITLE
v0.4.652 — s134 t517: e2e probe for core-fork branch (mode picker + chat aside suppressed)

### DIFF
--- a/e2e/project-workspace-mode-picker.spec.ts
+++ b/e2e/project-workspace-mode-picker.spec.ts
@@ -247,4 +247,43 @@ test.describe("Project workspace mode picker (s134 t517)", () => {
     await expect(aside).toContainText(/Chat/);
     await expect(page.getByTestId("project-chat-aside-open")).toBeVisible();
   });
+
+  // -----------------------------------------------------------------------
+  // Cycle 195 — core-fork branch verification. Core forks (agi/prime/id/
+  // marketplace/mapp-marketplace/_aionima) suppress the workspace mode
+  // picker AND the chat aside; only the simpler Editor/Repository tabs
+  // are exposed. Pre-AccordionFlyout-integration (s134 item 5) this is the
+  // ground-truth shape that the integration must preserve.
+  // -----------------------------------------------------------------------
+
+  async function findCoreForkProject(page: Page): Promise<string | null> {
+    const apiResponse = await page.request.get("/api/projects");
+    if (!apiResponse.ok()) return null;
+    const projects = await apiResponse.json() as Array<{
+      name: string;
+      path: string;
+      coreForkSlug?: string | null;
+      projectType?: { id?: string };
+    }>;
+    const match = projects.find((p) => Boolean(p.coreForkSlug) || p.projectType?.id === "aionima");
+    if (!match) return null;
+    return match.path.split("/").pop() ?? match.name;
+  }
+
+  test("core-fork project hides mode picker + chat aside (cycle 195)", async ({ page }) => {
+    const slug = await findCoreForkProject(page);
+    test.skip(!slug, "no core-fork project available in test workspace");
+
+    await page.goto(`/projects/${String(slug)}`);
+    // Core forks skip the mode picker entirely — only the simple Editor/
+    // Repository TabsList renders. Wait on the flyout-shell wrapper since
+    // it's present regardless (just sans aside).
+    await page.getByTestId("project-flyout-shell").waitFor({ state: "visible", timeout: 15_000 });
+
+    await expect(page.getByTestId("project-mode-picker")).toHaveCount(0);
+    await expect(page.getByTestId("project-chat-aside")).toHaveCount(0);
+    // Editor + Repository tabs are the core-fork surface.
+    await expect(page.getByRole("tab", { name: "Editor" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Repository" })).toBeVisible();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.651",
+  "version": "0.4.652",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",


### PR DESCRIPTION
s134 t517 item 5 (AccordionFlyout integration) is genuinely multi-cycle architecture work. Pivoted to item-8 e2e extension this cycle.

## New test
- core-fork project hides mode picker + chat aside — Editor/Repository tabs only

Uses `findCoreForkProject` helper (skip-when-absent pattern matching cycle 188). Establishes the ground-truth shape that any future AccordionFlyout integration must preserve: core forks DON'T wrap in the flyout chrome since they have no canvas/chat concept.

## Spec count
10 tests in `project-workspace-mode-picker.spec.ts`: default mode picker, mode switching, sub-surface label/header, flyout-shell, literature/media/administration narrowing + auto-redirect, and now core-fork suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)