### PR TITLE
Release v0.4.659 — CPU sustained-high watchdog → main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.658",
+  "version": "0.4.659",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/cpu-watchdog.test.ts
+++ b/packages/gateway-core/src/cpu-watchdog.test.ts
@@ -1,0 +1,145 @@
+/**
+ * CpuWatchdog pure-logic tests (s159-sibling: sustained-CPU alert).
+ */
+
+import { describe, it, expect } from "vitest";
+import { CpuWatchdog, DEFAULT_CPU_WATCHDOG_CONFIG } from "./cpu-watchdog.js";
+
+describe("CpuWatchdog defaults", () => {
+  it("starts in normal state", () => {
+    const w = new CpuWatchdog();
+    expect(w.getState()).toBe("normal");
+  });
+
+  it("emits no events for low samples", () => {
+    const w = new CpuWatchdog();
+    for (let i = 0; i < 10; i++) {
+      expect(w.feed(20)).toBeNull();
+    }
+    expect(w.getState()).toBe("normal");
+  });
+
+  it("does NOT fire before sustainWindow samples", () => {
+    const w = new CpuWatchdog();
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow - 1; i++) {
+      expect(w.feed(95)).toBeNull();
+    }
+    expect(w.getState()).toBe("normal");
+  });
+
+  it("fires alert-fired after sustainWindow consecutive high samples", () => {
+    const w = new CpuWatchdog();
+    const events = [];
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) {
+      const evt = w.feed(95);
+      if (evt) events.push(evt);
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("alert-fired");
+    expect(w.getState()).toBe("alerting");
+  });
+
+  it("resets streak when a low sample breaks the high run", () => {
+    const w = new CpuWatchdog();
+    // 3 highs, then a low, then 5 highs — should NOT fire (only 5 consecutive)
+    for (let i = 0; i < 3; i++) w.feed(95);
+    w.feed(20); // breaks streak
+    for (let i = 0; i < 5; i++) {
+      expect(w.feed(95)).toBeNull();
+    }
+    expect(w.getState()).toBe("normal");
+  });
+
+  it("clears alert after clearWindow consecutive low samples", () => {
+    const w = new CpuWatchdog();
+    // Fire the alert
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) w.feed(95);
+    expect(w.getState()).toBe("alerting");
+    // Feed clear samples
+    const events = [];
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.clearWindow; i++) {
+      const evt = w.feed(20);
+      if (evt) events.push(evt);
+    }
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe("alert-cleared");
+    expect(w.getState()).toBe("normal");
+  });
+
+  it("hysteresis — samples between clearThreshold and highThreshold do NOT clear", () => {
+    const w = new CpuWatchdog();
+    // Fire
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) w.feed(95);
+    expect(w.getState()).toBe("alerting");
+    // Feed samples in the hysteresis band (75% — below high, above clear)
+    for (let i = 0; i < 20; i++) {
+      expect(w.feed(75)).toBeNull();
+    }
+    expect(w.getState()).toBe("alerting");
+  });
+
+  it("clear streak resets when a sample bumps back into hysteresis band", () => {
+    const w = new CpuWatchdog();
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) w.feed(95);
+    // Partial clear progress
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.clearWindow - 1; i++) w.feed(50);
+    expect(w.getStreak().clear).toBe(DEFAULT_CPU_WATCHDOG_CONFIG.clearWindow - 1);
+    // Bump back up — should reset
+    w.feed(75);
+    expect(w.getStreak().clear).toBe(0);
+    expect(w.getState()).toBe("alerting");
+  });
+
+  it("can fire-clear-fire across multiple cycles", () => {
+    const w = new CpuWatchdog();
+    const events = [];
+    // Cycle 1: fire
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) {
+      const e = w.feed(95);
+      if (e) events.push(e);
+    }
+    // Clear
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.clearWindow; i++) {
+      const e = w.feed(20);
+      if (e) events.push(e);
+    }
+    // Cycle 2: fire again
+    for (let i = 0; i < DEFAULT_CPU_WATCHDOG_CONFIG.sustainWindow; i++) {
+      const e = w.feed(95);
+      if (e) events.push(e);
+    }
+    expect(events.map((e) => e.kind)).toEqual(["alert-fired", "alert-cleared", "alert-fired"]);
+  });
+});
+
+describe("CpuWatchdog with custom config", () => {
+  it("respects shorter sustainWindow", () => {
+    const w = new CpuWatchdog({
+      highThreshold: 80,
+      sustainWindow: 2,
+      clearThreshold: 50,
+      clearWindow: 2,
+    });
+    w.feed(85);
+    const evt = w.feed(85);
+    expect(evt?.kind).toBe("alert-fired");
+  });
+
+  it("uses custom thresholds", () => {
+    const w = new CpuWatchdog({
+      highThreshold: 50,
+      sustainWindow: 3,
+      clearThreshold: 30,
+      clearWindow: 3,
+    });
+    // 55 > 50 high
+    for (let i = 0; i < 3; i++) w.feed(55);
+    expect(w.getState()).toBe("alerting");
+    // 40 is between 30 and 50 — hysteresis band, should NOT clear
+    for (let i = 0; i < 10; i++) w.feed(40);
+    expect(w.getState()).toBe("alerting");
+    // 25 < 30 clear
+    for (let i = 0; i < 3; i++) w.feed(25);
+    expect(w.getState()).toBe("normal");
+  });
+});

