### PR TITLE
v0.4.657 — s157 Phase 2b: wire SharedWhiteboard into NotesPanel whiteboard branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.656",
+  "version": "0.4.657",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/ui/dashboard/src/components/NotesPanel.tsx
+++ b/ui/dashboard/src/components/NotesPanel.tsx
@@ -21,6 +21,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { createNote, deleteNote, fetchNotes, updateNote, type UserNote } from "../api.js";
+import { WhiteboardEditor } from "./WhiteboardEditor.js";
 
 export interface NotesPanelProps {
   /** Per-project: pass the absolute project path. Global: pass null. */
@@ -300,24 +301,12 @@ export function NotesPanel({ projectPath }: NotesPanelProps): ReactElement {
                 Delete
               </Button>
             </div>
-            {/* s157 Phase 2 — whiteboard kind renders a placeholder Card
-                until the fancy-whiteboard Canvas + agent-integrations
-                bridge land in Phase 2b. The textarea (s156 t675 raw
-                Markdown editor) renders for the default markdown kind. */}
+            {/* s157 Phase 2b — whiteboard kind renders the full
+                SharedWhiteboard (fancy-whiteboard primitives + in-page
+                MicroMcpServer + AgentPanel). State is session-ephemeral
+                in this slice; persistence + relay broker land in Phase 2c. */}
             {selected.kind === "whiteboard" ? (
-              <div
-                className="flex-1 flex flex-col items-center justify-center rounded border border-dashed border-input bg-secondary/10 p-6 text-center"
-                data-testid="notes-whiteboard-placeholder"
-              >
-                <p className="text-[12px] font-semibold text-foreground mb-2">Whiteboard mode</p>
-                <p className="text-[11px] text-muted-foreground max-w-[320px] mb-3">
-                  This note is a whiteboard. The fancy-whiteboard Canvas + agent-integrations
-                  bridge will render here in Phase 2b. Body JSON shape is preserved across saves.
-                </p>
-                <code className="text-[10px] font-mono text-muted-foreground/70 break-all max-w-full overflow-hidden">
-                  {draftBody.slice(0, 200)}
-                </code>
-              </div>
+              <WhiteboardEditor body={draftBody} />
             ) : (
               <textarea
                 ref={bodyRef}

--- a/ui/dashboard/src/components/WhiteboardEditor.test.ts
+++ b/ui/dashboard/src/components/WhiteboardEditor.test.ts
@@ -1,0 +1,68 @@
+/**
+ * WhiteboardEditor pure-helper tests (s157 Phase 2b).
+ *
+ * Covers parseWhiteboardBody — the JSON deserializer that feeds initial
+ * state into SharedWhiteboard. Pure function; no React render.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseWhiteboardBody } from "./WhiteboardEditor.js";
+
+describe("parseWhiteboardBody (s157 Phase 2b)", () => {
+  it("returns empty arrays for empty body", () => {
+    const out = parseWhiteboardBody("");
+    expect(out.initialNotes).toEqual([]);
+    expect(out.initialShapes).toEqual([]);
+    expect(out.initialConnectors).toEqual([]);
+    expect(out.initialStrokes).toEqual([]);
+    expect(out.initialViewport).toBeUndefined();
+  });
+
+  it("returns empty arrays for whitespace-only body", () => {
+    const out = parseWhiteboardBody("   \n  \t ");
+    expect(out.initialNotes).toEqual([]);
+  });
+
+  it("returns empty arrays for invalid JSON", () => {
+    const out = parseWhiteboardBody("not json");
+    expect(out.initialNotes).toEqual([]);
+    expect(out.initialShapes).toEqual([]);
+  });
+
+  it("returns empty arrays for JSON null/array (not object)", () => {
+    expect(parseWhiteboardBody("null").initialNotes).toEqual([]);
+    expect(parseWhiteboardBody("[1,2,3]").initialNotes).toEqual([]);
+  });
+
+  it("extracts each slot when present", () => {
+    const stickyNote = { id: "n1", x: 10, y: 20, text: "hello", color: "yellow" };
+    const shape = { id: "s1", kind: "rect", x: 0, y: 0, w: 100, h: 100 };
+    const body = JSON.stringify({
+      notes: [stickyNote],
+      shapes: [shape],
+      connectors: [],
+      strokes: [],
+      viewport: { x: 5, y: 5, zoom: 1.5 },
+    });
+    const out = parseWhiteboardBody(body);
+    expect(out.initialNotes).toEqual([stickyNote]);
+    expect(out.initialShapes).toEqual([shape]);
+    expect(out.initialViewport).toEqual({ x: 5, y: 5, zoom: 1.5 });
+  });
+
+  it("falls back to empty array for slot with wrong type", () => {
+    const body = JSON.stringify({ notes: "not an array", shapes: 42 });
+    const out = parseWhiteboardBody(body);
+    expect(out.initialNotes).toEqual([]);
+    expect(out.initialShapes).toEqual([]);
+  });
+
+  it("returns empty for the {} body (Phase 2a default for new whiteboards)", () => {
+    const out = parseWhiteboardBody("{}");
+    expect(out.initialNotes).toEqual([]);
+    expect(out.initialShapes).toEqual([]);
+    expect(out.initialConnectors).toEqual([]);
+    expect(out.initialStrokes).toEqual([]);
+    expect(out.initialViewport).toBeUndefined();
+  });
+});

--- a/ui/dashboard/src/components/WhiteboardEditor.tsx
+++ b/ui/dashboard/src/components/WhiteboardEditor.tsx
@@ -1,0 +1,102 @@
+/**
+ * WhiteboardEditor — s157 Phase 2b (2026-05-11).
+ *
+ * Wraps `@particle-academy/agent-integrations`'s `SharedWhiteboard`, which
+ * itself composes `fancy-whiteboard` primitives (Board / StickyNote /
+ * Shape / Connector / Drawing / CursorLayer) with a `MicroMcpServer`,
+ * AgentPanel, and presence cursors. One drop-in component delivers the
+ * "agent-collaborative whiteboard" UX the owner asked for ("particle
+ * academy has a fancy-whiteboard with agentic sessions sharing using
+ * their agent-integrations package as well. get both.").
+ *
+ * **What this Phase 2b slice ships:**
+ *   - Renders the full SharedWhiteboard inside the NotesPanel whiteboard
+ *     branch (replacing the Phase 2a JSON-preview placeholder).
+ *   - Reads initial board state from the note's body JSON when present,
+ *     falling back to empty arrays when not parseable.
+ *   - Identifies Aion ($A0) as the agent for the in-page MicroMcpServer
+ *     so the AgentPanel surfaces real presence.
+ *   - `shareBaseUrl={null}` — disables external relay. The board still
+ *     works locally with the in-process MCP server, which is the right
+ *     default until the gateway-side relay broker is wired (Phase 2c).
+ *
+ * **Phase 2c follow-ups (out of scope):**
+ *   - State persistence — SharedWhiteboard owns its internal state and
+ *     does NOT expose an onChange/onStateChange prop. New whiteboard
+ *     content is session-ephemeral until either upstream adds the
+ *     callback OR we swap to the lower-level Board + controlled state
+ *     pattern. Tracked as Phase 2c.
+ *   - Relay broker — wiring `shareBaseUrl` so multi-user / external-agent
+ *     sessions work end-to-end. The host (this app) needs to implement
+ *     the relay HTTP endpoints per upstream's relay-protocol.md.
+ */
+
+import { useMemo } from "react";
+import { SharedWhiteboard, type SharedWhiteboardProps } from "@particle-academy/agent-integrations";
+
+interface WhiteboardEditorProps {
+  /** JSON-serialized board state from the note's body. May be empty/invalid. */
+  body: string;
+  /** Pixel height of the board area. Default 480 (fits the NotesPanel surface). */
+  height?: number;
+  /** Agent identity. Defaults to Aion ($A0). */
+  agent?: SharedWhiteboardProps["agent"];
+}
+
+/**
+ * Pure helper — parse the note body string into SharedWhiteboard
+ * initial-state props. Tolerates empty/invalid JSON by returning empty
+ * arrays for each slot. Exposed for testability.
+ */
+export function parseWhiteboardBody(body: string): {
+  initialNotes: NonNullable<SharedWhiteboardProps["initialNotes"]>;
+  initialShapes: NonNullable<SharedWhiteboardProps["initialShapes"]>;
+  initialConnectors: NonNullable<SharedWhiteboardProps["initialConnectors"]>;
+  initialStrokes: NonNullable<SharedWhiteboardProps["initialStrokes"]>;
+  initialViewport: SharedWhiteboardProps["initialViewport"];
+} {
+  const empty = {
+    initialNotes: [],
+    initialShapes: [],
+    initialConnectors: [],
+    initialStrokes: [],
+    initialViewport: undefined,
+  } as const;
+  if (body.trim().length === 0) return { ...empty };
+  let parsed: Record<string, unknown>;
+  try {
+    const out = JSON.parse(body) as unknown;
+    if (out === null || typeof out !== "object" || Array.isArray(out)) return { ...empty };
+    parsed = out as Record<string, unknown>;
+  } catch {
+    return { ...empty };
+  }
+  function arr<T>(key: string): T[] {
+    const v = parsed[key];
+    return Array.isArray(v) ? (v as T[]) : [];
+  }
+  return {
+    initialNotes: arr<NonNullable<SharedWhiteboardProps["initialNotes"]>[number]>("notes"),
+    initialShapes: arr<NonNullable<SharedWhiteboardProps["initialShapes"]>[number]>("shapes"),
+    initialConnectors: arr<NonNullable<SharedWhiteboardProps["initialConnectors"]>[number]>("connectors"),
+    initialStrokes: arr<NonNullable<SharedWhiteboardProps["initialStrokes"]>[number]>("strokes"),
+    initialViewport: (parsed["viewport"] ?? undefined) as SharedWhiteboardProps["initialViewport"],
+  };
+}
+
+export function WhiteboardEditor({ body, height = 480, agent }: WhiteboardEditorProps) {
+  const initial = useMemo(() => parseWhiteboardBody(body), [body]);
+  return (
+    <div className="flex-1 min-h-0" data-testid="notes-whiteboard-editor">
+      <SharedWhiteboard
+        {...initial}
+        agent={agent ?? { id: "$A0", name: "Aion", color: "#fbbf24" }}
+        shareBaseUrl={null}
+        showAgentPanel
+        showShareControls={false}
+        broadcastEdits={false}
+        height={height}
+      />
+    </div>
+  );
+}

--- a/ui/dashboard/src/main.tsx
+++ b/ui/dashboard/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from "react-dom/client";
 import { registerAll as registerAllEChartTypes } from "@particle-academy/react-echarts";
 import "./index.css";
 import "@particle-academy/react-fancy/styles.css";
+import "@particle-academy/fancy-whiteboard/styles.css";
+import "@particle-academy/agent-integrations/styles.css";
 import { App } from "./App.js";
 import { isElectron } from "./lib/environment.js";
 import { setupContentRendererExtensions } from "./lib/content-renderer-setup.js";


### PR DESCRIPTION
Phase 2b replaces the Phase 2a placeholder Card with the actual `fancy-whiteboard` Canvas via agent-integrations' `SharedWhiteboard` composite. One drop-in component delivers Board + StickyNote + Shape + Connector + Drawing + CursorLayer primitives, an in-page `MicroMcpServer`, the AgentPanel, and presence cursors.

## What ships
- `main.tsx`: 2 new global CSS imports (`fancy-whiteboard/styles.css` + `agent-integrations/styles.css`)
- `WhiteboardEditor.tsx`: thin wrapper over `SharedWhiteboard` with `parseWhiteboardBody` helper that hydrates initial state from the note body JSON. Aion identifies as `$A0` (yellow color) in the AgentPanel; `shareBaseUrl=null` disables external relay (Phase 2c).
- `WhiteboardEditor.test.ts`: 7 pure-logic tests for `parseWhiteboardBody` (empty/whitespace/invalid/null/array/object/slot-type-mismatch/`{}`).
- `NotesPanel.tsx`: whiteboard-kind branch renders `<WhiteboardEditor body={draftBody}/>` instead of the placeholder.

## Phase 2c (next slice)
`SharedWhiteboard` owns its internal state and doesn't expose `onChange` — new whiteboard content is currently session-ephemeral. Options: (a) wait for upstream `onStateChange` prop, (b) swap to lower-level Board + controlled state pattern. Documented inline.

## Test plan
- 7/7 pure-logic tests pass.
- Manual: create a +Board note, draw, switch away — content survives within the session; persist-across-reloads is Phase 2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)