### PR TITLE
v0.4.654 — s157 Phase 2 onboarding: fancy-whiteboard + agent-integrations added to PAx

### DIFF
--- a/config/src/schema.ts
+++ b/config/src/schema.ts
@@ -566,6 +566,14 @@ const DevConfigSchema = z
     fancy3dRepo: z.string().default("git@github.com:wishborn/fancy-3d.git"),
     /** Git remote URL for fancy-screens fork (s146 t604 cycle 199 — 6th PAx package). */
     fancyScreensRepo: z.string().default("git@github.com:wishborn/fancy-screens.git"),
+    /** Git remote URL for fancy-whiteboard fork (s157 cycle 197 — 7th PAx package).
+     *  Whiteboard primitives: sticky notes + diagramming + freeform drawing +
+     *  presence cursors. Powers UserNotes Phase 2 (whiteboard mode). */
+    fancyWhiteboardRepo: z.string().default("git@github.com:wishborn/fancy-whiteboard.git"),
+    /** Git remote URL for agent-integrations fork (s157 cycle 197 — 8th PAx package).
+     *  MCP-driven agent presence in collab sessions: per-session micro-MCP
+     *  bridges to fancy-* packages. Lets Aion join shared whiteboards. */
+    agentIntegrationsRepo: z.string().default("git@github.com:wishborn/agent-integrations.git"),
   })
   .strict();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.653",
+  "version": "0.4.654",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/dev-mode-forks.ts
+++ b/packages/gateway-core/src/dev-mode-forks.ts
@@ -45,7 +45,9 @@ export interface CoreRepoSpec {
     | "fancy-sheets"
     | "fancy-echarts"
     | "fancy-3d"
-    | "fancy-screens";
+    | "fancy-screens"
+    | "fancy-whiteboard"
+    | "agent-integrations";
   /** Repo name on GitHub (NOT the slug — sometimes diverges, e.g. prime
    *  → aionima, id → agi-local-id). */
   upstream: string;
@@ -66,7 +68,9 @@ export interface CoreRepoSpec {
     | "fancySheetsRepo"
     | "fancyEchartsRepo"
     | "fancy3dRepo"
-    | "fancyScreensRepo";
+    | "fancyScreensRepo"
+    | "fancyWhiteboardRepo"
+    | "agentIntegrationsRepo";
 }
 
 export const CORE_REPOS: readonly CoreRepoSpec[] = Object.freeze([
@@ -94,6 +98,16 @@ export const CORE_REPOS: readonly CoreRepoSpec[] = Object.freeze([
   // application surface with scoped state, typed ports, hibernation,
   // schema-driven rendering, agent-introspectable registry.
   { slug: "fancy-screens", upstream: "fancy-screens", upstreamOrg: "Particle-Academy", displayName: "fancy-screens", configKey: "fancyScreensRepo" },
+
+  // s157 cycle 197 — fancy-whiteboard + agent-integrations added to PAx
+  // (8 packages total). Owner-confirmed 2026-05-11: s157 Phase 2 (whiteboard
+  // mode for UserNotes) builds on @particle-academy/fancy-whiteboard's
+  // canvas primitives + sticky-notes + diagramming + freeform drawing +
+  // presence cursors. agent-integrations provides per-session micro-MCP
+  // bridges so Aion can participate in shared whiteboard sessions through
+  // the same channels other collaborators use (panel + on-canvas cursor).
+  { slug: "fancy-whiteboard",   upstream: "fancy-whiteboard",   upstreamOrg: "Particle-Academy", displayName: "fancy-whiteboard",   configKey: "fancyWhiteboardRepo" },
+  { slug: "agent-integrations", upstream: "agent-integrations", upstreamOrg: "Particle-Academy", displayName: "agent-integrations", configKey: "agentIntegrationsRepo" },
 ] as const);
 
 export interface ForkResolveResult {

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -3594,6 +3594,10 @@ export async function createGatewayRuntimeState(
               "fancy-code": "fancyCodeRepo",
               "fancy-sheets": "fancySheetsRepo",
               "fancy-echarts": "fancyEchartsRepo",
+              "fancy-3d": "fancy3dRepo",
+              "fancy-screens": "fancyScreensRepo",
+              "fancy-whiteboard": "fancyWhiteboardRepo",
+              "agent-integrations": "agentIntegrationsRepo",
             };
             const cfgKey = keyMap[f.slug];
             if (cfgKey) devRepoPatch[cfgKey] = f.cloneUrl;


### PR DESCRIPTION
Owner-confirmed 2026-05-11: s157 Phase 2 (whiteboard mode for UserNotes) builds on `@particle-academy/fancy-whiteboard`'s canvas primitives (sticky-notes + diagramming + freeform drawing + presence cursors). `@particle-academy/agent-integrations` provides MCP-driven per-session bridges so Aion participates in shared whiteboard sessions through the same channels as other collaborators.

## What ships
- `dev-mode-forks.ts CORE_REPOS`: 2 new specs (slugs `fancy-whiteboard` + `agent-integrations`, `upstreamOrg: "Particle-Academy"`, configKeys `fancyWhiteboardRepo` + `agentIntegrationsRepo`)
- `config/schema.ts`: 2 new Zod defaults `git@github.com:wishborn/<slug>.git` (matching existing PAx pattern)
- `server-runtime-state.ts keyMap`: added `fancy-3d` + `fancy-screens` (**previously missing!**) + the 2 new packages

## Pre-existing drift caught
`fancy-3d` + `fancy-screens` were declared in `CORE_REPOS` but the runtime `keyMap` that translates slug → configKey was missing them — the forks were being looked up but config wasn't being patched on creation. Fixed alongside this slice.

## Test plan
- Typecheck on `packages/gateway-core` green.
- When dashboard Contributing Mode toggles next, the 2 new forks (and the 2 previously-missing ones) will be created/looked-up via the existing flow. Cloned into `_aionima/<slug>/` on the next provisioning pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)