--- a/packages/gateway-core/src/cpu-watchdog.ts
+++ b/packages/gateway-core/src/cpu-watchdog.ts
@@ -1,0 +1,112 @@
+/**
+ * CpuWatchdog — sustained-high CPU detector with hysteresis.
+ *
+ * Owner directive 2026-05-12: "agi needs something that throws an alert if
+ * CPU usage is high for a sustained period of time." Real incident
+ * background: 324 stuck multipass-exec processes accumulated over 34
+ * hours pushed load average to 329 before the owner noticed. The pre-fix
+ * Aionima had no early-warning surface for sustained-high CPU.
+ *
+ * **Design — pure state machine, no I/O.** The 30s resource-stats sampler
+ * already produces a cpu % every tick (`recordStatsSnapshot` in
+ * server-runtime-state.ts). The watchdog observes each sample and emits
+ * transition events: alert-fired when the high-CPU pattern is sustained,
+ * alert-cleared when it returns to normal. The wrapper owns logging,
+ * incident-record writes, and dashboard notification.
+ *
+ * **Default thresholds (overridable via config):**
+ *   - High threshold: 90% CPU. Once N consecutive samples sit at-or-above
+ *     this value, the watchdog fires.
+ *   - Sustain window: 6 samples × 30s interval = 3 minutes.
+ *   - Clear threshold: 70% CPU. Hysteresis avoids flapping on a noisy
+ *     just-below-the-high-threshold trace.
+ *   - Clear window: 4 samples × 30s = 2 minutes below clear threshold.
+ *
+ * Total alert latency: 3 minutes from first high sample. Clearance: 2
+ * minutes from first low sample. These match a "sustained" intuition
+ * without alerting on every 30s spike.
+ */
+
+export interface CpuWatchdogConfig {
+  /** High threshold percentage (0-100). Samples ≥ this count toward fire. */
+  highThreshold: number;
+  /** Number of consecutive ≥-high samples needed to fire the alert. */
+  sustainWindow: number;
+  /** Clear threshold percentage. Samples < this count toward clearance. */
+  clearThreshold: number;
+  /** Number of consecutive <-clear samples needed to clear the alert. */
+  clearWindow: number;
+}
+
+/** Default thresholds: 90% sustained for 3min (6×30s), clear at 70% for 2min (4×30s). */
+export const DEFAULT_CPU_WATCHDOG_CONFIG: CpuWatchdogConfig = {
+  highThreshold: 90,
+  sustainWindow: 6,
+  clearThreshold: 70,
+  clearWindow: 4,
+};
+
+export type CpuWatchdogEvent =
+  | { kind: "alert-fired"; cpuPercent: number; sustainedSamples: number }
+  | { kind: "alert-cleared"; cpuPercent: number; clearedSamples: number };
+
+export type WatchdogState = "normal" | "alerting";
+
+/**
+ * Sliding-counter implementation — tracks consecutive samples in each
+ * direction. Resets the counter when the sample falls outside the
+ * relevant band. Hysteresis prevents flapping: once alerting, only the
+ * clear band's consecutive count is tracked (high count irrelevant);
+ * once normal, only the high band counts.
+ */
+export class CpuWatchdog {
+  private state: WatchdogState = "normal";
+  private highStreak = 0;
+  private clearStreak = 0;
+
+  constructor(private readonly config: CpuWatchdogConfig = DEFAULT_CPU_WATCHDOG_CONFIG) {}
+
+  /**
+   * Feed one cpu % sample. Returns an event when state transitions; null
+   * otherwise. Wrapper consumes the event to log + notify + record incident.
+   */
+  feed(cpuPercent: number): CpuWatchdogEvent | null {
+    if (this.state === "normal") {
+      if (cpuPercent >= this.config.highThreshold) {
+        this.highStreak += 1;
+        if (this.highStreak >= this.config.sustainWindow) {
+          this.state = "alerting";
+          const sustained = this.highStreak;
+          this.highStreak = 0; // reset for next cycle
+          return { kind: "alert-fired", cpuPercent, sustainedSamples: sustained };
+        }
+      } else {
+        this.highStreak = 0;
+      }
+      return null;
+    }
+    // state === "alerting"
+    if (cpuPercent < this.config.clearThreshold) {
+      this.clearStreak += 1;
+      if (this.clearStreak >= this.config.clearWindow) {
+        this.state = "normal";
+        const cleared = this.clearStreak;
+        this.clearStreak = 0;
+        return { kind: "alert-cleared", cpuPercent, clearedSamples: cleared };
+      }
+    } else {
+      this.clearStreak = 0;
+    }
+    return null;
+  }
+
+  /** Diagnostic — current state for logs / dashboard. */
+  getState(): WatchdogState {
+    return this.state;
+  }
+
+  /** Diagnostic — how many consecutive samples in the current direction. */
+  getStreak(): { high: number; clear: number } {
+    return { high: this.highStreak, clear: this.clearStreak };
+  }
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -4176,6 +4176,14 @@ export async function createGatewayRuntimeState(
   const STATS_HISTORY_MAX = 2880;
   const STATS_RECORD_INTERVAL_MS = 30_000;
   const STATS_FLUSH_INTERVAL_MS = 5 * 60 * 1000; // Write to disk every 5 minutes
+
+  // CPU sustained-high watchdog (owner directive 2026-05-12, after the
+  // 324-stuck-multipass-exec incident pushed load avg to 329). Fires when
+  // CPU stays ≥90% for 3 minutes (6 consecutive 30s samples); clears
+  // after 2 minutes <70%. Pure state machine in `./cpu-watchdog.ts`.
+  const { CpuWatchdog, DEFAULT_CPU_WATCHDOG_CONFIG } = await import("./cpu-watchdog.js");
+  const cpuWatchdog = new CpuWatchdog(DEFAULT_CPU_WATCHDOG_CONFIG);
+  const watchdogLog = createComponentLogger(deps.logger, "cpu-watchdog");
   type StatsPoint = { ts: string; cpu: number; mem: number; disk: number; diskRead: number; diskWrite: number; load1: number; load5: number; load15: number; cpuWatts?: number; gpuWatts?: number };
   const statsHistory: StatsPoint[] = [];
 
@@ -4432,6 +4440,25 @@ export async function createGatewayRuntimeState(
       });
       if (statsHistory.length > STATS_HISTORY_MAX) {
         statsHistory.splice(0, statsHistory.length - STATS_HISTORY_MAX);
+      }
+
+      // CPU watchdog feed — observes each 30s CPU sample, transitions on
+      // sustained-high vs cleared, logs WARN on fire and INFO on clear.
+      // Wire to dashboard notifications via DashboardEvent if deps surface
+      // an emitter; pure log-only otherwise.
+      const wdEvt = cpuWatchdog.feed(cpuUsage);
+      if (wdEvt !== null) {
+        const cores = Math.max(1, (await import("node:os")).cpus().length);
+        const load1Now = Math.round(loadAvg[0]! * 100) / 100;
+        if (wdEvt.kind === "alert-fired") {
+          watchdogLog.warn(
+            `🚨 SUSTAINED HIGH CPU — ${String(wdEvt.cpuPercent)}% for ${String(wdEvt.sustainedSamples)} consecutive 30s samples (load1=${String(load1Now)}, cores=${String(cores)}). Investigate: \`ps -eo pid,pcpu,etime,command --sort=-pcpu | head -20\` then \`agi doctor\`.`,
+          );
+        } else {
+          watchdogLog.info(
+            `CPU watchdog cleared — ${String(wdEvt.cpuPercent)}% after ${String(wdEvt.clearedSamples)} consecutive low samples.`,
+          );
+        }
       }
     } catch { /* stats recording failed — non-fatal */ }
   }


### PR DESCRIPTION
Dev → main release. Single commit: the CPU sustained-high watchdog (v0.4.659), shipped today after the host's load average hit 329 with zero in-system alerting.

## Why this should land on main today
The watchdog is real-incident response — protects future operators from the same blindness that let 324 stuck multipass-exec processes pile up over 34 hours. No new feature surface; pure observability addition. Default thresholds tuned conservatively (90% sustained 3 min, clear at 70% for 2 min) so benign peaks don't alert.

## Commit
- `e5b02d8` — `agi v0.4.659 — CPU sustained-high watchdog (real-incident response 2026-05-12) (#172)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)