### PR TITLE
v0.4.653 — dependabot: clear 3 HIGH alerts (babel + fast-uri overrides)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.652",
+  "version": "0.4.653",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",
@@ -92,7 +92,9 @@
       "uuid": ">=11.0.0",
       "lodash": ">=4.18.0",
       "postcss": ">=8.5.10",
-      "esbuild": ">=0.25.0"
+      "esbuild": ">=0.25.0",
+      "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+      "fast-uri": ">=3.1.2"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,8 @@ overrides:
   lodash: '>=4.18.0'
   postcss: '>=8.5.10'
   esbuild: '>=0.25.0'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -567,6 +569,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.0
         version: 1.2.3
+      '@particle-academy/fancy-3d':
+        specifier: ^0.1.6
+        version: 0.1.6(@particle-academy/react-fancy@2.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@particle-academy/fancy-sheets':
         specifier: ^0.7.2
         version: 0.7.2(@particle-academy/react-fancy@2.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1195,8 +1200,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2150,6 +2155,19 @@ packages:
     resolution: {integrity: sha512-Ae1fx7wmAcMVqzS8rLINaFRpAdh29QzHh133bEYMHzfWBYyK/hLu9g4GLwC/lEIVQu9884b8qutGfdOk6Qia3w==}
     cpu: [x64]
     os: [win32]
+
+  '@particle-academy/fancy-3d@0.1.6':
+    resolution: {integrity: sha512-m5K4SThTDNb7AAJfWl51h/z0ZdYSofCChmd12daFH695swcKcDuzWnISXJLH4OUFYg7LNo9C2FZL/rsGYiIVGQ==}
+    peerDependencies:
+      '@babylonjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0
+      '@particle-academy/react-fancy': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@babylonjs/core':
+        optional: true
+      '@particle-academy/react-fancy':
+        optional: true
 
   '@particle-academy/fancy-code@0.4.5':
     resolution: {integrity: sha512-2KEuHS/2vhvOQt060taZ/tMtRaqB77lKAeySHPMnwKmYVwQuG56LcCev57VbtzYK+apXz2JKLlNodOsESfJRvQ==}
@@ -4371,8 +4389,8 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -8218,7 +8236,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -8486,7 +8504,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -9225,7 +9243,7 @@ snapshots:
     dependencies:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
 
   '@fastify/error@4.2.0': {}
 
@@ -9486,6 +9504,13 @@ snapshots:
 
   '@oxlint/win32-x64@0.16.12':
     optional: true
+
+  '@particle-academy/fancy-3d@0.1.6(@particle-academy/react-fancy@2.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@particle-academy/react-fancy': 2.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
 
   '@particle-academy/fancy-code@0.4.5(@particle-academy/react-fancy@2.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -10502,14 +10527,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11896,7 +11921,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -11904,7 +11929,7 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastify-plugin@5.1.0: {}
 


### PR DESCRIPTION
Clears 3 unresolved HIGH-severity dependabot alerts by adding two pnpm overrides that weren't yet in the registry.

## Fixes
- `@babel/plugin-transform-modules-systemjs >=7.29.4` — fixes "arbitrary code generation when compiling malicious input" (alert #85). Bumps lockfile entry 7.29.0 → 7.29.4.
- `fast-uri >=3.1.2` — fixes path traversal via percent-encoded dot segments (alert #83) AND host confusion via percent-encoded authority delimiters (alert #84). Bumps lockfile entry 3.1.0 → 3.1.2.

## Test plan
- `pnpm install --lockfile-only` regenerated cleanly; 47 lines changed in pnpm-lock.yaml.
- The remaining ~40 HIGH alerts on wishborn/agi are stale (already overridden, lockfile already at safe versions on dev) — those should auto-close when dependabot rescans this dev branch.

## Pre-existing (out of scope)
- Peer-dep mismatch: fancy-screens 0.2.0 wants `react-fancy@^3.0.0` but lockfile has 2.9.0. Not blocking; logged for separate handling.
- 4 open dependabot PRs on wishborn/agi (#1-#4) target `main` not `dev`; they'll close naturally as dependabot rescans and sees the override approach covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)