### PR TITLE
v0.4.883 — 3-panel shell, Discord fixes, hosting, chat, migrations

### DIFF
--- a/channels/discord/src/config.ts
+++ b/channels/discord/src/config.ts
@@ -32,6 +32,19 @@ export interface DiscordConfig {
   mentionOnly?: boolean;
   /** Max messages per user per minute before rate-limiting (default: 20). */
   rateLimitPerMinute?: number;
+  /**
+   * Enable the Server Members privileged intent.
+   *
+   * Required for: guild member sync on bot ready, `discord_list_members` tool,
+   * per-guild role data in `discord_get_user` tool.
+   *
+   * BEFORE enabling this, go to discord.com/developers/applications → your app
+   * → Bot → Privileged Gateway Intents → turn on "Server Members Intent".
+   * Without that portal toggle, discord.js will fail to connect (4014 error).
+   *
+   * Default: false (bot connects without member data).
+   */
+  enableServerMembersIntent?: boolean;
 }
 
 /**
@@ -87,6 +100,9 @@ export function isDiscordConfig(value: unknown): value is DiscordConfig {
   if ("mentionOnly" in obj && typeof obj["mentionOnly"] !== "boolean")
     return false;
 
+  if ("enableServerMembersIntent" in obj && typeof obj["enableServerMembersIntent"] !== "boolean")
+    return false;
+
   if (
     "rateLimitPerMinute" in obj &&
     (typeof obj["rateLimitPerMinute"] !== "number" ||
@@ -110,6 +126,7 @@ export function createConfigAdapter(): ChannelConfigAdapter {
       allowedRoleIds: "",
       mentionOnly: true,
       rateLimitPerMinute: 20,
+      enableServerMembersIntent: false,
     }),
   };
 }

--- a/channels/discord/src/config.ts
+++ b/channels/discord/src/config.ts
@@ -97,20 +97,74 @@ export function isDiscordConfig(value: unknown): value is DiscordConfig {
     }
   }
 
-  if ("mentionOnly" in obj && typeof obj["mentionOnly"] !== "boolean")
-    return false;
+  // Accept boolean OR "true"/"false" string — the dashboard form serialises
+  // all config values as strings; coerceDiscordConfig() normalises them before
+  // the plugin consumes them.
+  if ("mentionOnly" in obj) {
+    const v = obj["mentionOnly"];
+    if (v !== undefined && typeof v !== "boolean" && v !== "true" && v !== "false")
+      return false;
+  }
 
-  if ("enableServerMembersIntent" in obj && typeof obj["enableServerMembersIntent"] !== "boolean")
-    return false;
+  if ("enableServerMembersIntent" in obj) {
+    const v = obj["enableServerMembersIntent"];
+    if (v !== undefined && typeof v !== "boolean" && v !== "true" && v !== "false")
+      return false;
+  }
 
-  if (
-    "rateLimitPerMinute" in obj &&
-    (typeof obj["rateLimitPerMinute"] !== "number" ||
-      obj["rateLimitPerMinute"] <= 0)
-  )
-    return false;
+  if ("rateLimitPerMinute" in obj) {
+    const v = obj["rateLimitPerMinute"];
+    if (v !== undefined) {
+      if (typeof v === "number") {
+        if (v <= 0) return false;
+      } else if (typeof v === "string") {
+        const n = Number(v);
+        if (Number.isNaN(n) || n <= 0) return false;
+      } else {
+        return false;
+      }
+    }
+  }
 
   return true;
+}
+
+/**
+ * Coerce a validated-but-stringified Discord config object to proper types.
+ *
+ * The dashboard settings form stores ALL values as `Record<string, string>`.
+ * This means boolean fields arrive as `"true"/"false"` and numeric fields as
+ * numeric strings. Call this after `isDiscordConfig()` returns true to
+ * guarantee `createDiscordPlugin()` always receives correctly-typed values.
+ */
+export function coerceDiscordConfig(raw: Record<string, unknown>): DiscordConfig {
+  const parseBool = (v: unknown, def: boolean): boolean =>
+    v === true || v === "true" ? true : v === false || v === "false" ? false : def;
+  const posNum = (v: unknown, def: number): number => {
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) && n > 0 ? n : def;
+  };
+  return {
+    botToken: String(raw["botToken"] ?? ""),
+    ...(raw["applicationId"] !== undefined
+      ? { applicationId: String(raw["applicationId"]) }
+      : {}),
+    ...(raw["allowedGuildIds"] !== undefined
+      ? { allowedGuildIds: raw["allowedGuildIds"] as DiscordConfig["allowedGuildIds"] }
+      : {}),
+    ...(raw["allowedChannelIds"] !== undefined
+      ? { allowedChannelIds: raw["allowedChannelIds"] as DiscordConfig["allowedChannelIds"] }
+      : {}),
+    ...(raw["allowedRoleIds"] !== undefined
+      ? { allowedRoleIds: raw["allowedRoleIds"] as DiscordConfig["allowedRoleIds"] }
+      : {}),
+    ...(raw["presenceChannelIds"] !== undefined
+      ? { presenceChannelIds: raw["presenceChannelIds"] as DiscordConfig["presenceChannelIds"] }
+      : {}),
+    mentionOnly: parseBool(raw["mentionOnly"], true),
+    rateLimitPerMinute: posNum(raw["rateLimitPerMinute"], 20),
+    enableServerMembersIntent: parseBool(raw["enableServerMembersIntent"], false),
+  };
 }
 
 /** ChannelConfigAdapter for the Discord channel. */

--- a/channels/discord/src/config.ts
+++ b/channels/discord/src/config.ts
@@ -97,24 +97,24 @@ export function isDiscordConfig(value: unknown): value is DiscordConfig {
     }
   }
 
-  // Accept boolean OR "true"/"false" string — the dashboard form serialises
-  // all config values as strings; coerceDiscordConfig() normalises them before
-  // the plugin consumes them.
+  // Accept boolean, "true"/"false" string, OR empty string (field cleared in UI = use default).
+  // coerceDiscordConfig() normalises these before the plugin consumes them.
   if ("mentionOnly" in obj) {
     const v = obj["mentionOnly"];
-    if (v !== undefined && typeof v !== "boolean" && v !== "true" && v !== "false")
+    if (v !== undefined && v !== "" && typeof v !== "boolean" && v !== "true" && v !== "false")
       return false;
   }
 
   if ("enableServerMembersIntent" in obj) {
     const v = obj["enableServerMembersIntent"];
-    if (v !== undefined && typeof v !== "boolean" && v !== "true" && v !== "false")
+    if (v !== undefined && v !== "" && typeof v !== "boolean" && v !== "true" && v !== "false")
       return false;
   }
 
   if ("rateLimitPerMinute" in obj) {
     const v = obj["rateLimitPerMinute"];
-    if (v !== undefined) {
+    // Empty string = field cleared, treat as "not set" (coerce will use default)
+    if (v !== undefined && v !== "") {
       if (typeof v === "number") {
         if (v <= 0) return false;
       } else if (typeof v === "string") {
@@ -138,9 +138,11 @@ export function isDiscordConfig(value: unknown): value is DiscordConfig {
  * guarantee `createDiscordPlugin()` always receives correctly-typed values.
  */
 export function coerceDiscordConfig(raw: Record<string, unknown>): DiscordConfig {
+  // Empty string = field cleared in UI; treat as not-set and use the default.
   const parseBool = (v: unknown, def: boolean): boolean =>
     v === true || v === "true" ? true : v === false || v === "false" ? false : def;
   const posNum = (v: unknown, def: number): number => {
+    if (v === "" || v === null || v === undefined) return def;
     const n = typeof v === "number" ? v : Number(v);
     return Number.isFinite(n) && n > 0 ? n : def;
   };

--- a/channels/discord/src/index.ts
+++ b/channels/discord/src/index.ts
@@ -480,24 +480,23 @@ export function createDiscordPlugin(
     throw new Error("Invalid Discord config: botToken is required");
   }
 
-  // Owner directive 2026-05-13: Aion needs richer Discord context —
-  // user profiles, roles, presence, all messages with time-window search.
-  // GuildMembers + GuildPresences are PRIVILEGED intents — must be
-  // enabled in the Discord developer portal for the bot before this
-  // client can connect with them. If the bot login fails with a
-  // privileged-intent error, the operator needs to toggle them on at
-  // https://discord.com/developers/applications/<applicationId>/bot.
-  const client = new Client({
-    intents: [
-      GatewayIntentBits.Guilds,
-      GatewayIntentBits.GuildMessages,
-      GatewayIntentBits.MessageContent,
-      GatewayIntentBits.DirectMessages,
-      GatewayIntentBits.GuildMembers,    // roles + member metadata (privileged)
-      // GuildPresences requires Presence Intent enabled in the developer portal.
-      // Disabled until explicitly needed — enable in portal first, then re-add.
-    ],
-  });
+  // GuildMembers and GuildPresences are PRIVILEGED intents — discord.js will
+  // fail to connect (4014 Disallowed Intents) if they're requested without the
+  // matching portal toggle turned ON at:
+  // https://discord.com/developers/applications/<applicationId>/bot
+  //
+  // GuildMembers: controlled by config.enableServerMembersIntent (default off).
+  // GuildPresences: disabled until explicitly needed — enable portal toggle first.
+  const baseIntents = [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.DirectMessages,
+  ];
+  if (config.enableServerMembersIntent) {
+    baseIntents.push(GatewayIntentBits.GuildMembers);
+  }
+  const client = new Client({ intents: baseIntents });
 
   let running = false;
   let messageHandler: ((message: AionimaMessage) => Promise<void>) | null = null;
@@ -772,10 +771,10 @@ export function createDiscordPlugin(
       );
     }
 
-    // Proactive member sync — register all guild members with allowed roles
-    // as pending AGI user accounts so they appear in Settings → Users before
-    // they ever send a message.
-    if (opts?.createUser) {
+    // Proactive member sync — only when Server Members Intent is enabled.
+    // guild.members.fetch() requires GuildMembers intent; without it the call
+    // throws. Skip sync silently when the intent is not configured.
+    if (opts?.createUser && config.enableServerMembersIntent) {
       const createUser = opts.createUser;
       const allowedRoleIds = normalizeDiscordArrayField(config.allowedRoleIds);
       void (async () => {

--- a/channels/discord/src/index.ts
+++ b/channels/discord/src/index.ts
@@ -27,6 +27,7 @@ import type {
 import {
   type DiscordConfig,
   isDiscordConfig,
+  coerceDiscordConfig,
   createConfigAdapter,
   normalizeDiscordArrayField,
 } from "./config.js";
@@ -48,7 +49,7 @@ import { getDiscordState, getDiscordAvailableRooms } from "./state.js";
 
 // Re-exports for consumer convenience
 export type { DiscordConfig } from "./config.js";
-export { isDiscordConfig } from "./config.js";
+export { isDiscordConfig, coerceDiscordConfig } from "./config.js";
 export {
   normalizeMessage,
   buildDisplayName,
@@ -926,6 +927,10 @@ export default {
       return;
     }
 
+    // Coerce string-serialized booleans/numbers from the dashboard form
+    // (form state is Record<string,string> so mentionOnly:"true", rateLimitPerMinute:"20" etc.)
+    const discordConfig = coerceDiscordConfig(channelConfig.config as Record<string, unknown>);
+
     const createUser = api.getOrCreateChannelUser?.bind(api);
     const logMessage = api.logAmbientMessage?.bind(api);
     const getContext = api.getAmbientContext?.bind(api);
@@ -935,7 +940,7 @@ export default {
     const deleteRegistrationSession = api.deleteRegistrationSession?.bind(api);
     const capturePendingApproval = api.capturePendingApproval?.bind(api);
     const plugin = createDiscordPlugin(
-      channelConfig.config as unknown as DiscordConfig,
+      discordConfig,
       {
         ...(createUser ? { createUser } : {}),
         ...(logMessage ? { logMessage } : {}),

--- a/e2e/accordion-flyout.spec.ts
+++ b/e2e/accordion-flyout.spec.ts
@@ -73,20 +73,20 @@ test.describe("AccordionFlyout chrome", () => {
     await expect(chatEmptyState).toBeVisible();
   });
 
-  test("shell chat rail trigger collapses and re-expands chat panel", async ({ page }) => {
-    // The shell's CHAT rail trigger handles panel collapse — no header button.
-    const chatRail = page.getByTestId("shell-rail-chat");
+  test("shell chat panel header collapses and re-expands chat panel", async ({ page }) => {
+    // The shell chat panel header's collapse button handles panel collapse.
+    const toggleBtn = page.getByTestId("shell-panel-toggle-chat");
     const flyout = page.getByTestId("chat-flyout");
 
     await expect(flyout).toBeVisible();
-    await expect(chatRail).toBeVisible();
+    await expect(toggleBtn).toBeVisible();
 
-    // Collapse via the shell rail.
-    await chatRail.click();
+    // Collapse via the header collapse button.
+    await toggleBtn.click();
     await expect(flyout).not.toBeVisible({ timeout: 3_000 });
 
-    // Re-expand.
-    await chatRail.click();
+    // Re-expand by clicking the collapsed header strip.
+    await page.getByTestId("shell-panel-header-chat").click();
     await expect(flyout).toBeVisible({ timeout: 3_000 });
   });
 

--- a/e2e/accordion-flyout.spec.ts
+++ b/e2e/accordion-flyout.spec.ts
@@ -18,8 +18,8 @@ import { test, expect } from "@playwright/test";
 test.describe("AccordionFlyout chrome", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    await page.getByTestId("header-chat-button").click();
-    await expect(page.getByTestId("chat-flyout")).toBeVisible();
+    // Chat is always visible in the shell — no button click needed
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
   });
 
   test("renders both canvas and chat panels by default on desktop", async ({ page }) => {
@@ -73,23 +73,21 @@ test.describe("AccordionFlyout chrome", () => {
     await expect(chatEmptyState).toBeVisible();
   });
 
-  test("header chat button stays clickable above the open flyout", async ({ page }) => {
-    // The flyout sits at z-[200]; the sticky header is at z-[100], BUT the
-    // header-chat-button is positioned to remain interactable because the
-    // flyout has pointer-events-none on its outer container. Verify by
-    // toggling the flyout off and on without dismissing through the panel.
-    const chatButton = page.getByTestId("header-chat-button");
+  test("shell chat rail trigger collapses and re-expands chat panel", async ({ page }) => {
+    // The shell's CHAT rail trigger handles panel collapse — no header button.
+    const chatRail = page.getByTestId("shell-rail-chat");
     const flyout = page.getByTestId("chat-flyout");
 
     await expect(flyout).toBeVisible();
+    await expect(chatRail).toBeVisible();
 
-    // Click the header chat button — should toggle flyout closed.
-    await chatButton.click();
-    await expect(flyout).not.toBeVisible();
+    // Collapse via the shell rail.
+    await chatRail.click();
+    await expect(flyout).not.toBeVisible({ timeout: 3_000 });
 
-    // Re-open.
-    await chatButton.click();
-    await expect(flyout).toBeVisible();
+    // Re-expand.
+    await chatRail.click();
+    await expect(flyout).toBeVisible({ timeout: 3_000 });
   });
 
   test("aria attributes on rail triggers reflect open/closed state", async ({ page }) => {

--- a/e2e/agi-bash-passthrough.spec.ts
+++ b/e2e/agi-bash-passthrough.spec.ts
@@ -77,8 +77,8 @@ test.describe("agi bash passthrough — caller migration enforcement", () => {
       const sentinel = `echo agi-bash-passthrough-sentinel-${Date.now()}`;
 
       await page.goto("/");
-      await page.getByTestId("header-chat-button").click();
-      await expect(page.getByTestId("chat-flyout")).toBeVisible();
+      // Chat is always visible in the shell
+      await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
 
       const input = page.getByTestId("chat-input");
       await input.fill(`Run \`${sentinel}\` via the shell_exec tool and report the output.`);

--- a/e2e/chat-persona.spec.ts
+++ b/e2e/chat-persona.spec.ts
@@ -1,55 +1,42 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Chat with persona verification e2e (task #236, story #76).
+ * Chat persona verification (task #236, story #76).
  *
- * Verifies the chat flyout opens from the header chat button and that
- * the owner's persona/display-name is visible in the chat context.
- * Structural only — does not send messages or wait for LLM responses.
+ * Chat lives in the always-on 3-panel shell — no header button needed to open it.
+ * The header chat button was removed when the shell went always-on.
  */
 
 test.describe("Chat flyout — persona verification", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
-    // Wait for the main layout to hydrate
     await page.waitForSelector("[data-testid='hearth-top']", { timeout: 10_000 });
   });
 
-  test("header chat button is present", async ({ page }) => {
-    const chatBtn = page.getByTestId("header-chat-button");
-    await expect(chatBtn).toBeVisible();
+  test("chat flyout is always visible without clicking any button", async ({ page }) => {
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
   });
 
-  test("clicking header chat button opens the flyout", async ({ page }) => {
-    const chatBtn = page.getByTestId("header-chat-button");
-    await chatBtn.click();
-    // ChatFlyout renders a "Chat" header inside its panel when open
-    await expect(page.getByText("Chat", { exact: true })).toBeVisible({ timeout: 5_000 });
+  test("chat flyout has Chat header label", async ({ page }) => {
+    const flyout = page.getByTestId("chat-flyout");
+    await expect(flyout).toBeVisible({ timeout: 8_000 });
+    // "Chat" label in the panel header
+    await expect(flyout.getByText("Chat", { exact: true })).toBeVisible();
   });
 
-  test("chat flyout header has Expand + X controls", async ({ page }) => {
-    await page.getByTestId("header-chat-button").click();
-    await expect(page.getByRole("button", { name: "Expand", exact: true })).toBeVisible();
-    await expect(page.getByRole("button", { name: "X", exact: true })).toBeVisible();
-  });
-
-  test("clicking X closes the chat flyout", async ({ page }) => {
-    await page.getByTestId("header-chat-button").click();
-    // "Chat" text also appears in sidebar context; match the flyout's own region.
-    await expect(page.getByTestId("chat-flyout")).toBeVisible();
-
-    await page.getByRole("button", { name: "X", exact: true }).click();
-    await expect(page.getByTestId("chat-flyout")).not.toBeVisible({ timeout: 3_000 });
+  test("chat flyout has no X close button when docked in shell", async ({ page }) => {
+    // The X button exists only in overlay mode; docked shell uses the rail trigger
+    const flyout = page.getByTestId("chat-flyout");
+    await expect(flyout).toBeVisible({ timeout: 8_000 });
+    await expect(flyout.getByRole("button", { name: "X", exact: true })).toHaveCount(0);
   });
 
   test("profile popover shows owner display name", async ({ page }) => {
-    // Owner initial button in the header — testid header-owner-avatar
     const avatar = page.getByTestId("header-owner-avatar");
     const hasAvatar = await avatar.isVisible({ timeout: 5_000 }).catch(() => false);
     test.skip(!hasAvatar, "Owner profile not configured in this test environment");
 
     await avatar.click();
-    // ProfileCard should render inside the popover.
     await expect(page.locator("[role='dialog'], [data-popover-content]").first()).toBeVisible({ timeout: 3_000 });
   });
 });

--- a/e2e/flyout-panel.spec.ts
+++ b/e2e/flyout-panel.spec.ts
@@ -23,7 +23,7 @@ test.describe("Shell — chat panel", () => {
 
   test("shell rail triggers are present (canvas / chat)", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByTestId("shell-rail-canvas")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("shell-rail-workspace")).toBeVisible({ timeout: 8_000 });
     await expect(page.getByTestId("shell-rail-chat")).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/e2e/flyout-panel.spec.ts
+++ b/e2e/flyout-panel.spec.ts
@@ -21,9 +21,9 @@ test.describe("Shell — chat panel", () => {
     await expect(page.getByTestId("header-chat-button")).toHaveCount(0);
   });
 
-  test("shell rail triggers are present (canvas / chat)", async ({ page }) => {
+  test("shell panel headers are present (workspace / chat)", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByTestId("shell-rail-workspace")).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByTestId("shell-rail-chat")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("shell-panel-header-workspace")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("shell-panel-header-chat")).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/e2e/flyout-panel.spec.ts
+++ b/e2e/flyout-panel.spec.ts
@@ -1,18 +1,29 @@
 import { test, expect } from "@playwright/test";
 
-test.describe("FlyoutPanel", () => {
-  // FlyoutPanel is used indirectly through the chat button and project detail pages.
-  // These tests verify the component behavior through real usage.
+/**
+ * Shell layout — chat panel is always visible.
+ *
+ * Chat lives in the 3-panel AccordionPanel shell (Canvas | Chat | Workspace).
+ * There is no toggle button; chat is open by default on every route.
+ */
 
-  test("chat flyout opens and closes via sidebar button", async ({ page }) => {
+test.describe("Shell — chat panel", () => {
+  test("chat flyout is always visible without clicking any button", async ({ page }) => {
     await page.goto("/");
-    const chatButton = page.getByTestId("header-chat-button");
-    await chatButton.click();
-    // Chat button should show active state
-    await expect(chatButton).toHaveClass(/bg-primary/);
+    await page.waitForSelector("[data-testid='hearth-top']", { timeout: 10_000 });
+    // Chat panel renders immediately — no button click required
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
+  });
 
-    // Click again to close
-    await chatButton.click({ force: true });
-    await expect(chatButton).not.toHaveClass(/bg-primary/);
+  test("header chat toggle button is absent (chat is always on)", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector("[data-testid='hearth-top']", { timeout: 10_000 });
+    await expect(page.getByTestId("header-chat-button")).toHaveCount(0);
+  });
+
+  test("shell rail triggers are present (canvas / chat)", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("shell-rail-canvas")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("shell-rail-chat")).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/e2e/hearth-focused-layout.spec.ts
+++ b/e2e/hearth-focused-layout.spec.ts
@@ -22,7 +22,7 @@ test.describe("HearthFocusedLayout", () => {
       return;
     }
     await cards.first().click();
-    await expect(page).toHaveURL(/\/projects\/[a-z0-9_\-]+/);
+    await expect(page).toHaveURL(/\/projects\/[a-z0-9_-]+/);
     await expect(page.getByTestId("hearth-focused-layout")).toBeVisible();
   });
 

--- a/e2e/hearth-focused-layout.spec.ts
+++ b/e2e/hearth-focused-layout.spec.ts
@@ -1,64 +1,69 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * HearthFocusedLayout e2e tests.
+ * Hearth layout e2e tests.
  *
- * Verifies the 38/62 split layout on /projects/:slug and /comms/* routes:
- * HearthChatPane on the left, canvas content on the right.
- * Back button returns to HearthHome. Non-focused routes remain unaffected.
+ * The Hearth layout is always-on: a docked ChatFlyout on the left (hearth-layout
+ * container) + canvas content on the right. Chat is context-aware — navigating
+ * to a project sets the project context; any other route uses workspace chat.
  *
- * s198 — Focused canvas state.
+ * The old HearthChatPane (s198 stub with hearth-chat-pane/hearth-context-title/
+ * hearth-back-button testids) was replaced by the real docked ChatFlyout.
  */
 
-test.describe("HearthFocusedLayout", () => {
-  test("focused layout activates when navigating to a project", async ({ page }) => {
+test.describe("HearthLayout", () => {
+  // -------------------------------------------------------------------------
+  // Layout always present
+  // -------------------------------------------------------------------------
+
+  test("hearth-layout container is present on project detail route", async ({ page }) => {
     await page.goto("/projects");
     await page.waitForLoadState("networkidle");
 
     const cards = page.getByTestId("project-card");
-    const cardCount = await cards.count();
-    if (cardCount === 0) {
-      test.skip();
-      return;
-    }
+    if (await cards.count() === 0) { test.skip(); return; }
     await cards.first().click();
     await expect(page).toHaveURL(/\/projects\/[a-z0-9_-]+/);
-    await expect(page.getByTestId("hearth-focused-layout")).toBeVisible();
+    await expect(page.getByTestId("hearth-layout")).toBeVisible();
   });
 
-  test("HearthChatPane is visible on project detail route", async ({ page }) => {
+  test("hearth-layout container is present on /comms/discord", async ({ page }) => {
+    await page.goto("/comms/discord");
+    await expect(page.getByTestId("hearth-layout")).toBeVisible();
+  });
+
+  test("hearth-layout container is present on /settings routes", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page.getByTestId("hearth-layout")).toBeVisible();
+  });
+
+  test("hearth-layout container is present on /projects list", async ({ page }) => {
+    await page.goto("/projects");
+    await expect(page.getByTestId("hearth-layout")).toBeVisible();
+  });
+
+  // -------------------------------------------------------------------------
+  // ChatFlyout docked — visible by default (chatOpen starts true)
+  // -------------------------------------------------------------------------
+
+  test("docked ChatFlyout is visible on project detail route", async ({ page }) => {
     await page.goto("/projects");
     await page.waitForLoadState("networkidle");
 
     const cards = page.getByTestId("project-card");
     if (await cards.count() === 0) { test.skip(); return; }
     await cards.first().click();
-    await expect(page.getByTestId("hearth-chat-pane")).toBeVisible();
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 6000 });
   });
 
-  test("HearthChatPane has back button on project route", async ({ page }) => {
-    await page.goto("/projects");
-    await page.waitForLoadState("networkidle");
-
-    const cards = page.getByTestId("project-card");
-    if (await cards.count() === 0) { test.skip(); return; }
-    await cards.first().click();
-    await expect(page.getByTestId("hearth-back-button")).toBeVisible();
+  test("docked ChatFlyout is visible on /comms/discord", async ({ page }) => {
+    await page.goto("/comms/discord");
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 6000 });
   });
 
-  test("context title shows project name in left pane", async ({ page }) => {
-    await page.goto("/projects");
-    await page.waitForLoadState("networkidle");
-
-    const cards = page.getByTestId("project-card");
-    if (await cards.count() === 0) { test.skip(); return; }
-    await cards.first().click();
-    // Context title must be non-empty after navigation
-    const title = page.getByTestId("hearth-context-title");
-    await expect(title).toBeVisible();
-    const text = await title.textContent();
-    expect(text?.trim().length).toBeGreaterThan(0);
-  });
+  // -------------------------------------------------------------------------
+  // Canvas renders route content
+  // -------------------------------------------------------------------------
 
   test("canvas renders ProjectDetail content on project route", async ({ page }) => {
     await page.goto("/projects");
@@ -68,78 +73,25 @@ test.describe("HearthFocusedLayout", () => {
     if (await cards.count() === 0) { test.skip(); return; }
     await cards.first().click();
     await expect(page.getByTestId("hearth-canvas")).toBeVisible();
-    // ProjectDetail has a mode picker — verify canvas renders it
     await expect(page.getByTestId("project-mode-picker")).toBeVisible({ timeout: 6000 });
   });
 
-  test("back button returns to HearthHome", async ({ page }) => {
-    await page.goto("/projects");
-    await page.waitForLoadState("networkidle");
+  // -------------------------------------------------------------------------
+  // Header still visible
+  // -------------------------------------------------------------------------
 
-    const cards = page.getByTestId("project-card");
-    if (await cards.count() === 0) { test.skip(); return; }
-    await cards.first().click();
-    await expect(page.getByTestId("hearth-back-button")).toBeVisible();
-    await page.getByTestId("hearth-back-button").click();
-    await expect(page).toHaveURL("/");
-    await expect(page.getByTestId("hearth-home")).toBeVisible();
-  });
-
-  test("focused layout activates on /comms/discord", async ({ page }) => {
-    await page.goto("/comms/discord");
-    await expect(page.getByTestId("hearth-focused-layout")).toBeVisible();
-  });
-
-  test("HearthChatPane is visible on /comms/discord", async ({ page }) => {
-    await page.goto("/comms/discord");
-    await expect(page.getByTestId("hearth-chat-pane")).toBeVisible();
-  });
-
-  test("comms chat pane shows channel name as context title", async ({ page }) => {
-    await page.goto("/comms/discord");
-    const title = page.getByTestId("hearth-context-title");
-    await expect(title).toBeVisible();
-    await expect(title).toHaveText("Discord");
-  });
-
-  test("comms back button returns to HearthHome", async ({ page }) => {
-    await page.goto("/comms/discord");
-    await page.getByTestId("hearth-back-button").click();
-    await expect(page).toHaveURL("/");
-    await expect(page.getByTestId("hearth-home")).toBeVisible();
-  });
-
-  test("no focused layout on /settings routes", async ({ page }) => {
-    await page.goto("/settings");
-    await expect(page.getByTestId("hearth-focused-layout")).toHaveCount(0);
-    await expect(page.getByTestId("hearth-home")).toHaveCount(0);
-  });
-
-  test("no focused layout on /system routes", async ({ page }) => {
-    await page.goto("/system/security");
-    await expect(page.getByTestId("hearth-focused-layout")).toHaveCount(0);
-  });
-
-  test("/projects list page does not trigger focused layout", async ({ page }) => {
-    await page.goto("/projects");
-    await expect(page.getByTestId("hearth-focused-layout")).toHaveCount(0);
-  });
-
-  test("HearthTop is still visible on focused routes", async ({ page }) => {
+  test("HearthTop is still visible on all routes", async ({ page }) => {
     await page.goto("/comms/discord");
     await expect(page.getByTestId("hearth-top")).toBeVisible();
   });
 
-  test("pane composer accepts text on project route", async ({ page }) => {
+  test("HearthTop is visible on project detail", async ({ page }) => {
     await page.goto("/projects");
     await page.waitForLoadState("networkidle");
 
     const cards = page.getByTestId("project-card");
     if (await cards.count() === 0) { test.skip(); return; }
     await cards.first().click();
-    const composer = page.getByTestId("hearth-pane-composer");
-    await expect(composer).toBeVisible();
-    await composer.fill("run tests");
-    await expect(composer).toHaveValue("run tests");
+    await expect(page.getByTestId("hearth-top")).toBeVisible();
   });
 });

--- a/e2e/logs-page-layout.spec.ts
+++ b/e2e/logs-page-layout.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Logs page full-height layout regression (v0.4.867).
+ *
+ * Prior to v0.4.867, LogsPage wrapped the Logs component in PageScroll
+ * (overflow-y-auto). The outer scroll and the inner entries-list scroll
+ * competed: scrolling the page moved the entire Logs component — including
+ * its toolbar — off-screen. Fix: LogsPage now uses flex-1 min-h-0 without
+ * PageScroll, matching the DocsPage / KnowledgePage full-height pattern.
+ *
+ * These tests verify the toolbar stays anchored and the layout is correct.
+ *
+ * **Pre-conditions:**
+ *   - Test VM running with gateway up (services-start)
+ */
+
+test.describe("Logs page full-height layout (v0.4.867)", () => {
+  test("/gateway/logs renders without crash", async ({ page }) => {
+    await page.goto("/gateway/logs", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/gateway\/logs(\?|#|$)/, { timeout: 10_000 });
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible();
+  });
+
+  test("log toolbar is visible in the initial viewport (not scrolled off)", async ({ page }) => {
+    await page.goto("/gateway/logs", { waitUntil: "domcontentloaded" });
+
+    // The toolbar contains level checkboxes and Pause/Resume button.
+    // These must be visible WITHOUT any scrolling — if the double-scroll
+    // layout bug regresses, the toolbar goes off-screen immediately.
+    await expect(page.getByRole("button", { name: /pause|resume/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: /clear/i })).toBeVisible();
+
+    // Level filter labels (rendered as checkbox + label)
+    await expect(page.getByText("INFO")).toBeVisible();
+    await expect(page.getByText("ERROR")).toBeVisible();
+  });
+
+  test("toolbar is in the upper portion of the viewport — not below the fold", async ({ page }) => {
+    await page.goto("/gateway/logs", { waitUntil: "domcontentloaded" });
+
+    const pauseBtn = page.getByRole("button", { name: /pause|resume/i });
+    await expect(pauseBtn).toBeVisible({ timeout: 10_000 });
+
+    const box = await pauseBtn.boundingBox();
+    const viewport = page.viewportSize();
+
+    expect(box).not.toBeNull();
+    expect(viewport).not.toBeNull();
+
+    if (box && viewport) {
+      // Toolbar should be in the top 40% of the viewport.
+      // If the layout regresses (PageScroll wrapping), the toolbar position
+      // is unchanged initially but the component becomes scrollable from the
+      // OUTER container — the Pause button would appear at the expected
+      // position but the inner scroll would be broken.
+      expect(box.y).toBeLessThan(viewport.height * 0.4);
+    }
+  });
+
+  test("log entries area is visible and scrollable below the toolbar", async ({ page }) => {
+    await page.goto("/gateway/logs", { waitUntil: "domcontentloaded" });
+
+    // Wait for the connection indicator badge (Live / Disconnected)
+    const statusBadge = page.locator("[class*='border-green'], [class*='border-red']").first();
+    await statusBadge.waitFor({ state: "visible", timeout: 10_000 }).catch(() => {
+      // Badge may not render instantly — not a fatal failure
+    });
+
+    // The entries area renders either a "Waiting for log entries..." empty state
+    // or actual entries. Either way it should be visible.
+    const entriesOrEmpty = page.locator(
+      "[class*='overflow-y-auto'][class*='font-mono'], [class*='overflow-y-auto'][class*='px-4']",
+    ).first();
+    const waitingText = page.getByText(/waiting for log entries/i);
+
+    const entriesCount = await entriesOrEmpty.count();
+    const waitingCount = await waitingText.count();
+    expect(entriesCount + waitingCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test("/system/logs redirects to /gateway/logs", async ({ page }) => {
+    await page.goto("/system/logs", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/gateway\/logs(\?|#|$)/, { timeout: 8_000 });
+  });
+});

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -93,12 +93,10 @@ test.describe("WorkspaceChip Navigation", () => {
     await expect(page.getByTestId("workspace-chip-dropdown")).toHaveCount(0);
   });
 
-  test("chat button in header opens ChatFlyout", async ({ page }) => {
+  test("chat flyout is always visible in shell (no header button needed)", async ({ page }) => {
     await page.goto("/");
-    const chatButton = page.getByTestId("header-chat-button");
-    await expect(chatButton).toBeVisible();
-    await chatButton.click();
-    await expect(chatButton).toHaveClass(/bg-primary/);
+    await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("header-chat-button")).toHaveCount(0);
   });
 });
 

--- a/e2e/proj-header-stack-strip.spec.ts
+++ b/e2e/proj-header-stack-strip.spec.ts
@@ -17,7 +17,7 @@ test.describe("ProjHeader + StackStrip", () => {
     const cards = page.getByTestId("project-card");
     if (await cards.count() === 0) return false;
     await cards.first().click();
-    await expect(page).toHaveURL(/\/projects\/[a-z0-9_\-]+/);
+    await expect(page).toHaveURL(/\/projects\/[a-z0-9_-]+/);
     return true;
   }
 

--- a/e2e/proj-header-stack-strip.spec.ts
+++ b/e2e/proj-header-stack-strip.spec.ts
@@ -35,10 +35,9 @@ test.describe("ProjHeader + StackStrip", () => {
     expect(name?.trim().length).toBeGreaterThan(0);
   });
 
-  test("ProjHeader Chat button is clickable (no crash)", async ({ page }) => {
+  test("ProjHeader has no Chat button (chat is in the global shell)", async ({ page }) => {
     if (!await navigateToFirstProject(page)) { test.skip(); return; }
-    await page.getByTestId("proj-header-chat-button").click();
-    await expect(page.getByRole("heading", { name: /error/i })).toHaveCount(0);
+    await expect(page.getByTestId("proj-header-chat-button")).toHaveCount(0);
   });
 
   test("StackStrip renders between ProjHeader and mode picker", async ({ page }) => {

--- a/e2e/project-chat-solid.spec.ts
+++ b/e2e/project-chat-solid.spec.ts
@@ -59,18 +59,7 @@ test.describe("Project chat — solid (cycle 158)", () => {
     await cards.first().click();
     await expect(page).toHaveURL(/\/projects\/[a-z0-9-]+/, { timeout: 10_000 });
 
-    // Open the project chat — clicking the aside CTA opens the chat panel.
-    // The aside button is part of slice 5c phase 3 (cycle 147+); fall back
-    // to the header chat button if the project chat aside isn't rendered
-    // (e.g. core-fork projects, narrow viewports).
-    const projectChatBtn = page.getByRole("button", { name: /^Open chat$/i }).first();
-    if (await projectChatBtn.count() > 0 && await projectChatBtn.isVisible()) {
-      await projectChatBtn.click();
-    } else {
-      const headerChatBtn = page.getByTestId("header-chat-button");
-      await headerChatBtn.click();
-    }
-
+    // Chat is always visible in the shell — no button click needed.
     // Chat panel must surface AND carry the project slug as its active
     // context chip (the chip is the visual ack that project context is
     // being applied — without it, the agent invocation goes through the

--- a/e2e/project-workspace-mode-picker.spec.ts
+++ b/e2e/project-workspace-mode-picker.spec.ts
@@ -230,22 +230,16 @@ test.describe("Project workspace mode picker (s134 t517)", () => {
     await expect(page.getByTestId("project-mode-operate")).toHaveAttribute("aria-pressed", "true");
   });
 
-  test("flyout-shell wraps Canvas + Chat aside (slice 5c phase 2)", async ({ page }) => {
+  test("project detail has no chat aside (chat is in the global shell)", async ({ page }) => {
     const found = await navigateToFullModeProject(page);
     test.skip(!found, "no full-mode project available");
 
     // The flyout-shell wrapper must be present.
     await expect(page.getByTestId("project-flyout-shell")).toBeVisible();
 
-    // The chat aside is rendered (DOM-present); visibility depends on viewport
-    // width because of `hidden lg:flex`. Default Playwright viewport is 1280×720
-    // which is lg+, so the aside should be visible.
-    const aside = page.getByTestId("project-chat-aside");
-    await expect(aside).toBeAttached();
-    // Aside has a "Chat" header (cycle 145) and an Open-chat affordance
-    // (cycle 147 phase-3 starter — kept across copy revisions).
-    await expect(aside).toContainText(/Chat/);
-    await expect(page.getByTestId("project-chat-aside-open")).toBeVisible();
+    // Project chat aside was removed — chat is always in the global 3-panel shell.
+    await expect(page.getByTestId("project-chat-aside")).toHaveCount(0);
+    await expect(page.getByTestId("project-chat-aside-open")).toHaveCount(0);
   });
 
   // -----------------------------------------------------------------------
@@ -281,6 +275,7 @@ test.describe("Project workspace mode picker (s134 t517)", () => {
     await page.getByTestId("project-flyout-shell").waitFor({ state: "visible", timeout: 15_000 });
 
     await expect(page.getByTestId("project-mode-picker")).toHaveCount(0);
+    // project-chat-aside is always absent (removed from ProjectDetail)
     await expect(page.getByTestId("project-chat-aside")).toHaveCount(0);
     // Editor + Repository tabs are the core-fork surface.
     await expect(page.getByRole("tab", { name: "Editor" })).toBeVisible();

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,5 +1,34 @@
 import { test, expect } from "@playwright/test";
 
+test.describe("Projects — direct navigation regression (v0.4.864)", () => {
+  // Regression: /projects/:slug crashed with ReferenceError when projectActivity
+  // was in ProjectDetailProps but missing from function destructuring (v0.4.863).
+  // These tests bypass the card-click path and navigate directly to the URL.
+
+  test("direct navigation to /projects/sample-monorepo does not crash", async ({ page }) => {
+    await page.goto("/projects/sample-monorepo", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/projects\/sample-monorepo(\?|#|$)/, { timeout: 10_000 });
+
+    // ErrorBoundary renders "Something went wrong" on a crash — must NOT appear
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible({ timeout: 8_000 });
+
+    // ProjectDetail renders — back button is the cheapest structural check
+    await expect(page.getByText("Back to Projects")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("project detail page renders without JS errors on direct load", async ({ page }) => {
+    const jsErrors: string[] = [];
+    page.on("pageerror", (err) => jsErrors.push(err.message));
+
+    await page.goto("/projects/sample-monorepo", { waitUntil: "networkidle" });
+    await expect(page).toHaveURL(/\/projects\/sample-monorepo(\?|#|$)/);
+
+    // Filter to ReferenceErrors which were the failure mode (projectActivity not defined)
+    const refErrors = jsErrors.filter((m) => /ReferenceError/i.test(m));
+    expect(refErrors).toHaveLength(0);
+  });
+});
+
 test.describe("Projects", () => {
   test("projects grid renders compact cards", async ({ page }) => {
     await page.goto("/projects");

--- a/e2e/scrum-master-skill.spec.ts
+++ b/e2e/scrum-master-skill.spec.ts
@@ -49,12 +49,7 @@ test.describe("Scrum-master skill infrastructure (s168 CHN-G)", () => {
     await page.goto("/projects/sample-monorepo", { waitUntil: "domcontentloaded" });
     await expect(page).toHaveURL(/\/projects\/sample-monorepo(\?|#|$)/, { timeout: 10_000 });
 
-    // Open the global chat flyout via the header button
-    const chatButton = page.getByTestId("header-chat-button");
-    await expect(chatButton).toBeVisible({ timeout: 8_000 });
-    await chatButton.click();
-
-    // Chat flyout mounts — shows "Click + to start a new chat" before a session exists.
+    // Chat is always visible in the shell — no header button click needed.
     await expect(page.getByTestId("chat-flyout")).toBeVisible({ timeout: 8_000 });
 
     // Click + to start a new chat session

--- a/e2e/settings-channels-discord.spec.ts
+++ b/e2e/settings-channels-discord.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Settings → Channels → Discord tab UX (v0.4.865).
+ *
+ * Verifies the DiscordSettingsPanel shipped in v0.4.865:
+ *   - /settings/channels loads and shows the Discord tab when Discord is installed
+ *   - The Settings inner tab (default) renders DiscordSettingsPanel, not the
+ *     old generic camelCase field form
+ *   - Bot Token field is a password input with a human label (not "botToken")
+ *   - mentionOnly is a toggle button (not a text input showing "true"/"false")
+ *   - When bot token is empty, the setup guide is visible
+ *   - Status bar warning check: when channel is running but bot is not connected,
+ *     the amber warning badge renders (requires a running but disconnected bot —
+ *     tested here as an API-level shape check since live Discord is unavailable)
+ *
+ * **Pre-conditions:**
+ *   - Test VM running with gateway up (services-start)
+ *   - Discord channel plugin installed (default in test VM bootstrap)
+ *
+ * **What this spec does NOT cover:**
+ *   - Live bot connection / end-to-end Discord messaging
+ *   - Saving config (would require POST to gateway)
+ */
+
+test.describe("Settings → Channels — Discord settings panel (v0.4.865)", () => {
+  async function openDiscordSettingsTab(page: import("@playwright/test").Page) {
+    await page.goto("/settings/channels", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/settings\/channels(\?|#|$)/, { timeout: 10_000 });
+
+    // Wait for channel tabs to load (plugin-driven — async fetch)
+    // The Discord channel tab shows as either "Discord" or a pill with "Discord" text
+    const discordTab = page.getByRole("tab", { name: /^discord$/i });
+    await discordTab.waitFor({ state: "visible", timeout: 12_000 });
+    await discordTab.click();
+
+    // Default inner tab is "Settings" — wait for it to be selected
+    const settingsTab = page.getByRole("tab", { name: /^settings$/i }).first();
+    await expect(settingsTab).toBeVisible({ timeout: 8_000 });
+    // Settings tab should already be selected by default; if not, click it
+    const isSelected = await settingsTab.getAttribute("data-state");
+    if (isSelected !== "active" && isSelected !== "selected") {
+      await settingsTab.click();
+    }
+  }
+
+  test("/settings/channels renders without crash", async ({ page }) => {
+    await page.goto("/settings/channels", { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(/\/settings\/channels(\?|#|$)/, { timeout: 10_000 });
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible();
+    await expect(page.getByText("Channel Settings")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("Discord Settings tab shows labeled 'Bot Token' field (not raw 'botToken')", async ({ page }) => {
+    await openDiscordSettingsTab(page);
+
+    // DiscordSettingsPanel renders "Bot Token" as the label (not camelCase "botToken")
+    await expect(page.getByText("Bot Token")).toBeVisible({ timeout: 10_000 });
+
+    // The input for botToken must be type=password
+    const botTokenInput = page.locator("input[type='password']").first();
+    await expect(botTokenInput).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("mentionOnly renders as a toggle button, not a text input", async ({ page }) => {
+    await openDiscordSettingsTab(page);
+
+    // DiscordSettingsPanel renders a <button> for the toggle, not an <input type=text>
+    // The toggle label is "Respond only when @mentioned"
+    const toggleLabel = page.getByText(/respond only when @?mentioned/i);
+    await expect(toggleLabel).toBeVisible({ timeout: 10_000 });
+
+    // There must be no raw text input for "mentionOnly" or "Mention Only"
+    // (old generic form rendered: label="Mention Only" + input[type=text] showing "true"/"false")
+    const oldTextInput = page.locator("input[type='text']").filter({
+      has: page.locator(".. >> text=Mention Only"),
+    });
+    await expect(oldTextInput).not.toBeVisible();
+  });
+
+  test("setup guide is visible when bot token is empty", async ({ page }) => {
+    await openDiscordSettingsTab(page);
+
+    // Fetch current config to check if botToken is set
+    const tokenValue = await page.locator("input[type='password']").first().inputValue();
+    if (!tokenValue.trim()) {
+      // No token configured — setup guide must be visible
+      await expect(page.getByText("Connect Aion to Discord")).toBeVisible({ timeout: 8_000 });
+      // Setup guide has numbered steps
+      await expect(page.getByText(/discord\.com\/developers\/applications/i)).toBeVisible();
+    }
+    // When token IS set, guide is hidden — this branch is a no-op in CI
+  });
+
+  test("Application ID field is present with description text", async ({ page }) => {
+    await openDiscordSettingsTab(page);
+
+    await expect(page.getByText("Application ID")).toBeVisible({ timeout: 10_000 });
+    // Description text for applicationId
+    await expect(page.getByText(/optional.*developer portal/i)).toBeVisible({ timeout: 6_000 });
+  });
+
+  test("status bar shows Start/Stop/Restart controls", async ({ page }) => {
+    await openDiscordSettingsTab(page);
+
+    // Status card is above the inner tabs — controls always present
+    await expect(page.getByRole("button", { name: "Start" })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Restart" })).toBeVisible();
+  });
+});

--- a/e2e/settings-channels-discord.spec.ts
+++ b/e2e/settings-channels-discord.spec.ts
@@ -55,7 +55,8 @@ test.describe("Settings → Channels — Discord settings panel (v0.4.865)", () 
     await openDiscordSettingsTab(page);
 
     // DiscordSettingsPanel renders "Bot Token" as the label (not camelCase "botToken")
-    await expect(page.getByText("Bot Token")).toBeVisible({ timeout: 10_000 });
+    // Use testid to avoid matching the setup guide's <strong>Bot Token</strong> snippet
+    await expect(page.getByTestId("discord-bot-token-label")).toBeVisible({ timeout: 10_000 });
 
     // The input for botToken must be type=password
     const botTokenInput = page.locator("input[type='password']").first();
@@ -104,8 +105,9 @@ test.describe("Settings → Channels — Discord settings panel (v0.4.865)", () 
     await openDiscordSettingsTab(page);
 
     // Status card is above the inner tabs — controls always present
-    await expect(page.getByRole("button", { name: "Start" })).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Restart" })).toBeVisible();
+    // exact: true avoids Playwright matching "Restart" when name: "Start" is used (substring match)
+    await expect(page.getByRole("button", { name: "Start", exact: true })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Restart", exact: true })).toBeVisible();
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.868",
+  "version": "0.4.869",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.864",
+  "version": "0.4.865",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.869",
+  "version": "0.4.870",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.866",
+  "version": "0.4.867",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.863",
+  "version": "0.4.864",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.865",
+  "version": "0.4.866",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.867",
+  "version": "0.4.868",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.880",
+  "version": "0.4.881",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.877",
+  "version": "0.4.878",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.878",
+  "version": "0.4.879",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.875",
+  "version": "0.4.876",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.870",
+  "version": "0.4.871",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.874",
+  "version": "0.4.875",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.876",
+  "version": "0.4.877",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",
@@ -15,6 +15,7 @@
     "migrate:agi_data:dry": "tsx scripts/migrate-to-agi_data.ts --dry-run",
     "build:dashboard": "pnpm --filter @agi/dashboard build",
     "runtime:build:lamp": "bash scripts/runtime-images/lamp/build.sh",
+    "runtime:build:polyglot": "bash scripts/runtime-images/polyglot/build.sh",
     "start": "tsx cli/src/index.ts run",
     "cli": "tsx cli/src/index.ts",
     "dev": "tsx watch cli/src/index.ts run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.871",
+  "version": "0.4.872",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.873",
+  "version": "0.4.874",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.872",
+  "version": "0.4.873",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.879",
+  "version": "0.4.880",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.882",
+  "version": "0.4.883",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi",
-  "version": "0.4.881",
+  "version": "0.4.882",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.5.2",

--- a/packages/gateway-core/src/agent-invoker.ts
+++ b/packages/gateway-core/src/agent-invoker.ts
@@ -567,10 +567,7 @@ export class AgentInvoker extends EventEmitter {
 
       for (const registered of validSkills) {
         const def = registered.definition;
-        // Filter by gateway state
-        if (def.requiresState !== undefined && def.requiresState.length > 0) {
-          if (!def.requiresState.includes(state)) continue;
-        }
+        // requiresState is audit metadata only — not a skill visibility gate.
         // Check trigger patterns against user message
         for (const regex of def.compiledTriggers) {
           if (regex.test(inputText)) {

--- a/packages/gateway-core/src/dashboard-events.ts
+++ b/packages/gateway-core/src/dashboard-events.ts
@@ -20,6 +20,7 @@ import type {
   ProjectActivityData,
   ProjectConfigChangedData,
   SystemUpgradeData,
+  SystemUpgradedData,
   HostingStatusData,
   UpdateCheckData,
 } from "./dashboard-types.js";
@@ -153,6 +154,14 @@ export class DashboardEventBroadcaster {
   emitSystemUpgrade(data: SystemUpgradeData): void {
     this.broadcastToSubscribers({
       type: "system:upgrade",
+      data,
+    });
+  }
+
+  /** Emit system:upgraded once after a new version is detected on boot. */
+  emitSystemUpgraded(data: SystemUpgradedData): void {
+    this.broadcastToSubscribers({
+      type: "system:upgraded",
       data,
     });
   }
@@ -306,6 +315,7 @@ function extractEntityId(event: DashboardEvent): string | null {
     case "overview:updated":
     case "project:activity":
     case "system:upgrade":
+    case "system:upgraded":
     case "system:update_available":
     case "hosting:status":
     case "project:config_changed":

--- a/packages/gateway-core/src/dashboard-types.ts
+++ b/packages/gateway-core/src/dashboard-types.ts
@@ -260,13 +260,25 @@ export interface ProjectActivityData {
   summary: string;
 }
 
-/** System upgrade event payload. */
+/** System upgrade event payload (per-step during an active upgrade). */
 export interface SystemUpgradeData {
   phase: string;
   message: string;
   timestamp: string;
   step?: string;
   status?: string;
+}
+
+/** Emitted once on gateway boot when a new version is detected vs seen-version.txt. */
+export interface SystemUpgradedData {
+  /** The version that was just deployed. */
+  toVersion: string;
+  /** The previously seen version (null if first boot with version tracking). */
+  fromVersion: string | null;
+  /** Number of pending UpgradeNextSteps (required + optional). */
+  pendingSteps: number;
+  /** True if any pending step is required (blocks acknowledgement). */
+  hasRequired: boolean;
 }
 
 /** Hosting infrastructure status. */
@@ -436,6 +448,7 @@ export type DashboardEvent =
   | { type: "overview:updated"; data: DashboardOverview }
   | { type: "project:activity"; data: ProjectActivityData & { timestamp: string } }
   | { type: "system:upgrade"; data: SystemUpgradeData }
+  | { type: "system:upgraded"; data: SystemUpgradedData }
   | { type: "system:update_available"; data: UpdateCheckData }
   | { type: "hosting:status"; data: HostingStatusData }
   | { type: "project:config_changed"; data: ProjectConfigChangedData }

--- a/packages/gateway-core/src/dev-mode-forks.ts
+++ b/packages/gateway-core/src/dev-mode-forks.ts
@@ -47,7 +47,10 @@ export interface CoreRepoSpec {
     | "fancy-3d"
     | "fancy-screens"
     | "fancy-whiteboard"
-    | "agent-integrations";
+    | "agent-integrations"
+    | "fancy-artboard"
+    | "fancy-slides"
+    | "fancy-flow";
   /** Repo name on GitHub (NOT the slug — sometimes diverges, e.g. prime
    *  → aionima, id → agi-local-id). */
   upstream: string;
@@ -70,7 +73,10 @@ export interface CoreRepoSpec {
     | "fancy3dRepo"
     | "fancyScreensRepo"
     | "fancyWhiteboardRepo"
-    | "agentIntegrationsRepo";
+    | "agentIntegrationsRepo"
+    | "fancyArtboardRepo"
+    | "fancySlidesRepo"
+    | "fancyFlowRepo";
 }
 
 export const CORE_REPOS: readonly CoreRepoSpec[] = Object.freeze([
@@ -112,6 +118,10 @@ export const CORE_REPOS: readonly CoreRepoSpec[] = Object.freeze([
   // the same channels other collaborators use (panel + on-canvas cursor).
   { slug: "fancy-whiteboard",   upstream: "fancy-whiteboard",   upstreamOrg: "Particle-Academy", displayName: "fancy-whiteboard",   configKey: "fancyWhiteboardRepo" },
   { slug: "agent-integrations", upstream: "agent-integrations", upstreamOrg: "Particle-Academy", displayName: "agent-integrations", configKey: "agentIntegrationsRepo" },
+  // s200 — additional PAx packages registered in the Fancy UI MCP registry.
+  { slug: "fancy-artboard",     upstream: "fancy-artboard",     upstreamOrg: "Particle-Academy", displayName: "fancy-artboard",     configKey: "fancyArtboardRepo" },
+  { slug: "fancy-slides",       upstream: "fancy-slides",       upstreamOrg: "Particle-Academy", displayName: "fancy-slides",       configKey: "fancySlidesRepo" },
+  { slug: "fancy-flow",         upstream: "fancy-flow",         upstreamOrg: "Particle-Academy", displayName: "fancy-flow",         configKey: "fancyFlowRepo" },
 ] as const);
 
 export interface ForkResolveResult {

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -363,6 +363,9 @@ export interface BuildCaddyfileOptions {
      *  handle_path block. Only repos with both port + externalPath are
      *  routed; default repo serves on `/` via the catch-all reverse_proxy. */
     repos?: Array<{ name: string; port: number; externalPath: string }>;
+    /** When false, omit the Caddy offline-page `handle_errors` block so raw
+     *  upstream errors pass through. Default true. */
+    friendlyErrors?: boolean;
   }>;
   existingCaddyfile: string;
 }
@@ -620,23 +623,28 @@ export function buildCaddyfileContent(opts: BuildCaddyfileOptions): string {
     }
 
     blocks.push(`    reverse_proxy ${projectUpstream}`);
-    // `handle_errors <status_codes...>` (filter form) needs Caddy 2.8+.
-    // Plenty of deployments are still on 2.6.x which rejects that syntax
-    // with "Wrong argument count or unexpected line ending after '502'"
-    // and fails the whole reload. Use the expression-matcher form that
-    // works on 2.6 through 2.8 uniformly — still limits the offline
-    // page to 5xx responses so legitimate 4xx from the backend (403,
-    // 404, etc.) aren't hidden behind a "container not running" page.
-    blocks.push(`    handle_errors {`);
-    blocks.push(`        @5xx expression \`{http.error.status_code} >= 500\``);
-    blocks.push(`        handle @5xx {`);
-    // `respond` defaults to text/plain, which renders the offline HTML
-    // as raw source in browsers (cycle-122 owner-reported bug). Set
-    // Content-Type explicitly so the styled card renders.
-    blocks.push(`            header Content-Type "text/html; charset=utf-8"`);
-    blocks.push(`            respond \`${offlineHtml}\` 503`);
-    blocks.push(`        }`);
-    blocks.push(`    }`);
+    // Friendly-errors block: intercepts 5xx and serves a styled offline card.
+    // Omitted when project.friendlyErrors === false so raw upstream errors
+    // (crash output, debug pages, real 500 bodies) pass through to the browser.
+    if (project.friendlyErrors !== false) {
+      // `handle_errors <status_codes...>` (filter form) needs Caddy 2.8+.
+      // Plenty of deployments are still on 2.6.x which rejects that syntax
+      // with "Wrong argument count or unexpected line ending after '502'"
+      // and fails the whole reload. Use the expression-matcher form that
+      // works on 2.6 through 2.8 uniformly — still limits the offline
+      // page to 5xx responses so legitimate 4xx from the backend (403,
+      // 404, etc.) aren't hidden behind a "container not running" page.
+      blocks.push(`    handle_errors {`);
+      blocks.push(`        @5xx expression \`{http.error.status_code} >= 500\``);
+      blocks.push(`        handle @5xx {`);
+      // `respond` defaults to text/plain, which renders the offline HTML
+      // as raw source in browsers (cycle-122 owner-reported bug). Set
+      // Content-Type explicitly so the styled card renders.
+      blocks.push(`            header Content-Type "text/html; charset=utf-8"`);
+      blocks.push(`            respond \`${offlineHtml}\` 503`);
+      blocks.push(`        }`);
+      blocks.push(`    }`);
+    }
     blocks.push(`}\n`);
   }
 
@@ -777,6 +785,19 @@ export interface ProjectHostingMeta {
   containerKind?: "static" | "code" | "mapp";
   /** s145 t584 — Installed MApp IDs for the Desktop-served container shape. */
   mapps?: string[];
+  /**
+   * When false, the Caddy `handle_errors` offline-page block is omitted so raw
+   * upstream errors pass through to the browser. Default true (friendly page).
+   * Set to false for development projects where you want to see real crash output.
+   */
+  friendlyErrors?: boolean;
+  /**
+   * Custom container image for multi-repo projects. Overrides the default
+   * `agi-runtime:lamp`. Use for mixed-language monorepos (e.g. a Python sim
+   * engine + Node.js frontend) where you need a fat image with multiple runtimes.
+   * Leave empty to use the default lamp image.
+   */
+  baseImage?: string | null;
 }
 
 export interface HostedProject {
@@ -1755,6 +1776,8 @@ export class HostingManager {
     // break, but dispatch reads only `type` via isDesktopServed.
     if (updates.containerKind !== undefined) hosted.meta.containerKind = updates.containerKind;
     if (updates.mapps !== undefined) hosted.meta.mapps = updates.mapps;
+    if (updates.friendlyErrors !== undefined) hosted.meta.friendlyErrors = updates.friendlyErrors;
+    if (updates.baseImage !== undefined) hosted.meta.baseImage = updates.baseImage;
 
     // s145 t586 / s150 t634 — when the project is Desktop-served, stamp
     // internalPort=80 here (synchronously, before startContainer fires async)
@@ -2365,6 +2388,7 @@ export class HostingManager {
       aiBindingArgs,
       tunnelOrigin: this.computeTunnelOrigin(hosted),
       networkName: projectNetworkName(hosted.meta.hostname),
+      ...(hosted.meta.baseImage ? { image: hosted.meta.baseImage } : {}),
     });
     if (!result) return null;
     // Set internalPort to the default repo's port so the Caddyfile
@@ -3037,6 +3061,7 @@ export class HostingManager {
             port: p.meta.port,
             containerName: p.containerName ?? (p.meta.hostname ? `agi-${p.meta.hostname}` : null),
             internalPort: p.meta.internalPort,
+            friendlyErrors: p.meta.friendlyErrors,
             ...(repos ? { repos } : {}),
           };
         }),
@@ -3187,6 +3212,10 @@ export class HostingManager {
     /** s145 t585 — surface containerKind + mapps to dashboard. */
     containerKind?: "static" | "code" | "mapp";
     mapps?: string[];
+    /** When false, the Caddy offline-page error block is omitted for this project. */
+    friendlyErrors?: boolean;
+    /** Custom container image override for multi-repo projects. */
+    baseImage?: string | null;
     /** Circuit-breaker state for this project's hosting service id, when not closed.
      * Surfaces "open" / "half-open" so the dashboard can render a distinct chip
      * instead of leaving the project looking simply "stopped" with no context. */
@@ -3243,6 +3272,8 @@ export class HostingManager {
         // dashboards. Removed entirely once t636 lands the HostingPanel UI cleanup.
         containerKind: this.isDesktopServed(hosted.meta) ? "mapp" : "code",
         ...(hosted.meta.mapps !== undefined ? { mapps: hosted.meta.mapps } : {}),
+        ...(hosted.meta.friendlyErrors !== undefined ? { friendlyErrors: hosted.meta.friendlyErrors } : {}),
+        ...(hosted.meta.baseImage ? { baseImage: hosted.meta.baseImage } : {}),
         ...(breaker ? { breaker } : {}),
         url: hosted.status === "running"
           ? `https://${hosted.meta.hostname}.${this.config.baseDomain}`

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -2530,12 +2530,22 @@ export class HostingManager {
       hosted.status = "running";
       hosted.error = undefined;
 
-      this.log.info(`[${hosted.meta.hostname}] container started: ${containerName} (port ${String(hosted.meta.port)}) [${source}]`);
+      this.log.info(`[${hosted.meta.hostname}] container started: ${containerName} (port ${String(hosted.meta.port)}, internalPort ${String(hosted.meta.internalPort)}) [${source}]`);
       // s143 t568 — record container-start success so any prior breaker
       // state for this project gets cleared. The boot-loop's recordSuccess
       // covers enableProject's success path, but startContainer is fire-
       // and-forget from there, so its outcome lives or dies here.
       this.circuitBreaker?.recordSuccess(`hosting:${hosted.path}`);
+
+      // Persist the stack-resolved internalPort back to disk so it survives
+      // gateway restarts and is available to Caddyfile generation on next boot.
+      // Without this write, a stack-resolved port (e.g. Next.js → 3000) is
+      // only in memory for the duration of this session — the on-disk copy
+      // still shows internalPort:null. Also regenerate Caddyfile immediately
+      // so Caddy routes to the correct containerName:internalPort upstream
+      // rather than the fallback host.containers.internal:<allocatedPort>.
+      this.writeHostingMeta(hosted.path, hosted.meta);
+      this.regenerateCaddyfile();
     } catch (err) {
       hosted.status = "error";
       hosted.error = err instanceof Error ? err.message : String(err);

--- a/packages/gateway-core/src/hosting-manager.ts
+++ b/packages/gateway-core/src/hosting-manager.ts
@@ -12,6 +12,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from "node:fs";
+import { createConnection } from "node:net";
 import { join, resolve as resolvePath, dirname } from "node:path";
 import { homedir } from "node:os";
 import { execSync, execFileSync, spawnSync, spawn, type ChildProcess } from "node:child_process";
@@ -50,6 +51,21 @@ import {
 /** Strip ANSI escape codes from command output for clean dashboard display. */
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07/g;
+
+/**
+ * TCP connect probe — resolves true when something is listening on the port,
+ * false on connection refused or timeout. Does not send any data, so no HTTP
+ * logs appear in the target app. Used by pollContainerHealth() to distinguish
+ * "container running but app not yet serving" from "container running + app ready".
+ */
+function probePort(port: number, timeoutMs = 2_000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port, timeout: timeoutMs });
+    socket.on("connect", () => { socket.destroy(); resolve(true); });
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => { socket.destroy(); resolve(false); });
+  });
+}
 
 /** Simple shell argument escaping — wraps in single quotes. Used by
  *  buildMultiRepoContainerArgs to safely pass startCommand strings
@@ -772,6 +788,11 @@ export interface HostedProject {
   error?: string;
   tunnelPid: number | null;
   tunnelUrl: string | null;
+  /** True when the most recent TCP probe to the container's host port succeeded.
+   * Starts false; set to true by pollContainerHealth() once the app is listening.
+   * Reset to false when the container stops. Used to distinguish green (serving)
+   * from yellow (container up but app not yet responding). */
+  serving: boolean;
 }
 
 export interface InfraStatus {
@@ -913,6 +934,7 @@ export class HostingManager {
   private loginProcess: ChildProcess | null = null;
   private onStatusChange: (() => void) | null = null;
   private statusPollTimer: ReturnType<typeof setInterval> | null = null;
+  private healthPollTimer: ReturnType<typeof setInterval> | null = null;
   private eventsProcess: ChildProcess | null = null;
   /** HuggingFace model runtime deps — set via setModelDeps() after Step 5i. */
   private modelDeps: HostingManagerModelDeps | null = null;
@@ -1601,6 +1623,7 @@ export class HostingManager {
       status: "stopped",
       tunnelPid: null,
       tunnelUrl: null,
+      serving: false,
     };
 
     this.projects.set(resolved, hosted);
@@ -2774,6 +2797,35 @@ export class HostingManager {
       () => this.pollContainerStatuses(),
       120_000,
     );
+
+    // Kick off an immediate health probe so running containers get their
+    // serving flag on boot rather than waiting 10s for the first interval.
+    void this.pollContainerHealth();
+    this.startHealthProbing();
+  }
+
+  /** Start the 10-second TCP health probe loop. */
+  private startHealthProbing(): void {
+    if (this.healthPollTimer !== null) return;
+    this.healthPollTimer = setInterval(() => void this.pollContainerHealth(), 10_000);
+  }
+
+  /** Probe each running container's host port and update its `serving` flag. */
+  private async pollContainerHealth(): Promise<void> {
+    const probes: Promise<void>[] = [];
+    for (const hosted of this.projects.values()) {
+      if (hosted.status !== "running" || !hosted.meta.port) continue;
+      const port = hosted.meta.port;
+      probes.push(
+        probePort(port).then((alive) => {
+          if (hosted.serving !== alive) {
+            hosted.serving = alive;
+            this.notifyStatusChange();
+          }
+        }).catch(() => { /* probe errors are non-fatal */ }),
+      );
+    }
+    await Promise.allSettled(probes);
   }
 
   /**
@@ -2852,6 +2904,7 @@ export class HostingManager {
 
       if (hosted.status !== newStatus) {
         hosted.status = newStatus;
+        if (newStatus !== "running") hosted.serving = false;
         this.notifyStatusChange();
       }
       return;
@@ -3051,6 +3104,7 @@ export class HostingManager {
       hostname: string;
       type: string;
       status: "running" | "stopped" | "error" | "unconfigured";
+      serving: boolean;
       port: number | null;
       url: string | null;
       mode: "production" | "development";
@@ -3069,6 +3123,7 @@ export class HostingManager {
         hostname: hosted.meta.hostname,
         type: hosted.meta.type,
         status: hosted.status,
+        serving: hosted.serving,
         port: hosted.meta.port,
         mode: hosted.meta.mode,
         internalPort: hosted.meta.internalPort,
@@ -3109,6 +3164,10 @@ export class HostingManager {
     internalPort: number | null;
     runtimeId?: string | null;
     status: "running" | "stopped" | "error" | "unconfigured";
+    /** True when the most recent TCP probe succeeded — i.e. the app is actively
+     * listening on its port. False when container is running but app not yet
+     * ready (starting up, crashed internally). Only meaningful when status === "running". */
+    serving: boolean;
     tunnelUrl?: string | null;
     containerName?: string;
     image?: string;
@@ -3164,6 +3223,7 @@ export class HostingManager {
         internalPort: hosted.meta.internalPort,
         runtimeId: hosted.meta.runtimeId ?? null,
         status: hosted.status,
+        serving: hosted.serving,
         ...(hosted.tunnelUrl ? { tunnelUrl: hosted.tunnelUrl } : {}),
         ...(hosted.containerName ? { containerName: hosted.containerName } : {}),
         ...(resolvedImage ? { image: resolvedImage } : {}),
@@ -3198,6 +3258,7 @@ export class HostingManager {
         containerKind: this.isDesktopServed(meta) ? "mapp" : "code",
         ...(meta.mapps !== undefined ? { mapps: meta.mapps } : {}),
         status: "unconfigured",
+        serving: false,
         url: null,
       };
     }
@@ -3213,6 +3274,7 @@ export class HostingManager {
       mode: "production",
       internalPort: null,
       status: "unconfigured",
+      serving: false,
       url: null,
     };
   }
@@ -3467,6 +3529,10 @@ export class HostingManager {
     if (this.statusPollTimer !== null) {
       clearInterval(this.statusPollTimer);
       this.statusPollTimer = null;
+    }
+    if (this.healthPollTimer !== null) {
+      clearInterval(this.healthPollTimer);
+      this.healthPollTimer = null;
     }
     if (this.eventsProcess !== null) {
       try { this.eventsProcess.kill(); } catch { /* already dead */ }

--- a/packages/gateway-core/src/migration-runner.ts
+++ b/packages/gateway-core/src/migration-runner.ts
@@ -1,0 +1,227 @@
+/**
+ * Migration runner — versioned TypeScript migrations for the gateway.
+ *
+ * # Why this exists
+ *
+ * Users don't always upgrade immediately. Someone on v0.4.850 might skip ten
+ * releases and land on v0.4.880 in a single `agi upgrade`. The migration
+ * runner ensures ALL intermediate migrations run in order, not just the
+ * ones that shipped in the final version.
+ *
+ * # What migrations are for
+ *
+ * TypeScript migrations run on gateway boot AFTER the new code is deployed.
+ * They are for:
+ *  - Stacking UpgradeNextSteps (user guidance, required or optional)
+ *  - Cancelling/superseding steps from earlier versions
+ *  - Patching gateway.json config fields that changed shape
+ *  - Registering one-time boot-time data transforms
+ *
+ * They are NOT for:
+ *  - Schema changes (those belong in migrate-db.sh, run by upgrade.sh before boot)
+ *  - Filesystem operations that require root (those belong in upgrade.sh)
+ *
+ * # How to add a migration
+ *
+ * 1. Add an entry to MIGRATIONS below, ordered by version ascending.
+ * 2. Give it a unique `id` (never reuse IDs — idempotency is tracked by ID).
+ * 3. Return `UpgradeNextStep | null` from `run()`. Returning a step stacks it.
+ *    To supersede a prior step, set `cancels: ["prior-step-id"]` on the new step.
+ *    Return `null` if the migration is structural (no user action needed).
+ *
+ * # Version comparison
+ *
+ * Migrations run when `migration.version > lastMigratedVersion && migration.version <= currentVersion`.
+ * The runner sorts by version before executing, so order in this file doesn't
+ * matter — but keeping them sorted makes diffs easier to read.
+ */
+
+import type { UpgradeNextStep } from "./upgrade-next-steps.js";
+import {
+  hasMigrationRun,
+  recordMigrationRun,
+  readLastMigratedVersion,
+  writeLastMigratedVersion,
+  stackUpgradeNextStep,
+  supersedeUpgradeNextStep,
+} from "./upgrade-next-steps.js";
+import { createComponentLogger } from "./logger.js";
+
+const log = createComponentLogger(undefined, "migration-runner");
+
+// ---------------------------------------------------------------------------
+// Migration context (passed to each migration's run function)
+// ---------------------------------------------------------------------------
+
+export interface MigrationContext {
+  /** The version the user is upgrading FROM (may be null on first install). */
+  fromVersion: string | null;
+  /** The version being deployed. */
+  toVersion: string;
+  /** Stack a post-upgrade next step. */
+  stackStep: (step: Omit<UpgradeNextStep, "status" | "addedAt">) => void;
+  /** Supersede a previously-stacked step by ID (marks it "superseded"). */
+  cancelStep: (id: string) => void;
+  /** Write a message to the gateway log. */
+  log: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Migration definition
+// ---------------------------------------------------------------------------
+
+export interface Migration {
+  /**
+   * The gateway version that introduced this migration.
+   * Format: "MAJOR.MINOR.PATCH" (e.g. "0.4.880").
+   * Migrations run when version > lastMigratedVersion AND version <= currentVersion.
+   */
+  version: string;
+  /** Unique stable ID — never reuse. Tracked in ~/.agi/migration-run-log.json. */
+  id: string;
+  /** Human-readable description for logs. */
+  description: string;
+  /** The migration body. Return void; use ctx.stackStep / ctx.cancelStep for effects. */
+  run: (ctx: MigrationContext) => void | Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Version comparison helpers
+// ---------------------------------------------------------------------------
+
+/** Parse "1.2.3" into [1, 2, 3]. */
+function parseVersion(v: string): number[] {
+  return v.split(".").map((p) => parseInt(p, 10) || 0);
+}
+
+/** Returns true if a < b (semver-style, no pre-release parsing needed). */
+export function versionLessThan(a: string, b: string): boolean {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na < nb) return true;
+    if (na > nb) return false;
+  }
+  return false; // equal
+}
+
+/** Returns true if a <= b. */
+function versionLessThanOrEqual(a: string, b: string): boolean {
+  return !versionLessThan(b, a);
+}
+
+// ---------------------------------------------------------------------------
+// Migration registry — add new migrations here, sorted by version ascending
+// ---------------------------------------------------------------------------
+
+export const MIGRATIONS: readonly Migration[] = Object.freeze([
+  // ---------------------------------------------------------------------------
+  // v0.4.880 — establish the migration system itself.
+  // No user action needed; this is the bootstrap marker so subsequent
+  // migrations have a known baseline to compare against.
+  // ---------------------------------------------------------------------------
+  {
+    version: "0.4.880",
+    id: "migration-system-bootstrap",
+    description: "Bootstrap migration system — establish baseline",
+    run: (_ctx: MigrationContext) => {
+      // No-op: just marks v0.4.880 as the migration baseline.
+      // All future migrations can assume this has run.
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // Add new migrations below, ordered by version ascending.
+  //
+  // Template:
+  //
+  // {
+  //   version: "0.4.NNN",
+  //   id: "short-kebab-description-v0.4.NNN",
+  //   description: "What this does and why",
+  //   run: (ctx) => {
+  //     // Optional: cancel a prior step that's no longer needed
+  //     ctx.cancelStep("prior-step-id-v0.4.MMM");
+  //
+  //     // Optional: stack a new step
+  //     ctx.stackStep({
+  //       id: "action-needed-v0.4.NNN",
+  //       title: "Short action title",
+  //       description: "Why the user needs to do this.",
+  //       required: false, // true = blocks acknowledgement
+  //       fromVersion: "0.4.NNN",
+  //       cancels: ["prior-step-id-v0.4.MMM"], // also cancel via the step itself
+  //       action: { label: "Go there", kind: "navigate", target: "/settings/channels" },
+  //     });
+  //   },
+  // },
+  // ---------------------------------------------------------------------------
+] as const);
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all pending migrations between `fromVersion` (exclusive) and
+ * `toVersion` (inclusive), in ascending version order.
+ *
+ * Idempotent: each migration is skipped if its ID is already in the run log.
+ * Safe to call on every boot — it's a no-op when everything is current.
+ */
+export async function runPendingMigrations(
+  fromVersion: string | null,
+  toVersion: string,
+): Promise<{ ran: number; skipped: number }> {
+  const lastMigrated = readLastMigratedVersion() ?? fromVersion;
+  const pending = [...MIGRATIONS]
+    .filter((m) => {
+      // Include if: version > lastMigrated (or lastMigrated is null) AND version <= toVersion
+      if (!versionLessThanOrEqual(m.version, toVersion)) return false;
+      if (lastMigrated !== null && !versionLessThan(lastMigrated, m.version)) return false;
+      return true;
+    })
+    .sort((a, b) => versionLessThan(a.version, b.version) ? -1 : versionLessThan(b.version, a.version) ? 1 : 0);
+
+  if (pending.length === 0) return { ran: 0, skipped: 0 };
+
+  log.info(`migration-runner: ${String(pending.length)} migrations to run (${lastMigrated ?? "initial"} → ${toVersion})`);
+
+  const ctx: MigrationContext = {
+    fromVersion: fromVersion,
+    toVersion,
+    stackStep: (step) => stackUpgradeNextStep(step),
+    cancelStep: (id) => supersedeUpgradeNextStep(id),
+    log: (message) => log.info(`[migration ${toVersion}] ${message}`),
+  };
+
+  let ran = 0;
+  let skipped = 0;
+
+  for (const migration of pending) {
+    if (hasMigrationRun(migration.id)) {
+      log.debug(`migration-runner: skip already-run: ${migration.id}`);
+      skipped++;
+      continue;
+    }
+    try {
+      log.info(`migration-runner: running ${migration.id} (${migration.description})`);
+      await Promise.resolve(migration.run(ctx));
+      recordMigrationRun(migration.id);
+      ran++;
+    } catch (err) {
+      // Migrations must never crash the gateway. Log + continue.
+      log.warn(`migration-runner: migration ${migration.id} threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Advance the last-migrated pointer to the highest version we processed
+  const highestRun = pending[pending.length - 1]?.version ?? toVersion;
+  writeLastMigratedVersion(highestRun);
+
+  log.info(`migration-runner: complete — ran=${String(ran)} skipped=${String(skipped)} lastMigrated=${highestRun}`);
+  return { ran, skipped };
+}

--- a/packages/gateway-core/src/server-runtime-state.ts
+++ b/packages/gateway-core/src/server-runtime-state.ts
@@ -75,6 +75,12 @@ import type { COAChainLogger } from "@agi/coa-chain";
 import type { DashboardSession } from "./dashboard-user-store.js";
 import type { FederationRouter as FedRouter } from "./federation-router.js";
 import { appendUpgradeLog, clearUpgradeLog, getUpgradeLog } from "./upgrade-log.js";
+import {
+  listUpgradeNextSteps,
+  completeUpgradeNextStep,
+  dismissUpgradeNextStep,
+  hasPendingRequiredSteps,
+} from "./upgrade-next-steps.js";
 import { projectConfigPath } from "./project-config-path.js";
 import {
   buildCandidatePayload,
@@ -5511,6 +5517,40 @@ export async function createGatewayRuntimeState(
       return reply.code(403).send({ error: "System API only allowed from private network" });
     }
     return reply.send(getUpgradeLog());
+  });
+
+  // ---------------------------------------------------------------------------
+  // UpgradeNextSteps — post-upgrade interactive task queue
+  // ---------------------------------------------------------------------------
+
+  fastify.get("/api/system/upgrade-next-steps", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) {
+      return reply.code(403).send({ error: "System API only allowed from private network" });
+    }
+    const query = request.query as Record<string, string>;
+    const filter = query.filter === "pending" ? "pending" : "all";
+    return reply.send({
+      steps: listUpgradeNextSteps(filter),
+      hasRequired: hasPendingRequiredSteps(),
+    });
+  });
+
+  fastify.post("/api/system/upgrade-next-steps/:id/done", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Forbidden" });
+    const { id } = request.params as { id: string };
+    const ok = completeUpgradeNextStep(id);
+    return reply.send({ ok, hasRequired: hasPendingRequiredSteps() });
+  });
+
+  fastify.post("/api/system/upgrade-next-steps/:id/dismiss", async (request, reply) => {
+    const clientIp = getClientIp(request.raw);
+    if (!isPrivateNetwork(clientIp)) return reply.code(403).send({ error: "Forbidden" });
+    const { id } = request.params as { id: string };
+    const result = dismissUpgradeNextStep(id);
+    if (result === "required") return reply.code(409).send({ error: "Cannot dismiss a required step" });
+    return reply.send({ ok: result, hasRequired: hasPendingRequiredSteps() });
   });
 
   // GET /api/system/changelog — git commit history for the deployed repo

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -188,9 +188,11 @@ import {
   readDeployedVersion,
   readSeenVersion,
   writeSeenVersion,
+  readLastMigratedVersion,
   hasPendingRequiredSteps,
   listUpgradeNextSteps,
 } from "./upgrade-next-steps.js";
+import { runPendingMigrations } from "./migration-runner.js";
 import { EventEmitter } from "node:events";
 import { HardwareProfiler } from "./machine/hardware-profiler.js";
 import {
@@ -3750,9 +3752,18 @@ export async function startGatewayServer(
     }
   }
 
-  // UpgradeNextSteps: import pending steps written by upgrade.sh and record version.
+  // UpgradeNextSteps boot sequence:
+  // 1. Import pending steps written by upgrade.sh (bash→gateway handoff)
+  // 2. Run all TypeScript migrations between last-migrated and current version
   // The actual system:upgraded broadcast happens in Step 8 once the WS broadcaster is ready.
   importPendingSteps();
+  const _currentVersion: string = (() => {
+    try { return (require(join(selfRepoPath ?? process.cwd(), "package.json")) as { version: string }).version; } catch { return "0.0.0"; }
+  })();
+  const _lastMigrated = readLastMigratedVersion();
+  void runPendingMigrations(_lastMigrated, _currentVersion).catch((err: unknown) => {
+    log.warn(`migration-runner: boot-time error: ${err instanceof Error ? err.message : String(err)}`);
+  });
 
   // -------------------------------------------------------------------------
   // Step 6b: Log streaming — push log entries to subscribed dashboard clients
@@ -5076,12 +5087,7 @@ export async function startGatewayServer(
   // importPendingSteps() was called earlier (boot sequence); broadcaster is now ready.
   try {
     const deployed = readDeployedVersion();
-    const currentVersion: string = (() => {
-      try {
-        return (require(join(selfRepoPath ?? process.cwd(), "package.json")) as { version: string }).version;
-      } catch { return "unknown"; }
-    })();
-    const toVersion = deployed ?? currentVersion;
+    const toVersion = deployed ?? _currentVersion;
     const seen = readSeenVersion();
     if (toVersion !== seen) {
       writeSeenVersion(toVersion);

--- a/packages/gateway-core/src/server.ts
+++ b/packages/gateway-core/src/server.ts
@@ -183,6 +183,14 @@ import { registerReportsApi } from "./reports-api.js";
 import { registerWorkerApi } from "./worker-api.js";
 import { registerUsageRoutes } from "./usage-api.js";
 import { appendUpgradeLog } from "./upgrade-log.js";
+import {
+  importPendingSteps,
+  readDeployedVersion,
+  readSeenVersion,
+  writeSeenVersion,
+  hasPendingRequiredSteps,
+  listUpgradeNextSteps,
+} from "./upgrade-next-steps.js";
 import { EventEmitter } from "node:events";
 import { HardwareProfiler } from "./machine/hardware-profiler.js";
 import {
@@ -3728,6 +3736,7 @@ export async function startGatewayServer(
 
   // -------------------------------------------------------------------------
   // Post-upgrade boot detection — if upgrade.sh restarted the service, finalize the upgrade log
+  // and emit a system:upgraded WS event so the dashboard can show the post-upgrade panel.
   // -------------------------------------------------------------------------
   const selfRepoPath = config.workspace?.selfRepo;
   if (selfRepoPath) {
@@ -3740,6 +3749,10 @@ export async function startGatewayServer(
       log.info("upgrade: post-restart cleanup complete");
     }
   }
+
+  // UpgradeNextSteps: import pending steps written by upgrade.sh and record version.
+  // The actual system:upgraded broadcast happens in Step 8 once the WS broadcaster is ready.
+  importPendingSteps();
 
   // -------------------------------------------------------------------------
   // Step 6b: Log streaming — push log entries to subscribed dashboard clients
@@ -5058,6 +5071,32 @@ export async function startGatewayServer(
 
   // Populate the late-bound ref so the chat:send handler can emit project activity.
   dashboardBroadcasterRef = dashboardBroadcaster;
+
+  // Emit system:upgraded if this boot follows a new version deploy.
+  // importPendingSteps() was called earlier (boot sequence); broadcaster is now ready.
+  try {
+    const deployed = readDeployedVersion();
+    const currentVersion: string = (() => {
+      try {
+        return (require(join(selfRepoPath ?? process.cwd(), "package.json")) as { version: string }).version;
+      } catch { return "unknown"; }
+    })();
+    const toVersion = deployed ?? currentVersion;
+    const seen = readSeenVersion();
+    if (toVersion !== seen) {
+      writeSeenVersion(toVersion);
+      const pending = listUpgradeNextSteps("pending");
+      dashboardBroadcaster?.emitSystemUpgraded({
+        toVersion,
+        fromVersion: seen,
+        pendingSteps: pending.length,
+        hasRequired: hasPendingRequiredSteps(),
+      });
+      log.info(`upgrade: system:upgraded — ${seen ?? "initial"} → ${toVersion}, ${String(pending.length)} pending steps`);
+    }
+  } catch (err) {
+    log.warn(`upgrade: system:upgraded broadcast failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   /**
    * Autonomous Aion turn triggered by a TaskMaster completion/handoff event

--- a/packages/gateway-core/src/tool-registry.ts
+++ b/packages/gateway-core/src/tool-registry.ts
@@ -213,15 +213,8 @@ export class ToolRegistry {
       );
     }
 
-    // Check per-tool state requirements
-    if (
-      registered.manifest.requiresState.length > 0 &&
-      !registered.manifest.requiresState.includes(ctx.state)
-    ) {
-      throw new Error(
-        `Tool "${toolName}" requires state: ${registered.manifest.requiresState.join(", ")}`,
-      );
-    }
+    // requiresState is audit metadata for COA<>COI logging and UI dimming only —
+    // it is NOT an execution gate. State never blocks tool use (see system-prompt.ts).
 
     // Step 3: Execute handler
     let rawResult: string;

--- a/packages/gateway-core/src/upgrade-next-steps.ts
+++ b/packages/gateway-core/src/upgrade-next-steps.ts
@@ -1,0 +1,182 @@
+/**
+ * UpgradeNextSteps — post-upgrade interactive task queue.
+ *
+ * Migrations and upgrade.sh can stack items here. Required items block the
+ * "upgrade complete" acknowledgement in the dashboard; optional items can be
+ * dismissed. Steps persist in ~/.agi/upgrade-next-steps.json until actioned.
+ *
+ * The upgrade script writes to ~/.agi/upgrade-next-steps-pending.ndjson;
+ * importPendingSteps() reads + merges them on gateway boot so bash scripts
+ * don't need to call a live API.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+  mkdirSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type UpgradeNextStepStatus = "pending" | "done" | "dismissed";
+export type UpgradeNextStepActionKind = "navigate" | "external-url" | "chat";
+
+export interface UpgradeNextStepAction {
+  label: string;
+  kind: UpgradeNextStepActionKind;
+  /** Route path, URL, or chat context string depending on kind. */
+  target: string;
+}
+
+export interface UpgradeNextStep {
+  /** Stable unique ID — use kebab-case + version suffix (e.g. "pax-conflict-react-fancy-v0.4.879"). */
+  id: string;
+  title: string;
+  description: string;
+  /** true = blocks "upgrade acknowledged" until completed. */
+  required: boolean;
+  status: UpgradeNextStepStatus;
+  /** ISO timestamp when the step was stacked. */
+  addedAt: string;
+  /** Gateway semver that stacked this step. */
+  fromVersion: string;
+  /** Optional dashboard action the user can take from the panel. */
+  action?: UpgradeNextStepAction;
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const AGI_DIR = join(homedir(), ".agi");
+const STEPS_PATH = join(AGI_DIR, "upgrade-next-steps.json");
+const PENDING_PATH = join(AGI_DIR, "upgrade-next-steps-pending.ndjson");
+/** Written by upgrade.sh after a successful deploy; read on boot to detect new versions. */
+export const DEPLOYED_VERSION_PATH = join(AGI_DIR, "deployed-version.txt");
+/** Last version the gateway acknowledged (emitted system:upgraded for). */
+export const SEEN_VERSION_PATH = join(AGI_DIR, "seen-version.txt");
+
+function ensureDir(): void {
+  if (!existsSync(AGI_DIR)) mkdirSync(AGI_DIR, { recursive: true });
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+function readSteps(): UpgradeNextStep[] {
+  if (!existsSync(STEPS_PATH)) return [];
+  try {
+    return JSON.parse(readFileSync(STEPS_PATH, "utf-8")) as UpgradeNextStep[];
+  } catch {
+    return [];
+  }
+}
+
+function writeSteps(steps: UpgradeNextStep[]): void {
+  ensureDir();
+  writeFileSync(STEPS_PATH, JSON.stringify(steps, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Stack a new step. Idempotent by ID — existing step with same ID is kept unchanged. */
+export function stackUpgradeNextStep(step: Omit<UpgradeNextStep, "status" | "addedAt"> & { addedAt?: string }): void {
+  const steps = readSteps();
+  if (steps.some((s) => s.id === step.id)) return;
+  steps.push({ ...step, status: "pending", addedAt: step.addedAt ?? new Date().toISOString() });
+  writeSteps(steps);
+}
+
+/** List all steps. Pass `filter="pending"` to get only actionable ones. */
+export function listUpgradeNextSteps(filter?: "pending" | "all"): UpgradeNextStep[] {
+  const steps = readSteps();
+  if (filter === "pending") return steps.filter((s) => s.status === "pending");
+  return steps;
+}
+
+/** Mark a step done. */
+export function completeUpgradeNextStep(id: string): boolean {
+  const steps = readSteps();
+  const step = steps.find((s) => s.id === id);
+  if (!step) return false;
+  step.status = "done";
+  writeSteps(steps);
+  return true;
+}
+
+/** Dismiss an optional step. Required steps cannot be dismissed. */
+export function dismissUpgradeNextStep(id: string): boolean | "required" {
+  const steps = readSteps();
+  const step = steps.find((s) => s.id === id);
+  if (!step) return false;
+  if (step.required) return "required";
+  step.status = "dismissed";
+  writeSteps(steps);
+  return true;
+}
+
+/** True when any pending step is marked required (blocks acknowledgement). */
+export function hasPendingRequiredSteps(): boolean {
+  return readSteps().some((s) => s.status === "pending" && s.required);
+}
+
+// ---------------------------------------------------------------------------
+// Pending import — upgrade.sh writes to the .ndjson file, gateway boot merges
+// ---------------------------------------------------------------------------
+
+/**
+ * Read upgrade-next-steps-pending.ndjson written by upgrade.sh and merge
+ * each line into the main steps store. Clears the pending file after import.
+ * Call once on gateway boot before emitting system:upgraded.
+ */
+export function importPendingSteps(): number {
+  if (!existsSync(PENDING_PATH)) return 0;
+  const raw = readFileSync(PENDING_PATH, "utf-8").trim();
+  if (!raw) return 0;
+  let count = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const step = JSON.parse(line) as Omit<UpgradeNextStep, "status" | "addedAt"> & { addedAt?: string };
+      stackUpgradeNextStep(step);
+      count++;
+    } catch {
+      // Malformed line — skip
+    }
+  }
+  writeFileSync(PENDING_PATH, ""); // clear after import
+  return count;
+}
+
+/**
+ * Append a step to the pending NDJSON file. Used from upgrade.sh via
+ * `node -e` inline calls so bash doesn't need to call a live API.
+ */
+export function appendPendingStep(step: Omit<UpgradeNextStep, "status" | "addedAt">): void {
+  ensureDir();
+  appendFileSync(PENDING_PATH, JSON.stringify({ ...step, addedAt: new Date().toISOString() }) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Version tracking
+// ---------------------------------------------------------------------------
+
+export function readDeployedVersion(): string | null {
+  if (!existsSync(DEPLOYED_VERSION_PATH)) return null;
+  return readFileSync(DEPLOYED_VERSION_PATH, "utf-8").trim() || null;
+}
+
+export function readSeenVersion(): string | null {
+  if (!existsSync(SEEN_VERSION_PATH)) return null;
+  return readFileSync(SEEN_VERSION_PATH, "utf-8").trim() || null;
+}
+
+export function writeSeenVersion(version: string): void {
+  ensureDir();
+  writeFileSync(SEEN_VERSION_PATH, version);
+}

--- a/packages/gateway-core/src/upgrade-next-steps.ts
+++ b/packages/gateway-core/src/upgrade-next-steps.ts
@@ -20,7 +20,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-export type UpgradeNextStepStatus = "pending" | "done" | "dismissed";
+export type UpgradeNextStepStatus = "pending" | "done" | "dismissed" | "superseded";
 export type UpgradeNextStepActionKind = "navigate" | "external-url" | "chat";
 
 export interface UpgradeNextStepAction {
@@ -44,6 +44,18 @@ export interface UpgradeNextStep {
   fromVersion: string;
   /** Optional dashboard action the user can take from the panel. */
   action?: UpgradeNextStepAction;
+  /**
+   * IDs of previously-stacked steps this step supersedes. When this step is
+   * stacked, every listed step is atomically marked "superseded" so users who
+   * skipped several upgrades only see the current guidance, not outdated steps
+   * from intermediate versions.
+   *
+   * Example: v0.4.872 auto-fixed the Discord config issue that v0.4.860 asked
+   * the user to fix manually. v0.4.872's migration sets
+   * `cancels: ["discord-config-manual-v0.4.860"]` so the old required step
+   * disappears when the user upgrades.
+   */
+  cancels?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -57,6 +69,10 @@ const PENDING_PATH = join(AGI_DIR, "upgrade-next-steps-pending.ndjson");
 export const DEPLOYED_VERSION_PATH = join(AGI_DIR, "deployed-version.txt");
 /** Last version the gateway acknowledged (emitted system:upgraded for). */
 export const SEEN_VERSION_PATH = join(AGI_DIR, "seen-version.txt");
+/** Tracks which migration IDs have already run — idempotency guard. */
+const MIGRATION_LOG_PATH = join(AGI_DIR, "migration-run-log.json");
+/** Records the highest version whose migrations have been applied. */
+export const LAST_MIGRATED_VERSION_PATH = join(AGI_DIR, "last-migrated-version.txt");
 
 function ensureDir(): void {
   if (!existsSync(AGI_DIR)) mkdirSync(AGI_DIR, { recursive: true });
@@ -84,12 +100,35 @@ function writeSteps(steps: UpgradeNextStep[]): void {
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Stack a new step. Idempotent by ID — existing step with same ID is kept unchanged. */
+/**
+ * Stack a new step. Idempotent by ID — existing step with same ID is kept unchanged.
+ * If the new step declares `cancels: [...]`, those existing steps are atomically
+ * marked "superseded" so the user only sees the current guidance.
+ */
 export function stackUpgradeNextStep(step: Omit<UpgradeNextStep, "status" | "addedAt"> & { addedAt?: string }): void {
   const steps = readSteps();
   if (steps.some((s) => s.id === step.id)) return;
+  // Supersede any steps this one cancels
+  if (step.cancels && step.cancels.length > 0) {
+    const cancelSet = new Set(step.cancels);
+    for (const s of steps) {
+      if (cancelSet.has(s.id) && s.status === "pending") {
+        s.status = "superseded";
+      }
+    }
+  }
   steps.push({ ...step, status: "pending", addedAt: step.addedAt ?? new Date().toISOString() });
   writeSteps(steps);
+}
+
+/** Directly supersede a step by ID (used by migration runner for programmatic cancellation). */
+export function supersedeUpgradeNextStep(id: string): void {
+  const steps = readSteps();
+  const step = steps.find((s) => s.id === id);
+  if (step && step.status === "pending") {
+    step.status = "superseded";
+    writeSteps(steps);
+  }
 }
 
 /** List all steps. Pass `filter="pending"` to get only actionable ones. */
@@ -122,6 +161,7 @@ export function dismissUpgradeNextStep(id: string): boolean | "required" {
 
 /** True when any pending step is marked required (blocks acknowledgement). */
 export function hasPendingRequiredSteps(): boolean {
+  // "superseded" is treated as resolved — it never blocks
   return readSteps().some((s) => s.status === "pending" && s.required);
 }
 
@@ -179,4 +219,45 @@ export function readSeenVersion(): string | null {
 export function writeSeenVersion(version: string): void {
   ensureDir();
   writeFileSync(SEEN_VERSION_PATH, version);
+}
+
+export function readLastMigratedVersion(): string | null {
+  if (!existsSync(LAST_MIGRATED_VERSION_PATH)) return null;
+  return readFileSync(LAST_MIGRATED_VERSION_PATH, "utf-8").trim() || null;
+}
+
+export function writeLastMigratedVersion(version: string): void {
+  ensureDir();
+  writeFileSync(LAST_MIGRATED_VERSION_PATH, version);
+}
+
+// ---------------------------------------------------------------------------
+// Migration run-log — idempotency guard
+// ---------------------------------------------------------------------------
+
+function readMigrationLog(): Set<string> {
+  if (!existsSync(MIGRATION_LOG_PATH)) return new Set();
+  try {
+    const ids = JSON.parse(readFileSync(MIGRATION_LOG_PATH, "utf-8")) as string[];
+    return new Set(Array.isArray(ids) ? ids : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function writeMigrationLog(log: Set<string>): void {
+  ensureDir();
+  writeFileSync(MIGRATION_LOG_PATH, JSON.stringify([...log], null, 2));
+}
+
+/** Returns true if this migration ID has already been applied. */
+export function hasMigrationRun(migrationId: string): boolean {
+  return readMigrationLog().has(migrationId);
+}
+
+/** Record that a migration has been applied. Idempotent. */
+export function recordMigrationRun(migrationId: string): void {
+  const log = readMigrationLog();
+  log.add(migrationId);
+  writeMigrationLog(log);
 }

--- a/scripts/agi-cli.sh
+++ b/scripts/agi-cli.sh
@@ -167,7 +167,13 @@ cmd_status() {
   echo ""
   echo -e "${BOLD}Infrastructure${RESET}"
   label "Caddy:"
-  systemctl is-active caddy 2>/dev/null || echo "not installed"
+  if podman ps --filter "name=^agi-caddy$" --format '{{.Status}}' 2>/dev/null | grep -q "^Up"; then
+    echo -e "${GREEN}active${RESET} (containerized)"
+  elif systemctl is-active caddy 2>/dev/null | grep -q "^active"; then
+    echo -e "${YELLOW}active${RESET} (system-scope)"
+  else
+    echo -e "${RED}inactive / not installed${RESET}"
+  fi
   label "Podman:"
   if command -v podman &>/dev/null; then
     echo -e "${GREEN}installed${RESET} ($(podman --version 2>/dev/null | head -1))"
@@ -177,9 +183,9 @@ cmd_status() {
   label "dnsmasq:"
   systemctl is-active dnsmasq 2>/dev/null || echo "not installed"
 
-  # Running containers
+  # Running containers — label is agi.managed=true (not aionima.managed)
   local containers
-  containers="$(podman ps --filter label=aionima.managed=true --format '{{.Names}}' 2>/dev/null | wc -l)"
+  containers="$(podman ps --filter label=agi.managed=true --format '{{.Names}}' 2>/dev/null | wc -l)"
   label "Containers:"
   echo "${containers} running"
 }

--- a/scripts/orphan-check.sh
+++ b/scripts/orphan-check.sh
@@ -51,6 +51,10 @@ ALLOWLIST=(
   "components/ui/dropdown-menu.tsx"
   "components/ui/panel-trigger.tsx"
   # (Orb.tsx removed from allowlist — now consumed by StackStrip.tsx s199)
+  # s198 focused-canvas stub replaced by docked ChatFlyout (2026-05-31).
+  # File kept in case the per-context pane design revives it; delete
+  # once the focused-canvas layout is confirmed final.
+  "components/HearthChatPane.tsx"
   # s197 Hearth Home — old overview tab components temporarily displaced.
   # Re-wire when /usage and /impactinomics dedicated routes ship (v0.4.0).
   "components/ActivityFeed.tsx"

--- a/scripts/runtime-images/polyglot/Dockerfile
+++ b/scripts/runtime-images/polyglot/Dockerfile
@@ -1,0 +1,93 @@
+# agi-runtime:polyglot — Python 3.11 + Node 24 multi-repo base image
+# (Debian 12/bookworm ships Python 3.11; upgrade base image for 3.12+)
+#
+# Use this when a multi-repo project mixes Python and Node.js services
+# in the same container — for example, a FastAPI sim engine running
+# alongside a Next.js frontend, supervised by concurrently.
+#
+# Bundles:
+#   - Python 3.12 + pip + venv + common web server packages
+#     (uvicorn, gunicorn, fastapi, flask, django, aiohttp, httpx)
+#   - Node.js 24 + pnpm + npm + npx
+#   - concurrently (global — process supervisor for multi-repo startup)
+#   - dumb-init (PID 1, signal forwarding)
+#   - git, curl, build-essential (compiled Python packages, source ops)
+#
+# Usage (hosting-manager sets this as baseImage in project.json):
+#   podman run --name agi-<hostname> \
+#     --network agi-net-<hostname> \
+#     -v /path/to/frontend:/srv/repos/frontend:Z \
+#     -v /path/to/api:/srv/repos/api:Z \
+#     agi-runtime:polyglot \
+#     dumb-init -- npx concurrently \
+#       --names "frontend,api" \
+#       --kill-others-on-fail=false \
+#       "cd /srv/repos/frontend && npm run dev" \
+#       "cd /srv/repos/api && uvicorn main:app --reload --host 0.0.0.0 --port 8000"
+
+FROM debian:12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NODE_VERSION=24 \
+    PNPM_HOME=/usr/local/share/pnpm \
+    PATH=/usr/local/share/pnpm:$PATH \
+    # Keeps Python from generating .pyc files
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Ensures stdout/stderr are unbuffered (logs appear immediately)
+    PYTHONUNBUFFERED=1
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dumb-init \
+        git \
+        gnupg \
+        # Build tools for compiled Python packages (numpy, pydantic, etc.)
+        build-essential \
+        libffi-dev \
+        libssl-dev \
+        # Python 3.12 from Debian bookworm (3.12 ships with Debian 12)
+        python3 \
+        python3-pip \
+        python3-venv \
+        python3-dev \
+    ; \
+    # NodeSource repo for Node 24
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends nodejs; \
+    # pnpm via corepack
+    corepack enable; \
+    corepack prepare pnpm@latest --activate; \
+    # concurrently globally — multi-repo process supervisor
+    npm install -g concurrently@^9; \
+    # Common Python web server packages installed system-wide.
+    # Projects that need exact versions should use a venv in their repo;
+    # these are the "works out of the box" defaults for FastAPI/Flask/Django.
+    pip3 install --no-cache-dir --break-system-packages \
+        uvicorn[standard] \
+        gunicorn \
+        fastapi \
+        flask \
+        django \
+        aiohttp \
+        httpx \
+        python-dotenv \
+        pydantic \
+        sqlalchemy \
+    ; \
+    # Cleanup
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /srv
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+CMD ["bash", "-lc", "echo 'agi-runtime:polyglot ready — no start command provided'; sleep infinity"]

--- a/scripts/runtime-images/polyglot/build.sh
+++ b/scripts/runtime-images/polyglot/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# agi-runtime:polyglot — build script
+#
+# Builds the Python 3.12 + Node 24 base image for mixed-language
+# multi-repo project containers. Tags as `agi-runtime:polyglot`.
+#
+# Usage:
+#   bash scripts/runtime-images/polyglot/build.sh
+#
+# Or: pnpm runtime:build:polyglot
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAG="agi-runtime:polyglot"
+
+echo "[polyglot] Building $TAG from $SCRIPT_DIR..."
+podman build -t "$TAG" "$SCRIPT_DIR"
+echo "[polyglot] Built $TAG"
+
+echo "[polyglot] Verifying runtimes..."
+podman run --rm "$TAG" bash -lc '
+  set -e
+  echo "  node:        $(node --version)"
+  echo "  npm:         $(npm --version)"
+  echo "  pnpm:        $(pnpm --version)"
+  echo "  concurrently: $(npx --no-install concurrently --version)"
+  echo "  python:      $(python3 --version)"
+  echo "  pip:         $(pip3 --version)"
+  echo "  uvicorn:     $(uvicorn --version)"
+  echo "  gunicorn:    $(gunicorn --version)"
+  echo "  fastapi:     $(python3 -c '\''import fastapi; print(fastapi.__version__)'\'')"
+  echo "  flask:       $(python3 -c '\''import flask; print(flask.__version__)'\'')"
+  echo "  django:      $(python3 -c '\''import django; print(django.__version__)'\'')"
+  echo "  dumb-init:   $(dumb-init --version 2>&1 | head -1)"
+'
+echo "[polyglot] OK"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -464,6 +464,67 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 7d. PAx upstream sync — merge upstream changes into owner forks
+#
+# Each Particle-Academy package fork lives at $HOME/_projects/_aionima/repos/<slug>/.
+# This step fetches upstream/main for every cloned PAx repo, attempts a
+# fast-forward merge, and pushes to origin. Conflicts are noted as optional
+# UpgradeNextSteps (never blocks restart). Uncloned repos are silently skipped.
+# ---------------------------------------------------------------------------
+PAX_BASE="$HOME/_projects/_aionima/repos"
+PAX_SLUGS=(
+  react-fancy fancy-code fancy-sheets fancy-echarts fancy-3d fancy-screens
+  fancy-whiteboard agent-integrations fancy-artboard fancy-slides fancy-flow
+)
+PAX_ANY_SYNCED=0
+emit "pax-sync" "start" "Syncing PAx forks from Particle-Academy upstream"
+for pax_slug in "${PAX_SLUGS[@]}"; do
+  pax_path="$PAX_BASE/$pax_slug"
+  if [ ! -d "$pax_path/.git" ]; then
+    emit "pax-sync" "skip" "$pax_slug not cloned — skipping"
+    continue
+  fi
+  (
+    cd "$pax_path" || exit 0
+    # Ensure upstream remote points to Particle-Academy
+    if ! git remote get-url upstream &>/dev/null; then
+      git remote add upstream "https://github.com/Particle-Academy/$pax_slug.git" 2>/dev/null || true
+    fi
+    git fetch upstream main --quiet 2>&1 || { emit "pax-sync" "warn" "$pax_slug: fetch failed"; exit 0; }
+    behind=$(git rev-list HEAD..upstream/main 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$behind" = "0" ]; then
+      emit "pax-sync" "skip" "$pax_slug already up to date"
+      exit 0
+    fi
+    current_branch=$(git branch --show-current 2>/dev/null || echo "dev")
+    merge_output=$(git merge upstream/main --no-edit 2>&1)
+    merge_exit=$?
+    if [ "$merge_exit" -eq 0 ]; then
+      git push origin "$current_branch" --quiet 2>/dev/null || true
+      emit "pax-sync" "done" "$pax_slug: merged $behind commits from upstream, pushed to origin/$current_branch"
+      PAX_ANY_SYNCED=$((PAX_ANY_SYNCED + 1))
+    else
+      git merge --abort 2>/dev/null || true
+      # Stack an optional UpgradeNextStep so the owner knows about the conflict
+      node -e "
+        const { appendPendingStep } = require('$DEPLOY_DIR/packages/gateway-core/src/upgrade-next-steps.js');
+        const version = require('$DEPLOY_DIR/package.json').version;
+        appendPendingStep({
+          id: 'pax-conflict-$pax_slug-' + version,
+          title: 'Merge conflict in $pax_slug',
+          description: 'upstream/main had conflicts with your local changes in $pax_path. Merge manually: cd $pax_path && git merge upstream/main',
+          required: false,
+          fromVersion: version,
+          action: { label: 'Open terminal', kind: 'navigate', target: '/projects/_aionima' }
+        });
+      " 2>/dev/null || true
+      emit "pax-sync" "warn" "$pax_slug: merge conflict — manual merge required (see post-upgrade steps)"
+    fi
+  )
+done
+emit "pax-sync" "done" "PAx sync complete"
+
+# ---------------------------------------------------------------------------
 # 7e. Migrate project configs to current schema
 # ---------------------------------------------------------------------------
 emit "migrate" "start"
@@ -536,6 +597,9 @@ git rev-parse HEAD > "$DEPLOY_DIR/.deployed-commit"
 # 12. Restart if version changed
 # ---------------------------------------------------------------------------
 version_after="$(cd "$DEPLOY_DIR" && node -p "require('./package.json').version" 2>/dev/null || echo "0.0.0")"
+
+# Write deployed version so the gateway can detect a new boot and emit system:upgraded.
+echo "$version_after" > "$HOME/.agi/deployed-version.txt"
 
 if [ "$version_before" != "$version_after" ]; then
   emit "restart" "start" "Version changed: $version_before → $version_after"

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -1109,6 +1109,7 @@ export interface HostingStatus {
     hostname: string;
     type: string;
     status: "running" | "stopped" | "error" | "unconfigured";
+    serving: boolean;
     port: number | null;
     url: string | null;
     mode: "production" | "development";

--- a/ui/dashboard/src/api.ts
+++ b/ui/dashboard/src/api.ts
@@ -885,6 +885,28 @@ export async function fetchChangelog(count = 50, offset = 0): Promise<{ commits:
 }
 
 // ---------------------------------------------------------------------------
+// UpgradeNextSteps — /api/system/upgrade-next-steps
+// ---------------------------------------------------------------------------
+
+export async function fetchUpgradeNextSteps(filter: "pending" | "all" = "pending"): Promise<{ steps: import("./types.js").UpgradeNextStep[]; hasRequired: boolean }> {
+  const res = await fetch(`/api/system/upgrade-next-steps?filter=${filter}`);
+  if (!res.ok) return { steps: [], hasRequired: false };
+  return res.json() as Promise<{ steps: import("./types.js").UpgradeNextStep[]; hasRequired: boolean }>;
+}
+
+export async function completeUpgradeStep(id: string): Promise<{ ok: boolean; hasRequired: boolean }> {
+  const res = await fetch(`/api/system/upgrade-next-steps/${encodeURIComponent(id)}/done`, { method: "POST" });
+  if (!res.ok) return { ok: false, hasRequired: false };
+  return res.json() as Promise<{ ok: boolean; hasRequired: boolean }>;
+}
+
+export async function dismissUpgradeStep(id: string): Promise<{ ok: boolean; hasRequired: boolean }> {
+  const res = await fetch(`/api/system/upgrade-next-steps/${encodeURIComponent(id)}/dismiss`, { method: "POST" });
+  if (!res.ok) return { ok: false, hasRequired: false };
+  return res.json() as Promise<{ ok: boolean; hasRequired: boolean }>;
+}
+
+// ---------------------------------------------------------------------------
 // System connections — /api/system/connections
 // ---------------------------------------------------------------------------
 

--- a/ui/dashboard/src/components/ChatFlyout.tsx
+++ b/ui/dashboard/src/components/ChatFlyout.tsx
@@ -1899,13 +1899,12 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
 
   // Docked / shell mode: inline flex child (no overlay, no backdrop).
   if (docked) {
-    const flyout = (
-      <AccordionFlyout
-        chat={chatSlot}
-        canvas={canvasSlot}
-        isMobile={isMobile}
-      />
-    );
+    // In shell mode, render the chat body directly — no nested AccordionFlyout.
+    // The outer shell's AccordionPanel already provides the canvas/chat/workspace
+    // split; nesting AccordionFlyout would produce 4 duplicate rail triggers.
+    const inner = inShell
+      ? chatSlot
+      : <AccordionFlyout chat={chatSlot} canvas={canvasSlot} isMobile={isMobile} />;
     return (
       <>
         <div
@@ -1917,7 +1916,7 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
           }
           style={inShell ? undefined : { width: "50%" }}
         >
-          {flyout}
+          {inner}
         </div>
         <TokenBreakdownModal
           open={tokenBreakdownMsg !== null}

--- a/ui/dashboard/src/components/ChatFlyout.tsx
+++ b/ui/dashboard/src/components/ChatFlyout.tsx
@@ -199,6 +199,9 @@ export interface ChatFlyoutProps {
   openRequestId?: string | null;
   /** When true, renders as an inline flex child instead of a fixed overlay. */
   docked?: boolean;
+  /** When true (implies docked=true), renders without the outer width div so
+   *  the AccordionPanel shell section owns the container sizing. */
+  inShell?: boolean;
   /** s124 cycle 86 rework — global notification list. ChatFlyout filters
    *  to iterative-work entries matching the active session's project path
    *  and renders the latest as an inline IterativeWorkArtifactCard at the
@@ -293,7 +296,7 @@ function TokenBreakdownModal({
 // Component
 // ---------------------------------------------------------------------------
 
-export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithContext, openWithMessage, openRequestId, docked = false, notifications: notificationsProp }: ChatFlyoutProps) {
+export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithContext, openWithMessage, openRequestId, docked = false, inShell = false, notifications: notificationsProp }: ChatFlyoutProps) {
   // State
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const sessionsRef = useRef(sessions);
@@ -1266,12 +1269,13 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
 
   if (!open && !docked) return null;
 
-  // Shared header for docked and overlay modes
+  // Shared header — overlay mode shows Expand + X; docked/shell mode shows neither
+  // (the AccordionPanel rail trigger handles panel collapse instead of an X button).
   const panelHeader = (
     <div className="flex items-center justify-between px-4 py-[10px] bg-card border-b border-border shrink-0">
       <span className="font-bold text-sm text-foreground">Chat</span>
-      <div className="flex gap-1.5">
-        {!docked && (
+      {!docked && (
+        <div className="flex gap-1.5">
           <Button
             variant="outline"
             size="xs"
@@ -1279,15 +1283,15 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
           >
             {isFullscreen ? "Restore" : "Expand"}
           </Button>
-        )}
-        <Button
-          variant="outline"
-          size="xs"
-          onClick={onClose}
-        >
-          X
-        </Button>
-      </div>
+          <Button
+            variant="outline"
+            size="xs"
+            onClick={onClose}
+          >
+            X
+          </Button>
+        </div>
+      )}
     </div>
   );
 
@@ -1893,23 +1897,27 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
     />
   );
 
-  // Docked mode: inline flex child (no overlay, no backdrop). The
-  // AccordionFlyout owns the chat-vs-canvas split internally — this branch
-  // just sizes the outer container.
+  // Docked / shell mode: inline flex child (no overlay, no backdrop).
   if (docked) {
+    const flyout = (
+      <AccordionFlyout
+        chat={chatSlot}
+        canvas={canvasSlot}
+        isMobile={isMobile}
+      />
+    );
     return (
       <>
         <div
           data-testid="chat-flyout"
           data-chat-context={openWithContext ?? undefined}
-          className="flex h-full border-l border-border bg-background"
-          style={{ width: "50%" }}
+          className={inShell
+            ? "flex h-full bg-background w-full"
+            : "flex h-full border-l border-border bg-background"
+          }
+          style={inShell ? undefined : { width: "50%" }}
         >
-          <AccordionFlyout
-            chat={chatSlot}
-            canvas={canvasSlot}
-            isMobile={isMobile}
-          />
+          {flyout}
         </div>
         <TokenBreakdownModal
           open={tokenBreakdownMsg !== null}

--- a/ui/dashboard/src/components/ChatFlyout.tsx
+++ b/ui/dashboard/src/components/ChatFlyout.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 // Chat content now renders via react-fancy's ContentRenderer (see imports
 // below). The legacy ReactMarkdown + markdownComponents path was retired
 // in favor of ContentRenderer + registered extensions (thinking, question,
@@ -202,6 +203,10 @@ export interface ChatFlyoutProps {
   /** When true (implies docked=true), renders without the outer width div so
    *  the AccordionPanel shell section owns the container sizing. */
   inShell?: boolean;
+  /** When provided (inShell=true), the AgentCanvas (canvasSlot) is portalled
+   *  into this element so it renders inside the shell's Canvas section while
+   *  remaining in ChatFlyout's React tree (state + WS events stay local). */
+  canvasPortalTarget?: Element | null;
   /** s124 cycle 86 rework — global notification list. ChatFlyout filters
    *  to iterative-work entries matching the active session's project path
    *  and renders the latest as an inline IterativeWorkArtifactCard at the
@@ -296,7 +301,7 @@ function TokenBreakdownModal({
 // Component
 // ---------------------------------------------------------------------------
 
-export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithContext, openWithMessage, openRequestId, docked = false, inShell = false, notifications: notificationsProp }: ChatFlyoutProps) {
+export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithContext, openWithMessage, openRequestId, docked = false, inShell = false, canvasPortalTarget, notifications: notificationsProp }: ChatFlyoutProps) {
   // State
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const sessionsRef = useRef(sessions);
@@ -1899,11 +1904,18 @@ export function ChatFlyout({ open, onClose, theme = "dark", projects, openWithCo
 
   // Docked / shell mode: inline flex child (no overlay, no backdrop).
   if (docked) {
-    // In shell mode, render the chat body directly — no nested AccordionFlyout.
-    // The outer shell's AccordionPanel already provides the canvas/chat/workspace
-    // split; nesting AccordionFlyout would produce 4 duplicate rail triggers.
+    // In shell mode, render chat directly (no nested AccordionFlyout — that
+    // would add 2 extra rail triggers inside the outer shell's 3 sections).
+    // The AgentCanvas is portalled into the shell's dedicated Canvas section
+    // via canvasPortalTarget so it stays in this React tree (state/WS events)
+    // but appears visually in the correct panel.
     const inner = inShell
-      ? chatSlot
+      ? (
+        <>
+          {chatSlot}
+          {canvasPortalTarget && createPortal(canvasSlot, canvasPortalTarget)}
+        </>
+      )
       : <AccordionFlyout chat={chatSlot} canvas={canvasSlot} isMobile={isMobile} />;
     return (
       <>

--- a/ui/dashboard/src/components/EditorFlyout.tsx
+++ b/ui/dashboard/src/components/EditorFlyout.tsx
@@ -2,11 +2,12 @@
  * EditorFlyout — slide-in panel wrapping KnowledgeEditor with file load/save lifecycle.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FlyoutPanel, FlyoutHeader, FlyoutBody, FlyoutFooter } from "@/components/ui/flyout-panel.js";
 import { KnowledgeEditor } from "@/components/KnowledgeEditor.js";
 import { fetchFile, saveFile, fetchProjectFile, saveProjectFile } from "@/api.js";
 import { useIsMobile } from "@/hooks.js";
+import { cn } from "@/lib/utils";
 
 export interface EditorFlyoutProps {
   filePath: string | null; // null = closed
@@ -14,9 +15,11 @@ export interface EditorFlyoutProps {
   theme?: "light" | "dark";
   position?: "left" | "right";
   docked?: boolean;
+  /** Shell panel mode — renders as full-height inline div with no overlay chrome. */
+  panel?: boolean;
 }
 
-export function EditorFlyout({ filePath, onClose, position = "right", docked = false }: EditorFlyoutProps) {
+export function EditorFlyout({ filePath, onClose, position = "right", docked = false, panel = false }: EditorFlyoutProps) {
   const [content, setContent] = useState("");
   const [draft, setDraft] = useState("");
   const [loading, setLoading] = useState(false);
@@ -24,6 +27,8 @@ export function EditorFlyout({ filePath, onClose, position = "right", docked = f
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
   const isMobile = useIsMobile();
+  // Keep handleSave stable for the keydown listener
+  const handleSaveRef = useRef<() => Promise<void>>();
 
   const dirty = draft !== content;
 
@@ -75,6 +80,21 @@ export function EditorFlyout({ filePath, onClose, position = "right", docked = f
       setSaving(false);
     }
   }, [filePath, draft, dirty, isProjectFile]);
+
+  // Keep ref in sync so the keydown handler always calls the latest version
+  handleSaveRef.current = handleSave;
+
+  // Ctrl+S / Cmd+S save
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
+        e.preventDefault();
+        void handleSaveRef.current?.();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
 
   const fileName = filePath?.split("/").pop() ?? "";
 
@@ -211,6 +231,28 @@ export function EditorFlyout({ filePath, onClose, position = "right", docked = f
       )}
     </>
   );
+
+  // Panel mode — shell workspace section, fills AccordionPanel.Content
+  if (panel) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col h-full w-full min-h-0 min-w-0 bg-card",
+          !filePath && "items-center justify-center",
+        )}
+        data-testid="editor-panel"
+      >
+        {filePath ? innerContent : (
+          <div className="text-center px-6">
+            <div className="text-5xl mb-3 opacity-20 select-none">✎</div>
+            <p className="text-[13px] text-muted-foreground/70">
+              Open a file from the project to edit it here.
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   if (docked) {
     return (

--- a/ui/dashboard/src/components/HostingPanel.tsx
+++ b/ui/dashboard/src/components/HostingPanel.tsx
@@ -13,7 +13,7 @@ import { Card } from "@/components/ui/card";
 import { Select } from "@/components/ui/select";
 import { isDesktopServedType } from "@/lib/project-type-classifier";
 import type { ProjectHostingInfo, ProjectTypeTool, RuntimeInfo, StackInfo, ProjectStackInstance } from "../types.js";
-import { fetchProjectDevCommands, fetchRuntimes, fetchProjectStacks, fetchStacks, fetchEffectiveStartCommand, resetCircuitBreaker } from "../api.js";
+import { fetchProjectDevCommands, fetchRuntimes, fetchProjectStacks, fetchStacks, fetchEffectiveStartCommand, resetCircuitBreaker, fetchContainerLogs } from "../api.js";
 import type { EffectiveStartCommand } from "../api.js";
 import { ProjectToolbar } from "./ProjectToolbar.js";
 import { StackManager } from "./StackManager.js";
@@ -104,6 +104,9 @@ export function HostingPanel({
   const [stickyError, setStickyError] = useState<string | null>(null);
   const [logRefreshKey, setLogRefreshKey] = useState(0);
   const [dbRestartNeeded, setDbRestartNeeded] = useState(false);
+  const [friendlyErrors, setFriendlyErrors] = useState<boolean>(hosting.friendlyErrors ?? true);
+  const [baseImage, setBaseImage] = useState<string>(hosting.baseImage ?? "");
+  const [autoLogs, setAutoLogs] = useState<string | null>(null);
 
   // Sync state when hosting prop changes
   useEffect(() => {
@@ -125,6 +128,32 @@ export function HostingPanel({
       setStickyError(null);
     }
   }, [hosting.error, hosting.status]);
+
+  // Auto-fetch container logs when the container is running but the app isn't
+  // responding (serving=false). Gives the developer immediate startup crash output
+  // without having to navigate to the Logs tab. Clears when serving flips true.
+  useEffect(() => {
+    const isDegraded = hosting.status === "running" && !(hosting.serving ?? true);
+    if (!isDegraded) {
+      setAutoLogs(null);
+      return;
+    }
+    let cancelled = false;
+    const fetch_ = () => {
+      fetchContainerLogs(projectPath, 50)
+        .then(({ logs }) => { if (!cancelled) setAutoLogs(logs || "(no output yet)"); })
+        .catch(() => { if (!cancelled) setAutoLogs("(failed to fetch logs)"); });
+    };
+    fetch_();
+    const interval = setInterval(fetch_, 5_000);
+    return () => { cancelled = true; clearInterval(interval); };
+  }, [projectPath, hosting.status, hosting.serving]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync friendlyErrors/baseImage when hosting prop updates
+  useEffect(() => {
+    setFriendlyErrors(hosting.friendlyErrors ?? true);
+    setBaseImage(hosting.baseImage ?? "");
+  }, [hosting.friendlyErrors, hosting.baseImage]);
 
   // Fetch aggregated dev commands from installed stacks
   useEffect(() => {
@@ -176,11 +205,13 @@ export function HostingPanel({
         mode,
         internalPort: portNum && !isNaN(portNum) ? portNum : undefined,
         mapps: parsedMapps,
+        friendlyErrors,
+        baseImage: baseImage.trim() || null,
       });
     } catch { /* error handled by caller */ } finally {
       setSaving(false);
     }
-  }, [projectPath, type, hostname, docRoot, startCommand, mode, internalPort, desktopServed, mappsInput, onConfigure]);
+  }, [projectPath, type, hostname, docRoot, startCommand, mode, internalPort, desktopServed, mappsInput, friendlyErrors, baseImage, onConfigure]);
 
   // Derive the set of compatible languages from installed stacks.
   // If any installed stack declares compatibleLanguages, restrict the runtime
@@ -310,6 +341,16 @@ export function HostingPanel({
           <div className="flex gap-3 mt-1.5 text-[11px] text-muted-foreground">
             {hosting.containerName && <span>Container: <code className="text-foreground">{hosting.containerName}</code></span>}
             {hosting.image && <span>Image: <code className="text-foreground">{hosting.image}</code></span>}
+          </div>
+        )}
+        {/* Auto-fetch logs when container is running but app not yet responding */}
+        {autoLogs !== null && (
+          <div className="mt-2 rounded border border-border bg-black/40 overflow-hidden">
+            <div className="flex items-center gap-2 px-2 py-1 border-b border-border bg-black/20">
+              <span className="text-[10px] text-yellow font-semibold">Startup logs</span>
+              <span className="text-[10px] text-muted-foreground">— container running, app not yet responding</span>
+            </div>
+            <pre className="text-[10px] text-muted-foreground font-mono px-2 py-1.5 overflow-x-auto max-h-40 overflow-y-auto whitespace-pre-wrap break-all">{autoLogs}</pre>
           </div>
         )}
       </div>
@@ -489,6 +530,40 @@ export function HostingPanel({
             className="text-[12px] h-8"
           />
         </div>
+      </div>
+
+      {/* Debug / error visibility options */}
+      <div className="mb-3 pt-2 border-t border-border">
+        <div className="text-[10px] font-semibold text-muted-foreground mb-1.5">Error Handling</div>
+        <label className="flex items-center gap-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={friendlyErrors}
+            onChange={(e) => setFriendlyErrors(e.target.checked)}
+            disabled={busy}
+            className="w-3.5 h-3.5 rounded"
+          />
+          <span className="text-[11px]">Friendly error page</span>
+          <span className="text-[10px] text-muted-foreground">(uncheck to see raw app errors in browser)</span>
+        </label>
+        {!desktopServed && (
+          <div className="mt-2">
+            <label className="block text-[10px] font-semibold text-muted-foreground mb-0.5">
+              Base image override <span className="font-normal">(multi-repo, optional)</span>
+            </label>
+            <Input
+              type="text"
+              value={baseImage}
+              onChange={(e) => setBaseImage(e.target.value)}
+              disabled={busy}
+              placeholder="agi-runtime:lamp (default)"
+              className="text-[11px] h-7 font-mono"
+            />
+            <p className="text-[10px] text-muted-foreground mt-0.5">
+              Use a custom fat image for mixed-language projects (e.g. Python + Node).
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Database */}

--- a/ui/dashboard/src/components/HostingPanel.tsx
+++ b/ui/dashboard/src/components/HostingPanel.tsx
@@ -205,23 +205,27 @@ export function HostingPanel({
   const needsBuild = hosting.status === "error"
     && (stickyError?.startsWith("Build output missing") ?? false);
 
+  // Green = running + TCP probe succeeded.
+  // Yellow = running but app not yet responding (starting up / degraded).
+  // Red = container stopped or error. Grey = not configured.
+  const isServing = hosting.status === "running" && (hosting.serving ?? false);
+  const isDegraded = hosting.status === "running" && !(hosting.serving ?? true);
+
   const statusColor = needsBuild
     ? "text-yellow"
-    : {
-        running: "text-green",
-        stopped: "text-muted-foreground",
-        error: "text-red",
-        unconfigured: "text-muted-foreground",
-      }[hosting.status];
+    : isServing ? "text-green"
+    : isDegraded ? "text-yellow"
+    : hosting.status === "stopped" ? "text-red"
+    : hosting.status === "error" ? "text-red"
+    : "text-muted-foreground";
 
   const statusDot = needsBuild
     ? "bg-yellow"
-    : {
-        running: "bg-green",
-        stopped: "bg-muted-foreground",
-        error: "bg-red",
-        unconfigured: "bg-muted-foreground",
-      }[hosting.status];
+    : isServing ? "bg-green"
+    : isDegraded ? "bg-yellow"
+    : hosting.status === "stopped" ? "bg-red"
+    : hosting.status === "error" ? "bg-red"
+    : "bg-muted-foreground";
 
   const statusLabel = needsBuild ? "needs build" : hosting.status;
 

--- a/ui/dashboard/src/components/Logs.tsx
+++ b/ui/dashboard/src/components/Logs.tsx
@@ -84,7 +84,7 @@ export function Logs({ entries, connected, paused, onClear, onTogglePause }: Log
   };
 
   return (
-    <div className="flex flex-col h-full min-h-0">
+    <div className="flex flex-col flex-1 min-h-0">
       {/* Toolbar */}
       <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-card flex-wrap">
         {/* Level checkboxes */}

--- a/ui/dashboard/src/components/ProjHeader.tsx
+++ b/ui/dashboard/src/components/ProjHeader.tsx
@@ -9,15 +9,14 @@
 
 import { ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import type { Project } from "@/types.js";
 
 interface ProjHeaderProps {
   project: Project;
-  onOpenChat: (path: string) => void;
+  onOpenChat?: (path: string) => void;
 }
 
-export function ProjHeader({ project, onOpenChat }: ProjHeaderProps) {
+export function ProjHeader({ project }: ProjHeaderProps) {
   const primaryRepo = project.repos?.[0];
   const shortRepoUrl = primaryRepo?.url
     ? primaryRepo.url.replace(/^https?:\/\/(www\.)?/, "").replace(/\.git$/, "")
@@ -65,17 +64,6 @@ export function ProjHeader({ project, onOpenChat }: ProjHeaderProps) {
           {hostedUrl}
         </a>
       )}
-      <div className="ml-auto shrink-0">
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 text-xs"
-          onClick={() => onOpenChat(project.path)}
-          data-testid="proj-header-chat-button"
-        >
-          Chat
-        </Button>
-      </div>
     </div>
   );
 }

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -112,6 +112,7 @@ function tabIdToCanvasLabel(tabId: string, panels: PluginPanel[]): string {
 
 export function ProjectDetail({
   projects, onUpdate, updating, onDelete, deleting, onRefresh, onOpenChat, theme,
+  projectActivity,
   hostingStatus, onHostingConfigure, onHostingRestart,
   onTunnelEnable, onTunnelDisable, hostingBusy,
   onOpenEditor, onToolExecute, onOpenTerminal, contributingEnabled, onFixFinding,

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -436,7 +436,13 @@ export function ProjectDetail({
           const s = project.hosting?.status;
           const enabled = project.hosting?.enabled;
           if (!enabled) return null;
-          const cls = s === "running" ? "bg-green" : s === "error" ? "bg-red" : "bg-yellow";
+          const serving = project.hosting?.serving ?? false;
+          const cls =
+            s === "running" && serving ? "bg-green"
+            : s === "running" ? "bg-yellow"
+            : s === "error" ? "bg-red"
+            : s === "stopped" ? "bg-red"
+            : "bg-muted-foreground";
           // s140 cycle-172 t594 — aria-label not title. title doesn't show
           // on touch devices and is inconsistently announced by screen
           // readers. aria-label is the durable a11y primitive for an
@@ -452,6 +458,12 @@ export function ProjectDetail({
         })()}
         <h2 className="text-xl font-bold text-foreground">{project.name}</h2>
         <DevNotes title="Project workspace — dev notes">
+          <DevNotes.Item kind="info" heading="Cycle 2026-05-31 — 3-state status dot + TCP health probe">
+            Status dot is now 3-state: green = container running AND TCP probe reached the port (app serving),
+            yellow = container running but port not yet responding (starting up / internal crash),
+            red = container stopped or error. Backend runs a 10-second TCP probe loop; frontend polls
+            every 10s (was 120s). StackStrip fallback text simplified to "No active tasks".
+          </DevNotes.Item>
           <DevNotes.Item kind="info" heading="s199 (2026-05-28) — ProjHeader + StackStrip + mode picker restyle">
             ProjHeader compact bar (name, category badge, primary repo URL, hosted URL, Chat button) added
             above mode picker. StackStrip shows Aion's live iterative-work task summary (from projectActivity)

--- a/ui/dashboard/src/components/ProjectDetail.tsx
+++ b/ui/dashboard/src/components/ProjectDetail.tsx
@@ -14,8 +14,8 @@ import { Select } from "@/components/ui/select";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-import { execGitAction, fetchProjectFileTree, fetchProjectFile, saveProjectFile, createProjectFile, deleteProjectFile, renameProjectFile, fetchPluginPanels, fetchPluginActions, fetchProjectTypes, fetchIterativeWorkStatus, fetchIterativeWorkProgress, fetchNotes, updateProjectRepo } from "../api.js";
-import type { FileNode, IterativeWorkProjectStatus, IterativeWorkProgress } from "../api.js";
+import { execGitAction, fetchProjectFileTree, fetchProjectFile, saveProjectFile, createProjectFile, deleteProjectFile, renameProjectFile, fetchPluginPanels, fetchPluginActions, fetchProjectTypes, updateProjectRepo } from "../api.js";
+import type { FileNode } from "../api.js";
 import { DevNotes } from "@/components/ui/dev-notes";
 import { ProjHeader } from "@/components/ProjHeader.js";
 import { StackStrip } from "@/components/StackStrip.js";
@@ -413,18 +413,10 @@ export function ProjectDetail({
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden p-3 md:p-6">
       {/* Header row */}
-      <div className="flex items-center justify-between mb-6 shrink-0">
+      <div className="flex items-center mb-6 shrink-0">
         <Link to="/projects" className="no-underline">
           <Button variant="outline" size="sm">Back to Projects</Button>
         </Link>
-        <div className="flex gap-2">
-          {/* The project-level (container) terminal lives in the Development tab > Terminal
-              subtab. The host-level system terminal is now a global button in the dashboard
-              header — see root.tsx. No Terminal button on the project page. */}
-          <Button size="sm" data-testid="project-chat-button" onClick={() => onOpenChat(project.path)}>
-            open chat
-          </Button>
-        </div>
       </div>
 
       {/* Project heading — extended per projects-ux-v2 mockup B (cycle 134):
@@ -1556,164 +1548,8 @@ export function ProjectDetail({
           </TabsContent>
         )}
       </Tabs>
-      {!isCoreFork && (
-        <aside
-          className="w-[280px] hidden lg:flex flex-col border-l border-border pl-3"
-          data-testid="project-chat-aside"
-          aria-label="Project chat panel"
-        >
-          <ProjectChatAside
-            project={project}
-            onOpenChat={() => onOpenChat(project.path)}
-            onOpenNotes={() => setActiveTab("notes")}
-          />
-        </aside>
-      )}
       </div>
     </div>
   );
 }
 
-/**
- * Project chat aside (slice 5c phase 3 starter — cycle 147).
- *
- * Replaces the cycle-145 placeholder with useful project-scoped content
- * pending the heavier ChatFlyout-into-aside integration. Shows:
- *  - Iterative-work status (enabled / cron / next fire) when eligible
- *  - Progress bar (done/total tasks) sourced from the PM provider
- *  - "Open chat" CTA that mirrors the header button (talk about this project)
- *
- * Iterative-work data is fetched in parallel with progress; failures collapse
- * to a "no status available" hint without breaking the aside chrome.
- */
-function ProjectChatAside({
-  project,
-  onOpenChat,
-  onOpenNotes,
-}: {
-  project: ProjectInfo;
-  onOpenChat: () => void;
-  /** s152 t653 — clicking the notes breadcrumb routes here. */
-  onOpenNotes?: () => void;
-}) {
-  const eligible = (project.iterativeWorkEligible ?? project.projectType?.iterativeWorkEligible) === true;
-  const [status, setStatus] = useState<IterativeWorkProjectStatus | null>(null);
-  const [progress, setProgress] = useState<IterativeWorkProgress | null>(null);
-  // s152 t653 — passive note-availability breadcrumb. When notes exist
-  // for this project (or globally), surface a count so the user knows
-  // Aion is seeing them as project context. Click navigates to the
-  // Notes tab. Best-effort fetch; failures are silent.
-  const [noteCount, setNoteCount] = useState<{ project: number; global: number } | null>(null);
-
-  useEffect(() => {
-    // Cycle 148 — reset state on project change so we don't briefly show
-    // the previous project's status/progress while the new fetch lands.
-    setStatus(null);
-    setProgress(null);
-    setNoteCount(null);
-    if (!eligible) return;
-    let cancelled = false;
-    void Promise.all([
-      fetchIterativeWorkStatus(project.path).catch(() => null),
-      fetchIterativeWorkProgress(project.path).catch(() => null),
-    ]).then(([s, p]) => {
-      if (cancelled) return;
-      setStatus(s);
-      setProgress(p);
-    });
-    return () => { cancelled = true; };
-  }, [eligible, project.path]);
-
-  // s152 t653 — note count fetch lives in its own effect so it runs for
-  // every project (not just iterative-work-eligible ones).
-  useEffect(() => {
-    let cancelled = false;
-    void Promise.all([
-      fetchNotes(project.path).catch(() => []),
-      fetchNotes(null).catch(() => []),
-    ]).then(([proj, global]) => {
-      if (cancelled) return;
-      setNoteCount({ project: proj.length, global: global.length });
-    });
-    return () => { cancelled = true; };
-  }, [project.path]);
-
-  return (
-    <>
-      <h2 className="text-[12px] uppercase tracking-wider text-muted-foreground/80 font-semibold mt-3 mb-2">
-        Chat
-      </h2>
-
-      {/* s152 t653 — passive notes breadcrumb. Visible when at least one
-          per-project or global note exists. Clicking it switches to the
-          Notes tab so the user can see what Aion is seeing. */}
-      {noteCount !== null && (noteCount.project > 0 || noteCount.global > 0) && (
-        <button
-          type="button"
-          className="text-left mb-2 px-3 py-2 rounded bg-secondary/10 hover:bg-secondary/20 transition-colors w-full"
-          onClick={() => { onOpenNotes?.(); }}
-          data-testid="project-chat-aside-notes-breadcrumb"
-          title="Aion sees these notes as project context"
-        >
-          <span className="text-[11px] text-muted-foreground">
-            <span aria-hidden="true">📝</span>{" "}
-            {noteCount.project > 0 && (
-              <>
-                <strong className="text-foreground">{String(noteCount.project)}</strong>{" "}
-                project note{noteCount.project === 1 ? "" : "s"}
-              </>
-            )}
-            {noteCount.project > 0 && noteCount.global > 0 && " · "}
-            {noteCount.global > 0 && (
-              <>
-                <strong className="text-foreground">{String(noteCount.global)}</strong>{" "}
-                global
-              </>
-            )}
-          </span>
-        </button>
-      )}
-
-      {eligible && (
-        <Card className="p-3 mb-2 bg-secondary/10" data-testid="project-chat-aside-iterative">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 font-semibold mb-1">Iterative work</div>
-          <div className="text-[12px] text-foreground">
-            {status === null ? "Loading…" : status.enabled ? "Enabled" : "Disabled"}
-            {status?.inFlight && <span className="ml-1 text-yellow text-[10px]">· running</span>}
-          </div>
-          {status?.cron && (
-            <div className="text-[11px] text-muted-foreground font-mono mt-0.5">{status.cron}</div>
-          )}
-          {progress !== null && progress.totalTasks > 0 && (
-            <div className="mt-2">
-              <div className="text-[11px] text-muted-foreground mb-1">
-                {progress.doneTasks}/{progress.totalTasks} done · {progress.percentComplete}%
-              </div>
-              <div className="h-1.5 bg-secondary rounded overflow-hidden">
-                <div
-                  className="h-full bg-yellow transition-[width]"
-                  style={{ width: `${String(progress.percentComplete)}%` }}
-                />
-              </div>
-            </div>
-          )}
-        </Card>
-      )}
-
-      <Card className="p-3 flex-1 min-h-0 overflow-y-auto bg-secondary/10 border-dashed border-border/60">
-        <p className="text-[11px] text-muted-foreground/80 leading-relaxed">
-          Project-scoped chat panel — the heavy integration ships in slice 5c phase 4. Use Open chat to talk
-          about this project today.
-        </p>
-        <Button
-          size="sm"
-          className="mt-3 w-full"
-          onClick={onOpenChat}
-          data-testid="project-chat-aside-open"
-        >
-          Open chat
-        </Button>
-      </Card>
-    </>
-  );
-}

--- a/ui/dashboard/src/components/Projects.tsx
+++ b/ui/dashboard/src/components/Projects.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { DevNotes } from "@/components/ui/dev-notes";
-import { SACRED_PROJECTS, PAX_SACRED_PROJECTS, isSacredProject, isPaxProject, matchSacredProject } from "@/lib/sacred-projects.js";
+import { SACRED_PROJECTS, PAX_SACRED_PROJECTS, isSacredProject, isPaxProject } from "@/lib/sacred-projects.js";
 import { Table } from "@particle-academy/react-fancy";
 import { fetchProjectActivitySummary, type ProjectActivitySummary } from "../api.js";
 import {
@@ -59,7 +59,7 @@ export interface ProjectsProps {
 
 export function Projects({
   projects, loading, error, creating, onCreate, onRefresh,
-  projectActivity, hostingStatus, contributingEnabled,
+  projectActivity, hostingStatus, contributingEnabled: _contributingEnabled,
 }: ProjectsProps) {
   const [showModal, setShowModal] = useState(false);
   const [showSetupTerminal, setShowSetupTerminal] = useState(false);
@@ -73,17 +73,6 @@ export function Projects({
   // the table render; a project without a summary just shows a flat line.
   const [activitySummaries, setActivitySummaries] = useState<Record<string, ProjectActivitySummary>>({});
   const navigate = useNavigate();
-  const isContributing = Boolean(contributingEnabled);
-
-  // Owner directive 2026-05-13: `_aionima` is the Sacred project and must be
-  // present + visible regardless of dev/contributing mode. Dev mode now only
-  // gates fork-population into `_aionima/repos/`, not card visibility.
-  // sacredEntries enumerated unconditionally; counts in the card description
-  // reflect what's actually cloned (0 when contributing-mode off + no forks).
-  const sacredEntries = SACRED_PROJECTS.map((sacred) => ({
-    sacred,
-    project: matchSacredProject(projects, sacred.id),
-  }));
 
   // Owner directive 2026-05-13: `_aionima/` is the meta-project and must
   // never appear in the regular projects list — only as the Sacred card.
@@ -147,6 +136,24 @@ export function Projects({
       })
       .join("");
   };
+
+  // Derive activity-based project health per the Hearth mockup:
+  // green = Aion active or has recent 30d activity, rose = hosting error, amber = idle
+  const deriveHealth = (p: ProjectInfo): "green" | "amber" | "rose" => {
+    if (p.hosting?.status === "error") return "rose";
+    if (projectActivity?.[p.path]) return "green";
+    const summary = activitySummaries[p.path];
+    if (summary && summary.total > 0) return "green";
+    return "amber";
+  };
+
+  // Sort: green → amber → rose (problems surface naturally)
+  const sortedProjects = [...visibleProjects].sort((a, b) => {
+    const order = { green: 0, amber: 1, rose: 2 } as const;
+    return order[deriveHealth(a)] - order[deriveHealth(b)];
+  });
+
+  const aionActiveCount = visibleProjects.filter((p) => projectActivity?.[p.path]).length;
 
   return (
     <div>
@@ -277,6 +284,70 @@ export function Projects({
           inline panel land in subsequent slices. */}
       {viewMode === "list" && (
         <div data-testid="projects-list">
+          {/* Platform hero — Aionima is the gateway itself, always present, always first */}
+          <div
+            className="mb-4 rounded-xl border border-yellow/30 bg-gradient-to-r from-yellow/5 to-transparent p-4 flex items-start gap-4 cursor-pointer hover:border-yellow/50 transition-colors"
+            onClick={() => void navigate("/projects/_aionima")}
+            data-testid="project-card-aionima"
+          >
+            <div className="shrink-0 w-10 h-10 rounded-lg bg-yellow/10 border border-yellow/30 flex items-center justify-center">
+              <Star className="h-5 w-5 text-yellow" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap mb-1">
+                <span className="text-[15px] font-bold text-foreground">Aionima</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow/15 text-yellow font-bold uppercase tracking-wide">Platform</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-500/15 text-indigo-400 font-semibold flex items-center gap-1">
+                  ⛨ sacred
+                </span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface1 text-muted-foreground font-mono">
+                  ⌗{SACRED_PROJECTS.length + PAX_SACRED_PROJECTS.length} repos
+                </span>
+              </div>
+              <p className="text-[11px] text-muted-foreground leading-relaxed">
+                The gateway itself — Aion's own source, the project suite, channels, and admin.
+                Present in every install · cannot be deleted or archived · Aion edits under guardrails.
+              </p>
+            </div>
+            <div className="shrink-0 flex items-center gap-3 text-[11px] text-muted-foreground">
+              <div className="text-center">
+                <div className="text-[12px] font-semibold text-green flex items-center gap-1">
+                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-[pulse-green_2s_ease-in-out_infinite]" />
+                  Running
+                </div>
+                <div className="text-[10px]">Aion lives here</div>
+              </div>
+              <div className="text-center">
+                <div className="text-[12px] font-semibold text-foreground">self-edit</div>
+                <div className="text-[10px]">source access</div>
+              </div>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); void navigate("/projects/_aionima"); }}
+                className="ml-2 text-[11px] px-3 py-1.5 rounded-lg bg-secondary text-secondary-foreground hover:bg-secondary/80 font-medium"
+              >
+                Open platform →
+              </button>
+            </div>
+          </div>
+
+          {/* Filter chips + sort indicator */}
+          <div className="flex items-center gap-2 mb-3 text-[11px]">
+            <span className="px-2.5 py-1 rounded-full bg-secondary text-secondary-foreground font-medium">
+              All {sortedProjects.length}
+            </span>
+            <span className="px-2.5 py-1 rounded-full border border-yellow/40 text-yellow font-medium">
+              Amber {sortedProjects.filter((p) => deriveHealth(p) === "amber").length}
+            </span>
+            {aionActiveCount > 0 && (
+              <span className="px-2.5 py-1 rounded-full border border-green/40 text-green font-medium flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-[pulse-green_2s_ease-in-out_infinite]" />
+                Aion active {aionActiveCount}
+              </span>
+            )}
+            <span className="ml-auto text-muted-foreground">sorted by health</span>
+          </div>
+
           <Table>
             <Table.Head>
               <Table.Column label="" />
@@ -291,41 +362,8 @@ export function Projects({
               <Table.Column label="Health" />
             </Table.Head>
             <Table.Body>
-              {/* Aionima — sacred row pinned at top of list */}
-              <Table.Row
-                onClick={() => void navigate("/projects/_aionima")}
-                className={cn(
-                  "cursor-pointer",
-                  "bg-indigo-50/70 dark:bg-indigo-950/40",
-                  "hover:bg-indigo-100/80 dark:hover:bg-indigo-900/50",
-                )}
-                data-testid="project-card-aionima"
-              >
-                <Table.Cell>
-                  <Star className="h-3 w-3 text-yellow" />
-                </Table.Cell>
-                <Table.Cell>
-                  <div className="flex items-center gap-2">
-                    <span className="text-[13px] font-semibold text-card-foreground">Aionima</span>
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow/15 text-yellow font-semibold">platform</span>
-                  </div>
-                </Table.Cell>
-                <Table.Cell>
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-500/15 text-indigo-400 font-medium">sacred</span>
-                </Table.Cell>
-                <Table.Cell>
-                  <span className="text-[11px] font-mono text-indigo-400 font-semibold" title={`${String(SACRED_PROJECTS.length)} Civicognita + ${String(PAX_SACRED_PROJECTS.length)} PAx`}>
-                    ⌗{SACRED_PROJECTS.length + PAX_SACRED_PROJECTS.length}
-                  </span>
-                </Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-                <Table.Cell><span className="text-[11px] text-muted-foreground/40">—</span></Table.Cell>
-              </Table.Row>
-              {visibleProjects.map((p) => {
+              {sortedProjects.map((p) => {
+                const health = deriveHealth(p);
                 const slug = projectSlug(p.path);
                 const cat = p.category ?? p.projectType?.category;
                 const isOps = cat === "ops" || cat === "administration";
@@ -463,15 +501,23 @@ export function Projects({
                   <Table.Row
                     key={p.path}
                     onClick={() => void navigate(`/projects/${slug}`)}
-                    className="cursor-pointer hover:bg-secondary/30"
+                    className={cn(
+                      "cursor-pointer hover:bg-secondary/30",
+                      health === "green" && "border-l-[3px] border-green",
+                      health === "amber" && "border-l-[3px] border-yellow",
+                      health === "rose" && "border-l-[3px] border-red",
+                    )}
                     tray={tray}
                     trayTriggerPosition="end"
                   >
                     <Table.Cell>
                       {projectActivity?.[p.path] ? (
-                        <span className="inline-block w-2 h-2 rounded-full bg-green animate-[pulse-green_2s_ease-in-out_infinite]" />
+                        <span className="inline-block w-2 h-2 rounded-full bg-green animate-[pulse-green_2s_ease-in-out_infinite]" title="Aion active" />
                       ) : (
-                        <span className="inline-block w-2 h-2 rounded-full bg-muted-foreground/20" />
+                        <span className={cn(
+                          "inline-block w-2 h-2 rounded-full",
+                          health === "green" ? "bg-green/30" : health === "rose" ? "bg-red/30" : "bg-muted-foreground/20",
+                        )} />
                       )}
                     </Table.Cell>
                     <Table.Cell>
@@ -662,40 +708,39 @@ export function Projects({
       {/* Project grid — original compact card layout, opt-in via viewMode toggle */}
       {viewMode === "grid" && (
       <div className="grid gap-4" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))" }}>
-        {/* Aionima — sacred card pinned at top of grid */}
+        {/* Aionima platform hero — spans full grid width */}
         <div
           onClick={() => { void navigate("/projects/_aionima"); }}
-          className={cn(
-            "rounded-xl border transition-colors duration-150 cursor-pointer hover:border-yellow",
-            "bg-indigo-50/70 border-indigo-200/80",
-            "dark:bg-indigo-950/40 dark:border-indigo-700/60",
-          )}
+          className="col-span-full rounded-xl border border-yellow/30 bg-gradient-to-r from-yellow/5 to-transparent p-4 flex items-center gap-4 cursor-pointer hover:border-yellow/50 transition-colors"
           data-testid="project-card-aionima"
         >
-          <div className="p-4">
-            <div className="flex items-center gap-2 mb-2">
-              <Star className="h-4 w-4 text-yellow" />
-              <span className="text-[15px] font-semibold text-card-foreground">Aionima</span>
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow/15 text-yellow font-semibold">platform</span>
-            </div>
-            <div className="text-[11px] text-muted-foreground">
-              Platform contribution portal — upstream alignment, PR submission, MINT impact ($WORK / $K / $RES).{" "}
-              {isContributing
-                ? <>Wraps the {sacredEntries.filter((e) => e.project !== null).length} core forks + {PAX_SACRED_PROJECTS.length} PAx primitives (`_aionima/repos/`).</>
-                : <>Enable contributing mode in Settings to clone the {SACRED_PROJECTS.length} core forks + {PAX_SACRED_PROJECTS.length} PAx primitives.</>}
-            </div>
-            <div className="text-[11px] text-yellow mt-2 font-medium">Open Aionima →</div>
+          <div className="shrink-0 w-10 h-10 rounded-lg bg-yellow/10 border border-yellow/30 flex items-center justify-center">
+            <Star className="h-5 w-5 text-yellow" />
           </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap mb-0.5">
+              <span className="text-[14px] font-bold text-foreground">Aionima</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow/15 text-yellow font-bold uppercase tracking-wide">Platform</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-500/15 text-indigo-400 font-semibold">⛨ sacred</span>
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface1 text-muted-foreground font-mono">⌗{SACRED_PROJECTS.length + PAX_SACRED_PROJECTS.length} repos</span>
+              <span className="flex items-center gap-1 text-[10px] text-green"><span className="inline-block w-1.5 h-1.5 rounded-full bg-green animate-[pulse-green_2s_ease-in-out_infinite]" />Aion lives here</span>
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              The gateway itself · cannot be deleted or archived · Aion edits under guardrails
+            </p>
+          </div>
+          <span className="shrink-0 text-[11px] text-yellow font-medium">Open platform →</span>
         </div>
-        {visibleProjects.map((p) => {
+        {sortedProjects.map((p) => {
           const slug = projectSlug(p.path);
+          const health = deriveHealth(p);
           return (
             <div
               key={p.path}
               onClick={() => void navigate(`/projects/${slug}`)}
               className={cn(
-                "rounded-xl bg-card border border-border transition-colors duration-150 cursor-pointer",
-                "hover:border-blue",
+                "rounded-xl bg-card border transition-colors duration-150 cursor-pointer hover:border-blue",
+                health === "green" ? "border-l-[3px] border-l-green border-border" : health === "rose" ? "border-l-[3px] border-l-red border-border" : "border-l-[3px] border-l-yellow border-border",
               )}
               data-testid="project-card"
             >

--- a/ui/dashboard/src/components/Projects.tsx
+++ b/ui/dashboard/src/components/Projects.tsx
@@ -736,11 +736,12 @@ export function Projects({
                   {p.hosting && (
                     <span className={cn(
                       "text-[10px] px-1.5 py-0.5 rounded font-semibold",
-                      p.hosting.status === "running" ? "bg-green/15 text-green" :
-                      p.hosting.status === "error" ? "bg-red/15 text-red" :
+                      p.hosting.status === "running" && (p.hosting.serving ?? false) ? "bg-green/15 text-green" :
+                      p.hosting.status === "running" ? "bg-yellow/15 text-yellow" :
+                      p.hosting.status === "error" || p.hosting.status === "stopped" ? "bg-red/15 text-red" :
                       "bg-muted-foreground/15 text-muted-foreground",
                     )}>
-                      {p.hosting.status}
+                      {p.hosting.status === "running" && !(p.hosting.serving ?? false) ? "starting" : p.hosting.status}
                     </span>
                   )}
                 </div>

--- a/ui/dashboard/src/components/StackStrip.tsx
+++ b/ui/dashboard/src/components/StackStrip.tsx
@@ -29,7 +29,7 @@ export function StackStrip({ projectPath, projectActivity }: StackStripProps) {
     >
       <Orb size={12} pulse={activity !== null && activity !== undefined} className="shrink-0" />
       <span className="truncate">
-        {summary ?? "Aion's iterative-work + plan reasoning reads from here ↑"}
+        {summary ?? "No active tasks"}
       </span>
     </div>
   );

--- a/ui/dashboard/src/components/UpgradeNextStepsPanel.tsx
+++ b/ui/dashboard/src/components/UpgradeNextStepsPanel.tsx
@@ -1,0 +1,206 @@
+/**
+ * UpgradeNextStepsPanel — post-upgrade modal showing what changed and
+ * any required/optional next steps stacked by the migration.
+ *
+ * Triggered by the system:upgraded WS event. Required steps must be
+ * acknowledged before the panel can be closed. Optional steps can be
+ * dismissed individually.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@particle-academy/react-fancy";
+import type { UpgradeNextStep } from "../types.js";
+import { fetchUpgradeNextSteps, completeUpgradeStep, dismissUpgradeStep, fetchChangelog } from "../api.js";
+
+export interface UpgradeNextStepsPanelProps {
+  open: boolean;
+  toVersion: string;
+  fromVersion: string | null;
+  onClose: () => void;
+}
+
+type ChangelogCommit = { hash: string; subject: string; body: string };
+
+export function UpgradeNextStepsPanel({ open, toVersion, fromVersion, onClose }: UpgradeNextStepsPanelProps) {
+  const navigate = useNavigate();
+  const [steps, setSteps] = useState<UpgradeNextStep[]>([]);
+  const [hasRequired, setHasRequired] = useState(false);
+  const [commits, setCommits] = useState<ChangelogCommit[]>([]);
+  const [working, setWorking] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    fetchUpgradeNextSteps("all")
+      .then(({ steps: s, hasRequired: r }) => { setSteps(s); setHasRequired(r); })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    refresh();
+    // Load recent commits for the changelog summary
+    fetchChangelog(8).then(({ commits: c }) => setCommits(c)).catch(() => {});
+  }, [open, refresh]);
+
+  const handleAction = useCallback(async (step: UpgradeNextStep) => {
+    if (step.action) {
+      if (step.action.kind === "navigate") {
+        void navigate(step.action.target);
+        onClose();
+        return;
+      }
+      if (step.action.kind === "external-url") {
+        window.open(step.action.target, "_blank", "noopener noreferrer");
+      }
+    }
+    setWorking(step.id);
+    const { ok, hasRequired: r } = await completeUpgradeStep(step.id).catch(() => ({ ok: false, hasRequired: hasRequired }));
+    if (ok) {
+      setSteps((prev) => prev.map((s) => s.id === step.id ? { ...s, status: "done" as const } : s));
+      setHasRequired(r);
+    }
+    setWorking(null);
+  }, [navigate, onClose, hasRequired]);
+
+  const handleDismiss = useCallback(async (id: string) => {
+    setWorking(id);
+    const { ok, hasRequired: r } = await dismissUpgradeStep(id).catch(() => ({ ok: false, hasRequired: hasRequired }));
+    if (ok) {
+      setSteps((prev) => prev.map((s) => s.id === id ? { ...s, status: "dismissed" as const } : s));
+      setHasRequired(r);
+    }
+    setWorking(null);
+  }, [hasRequired]);
+
+  const pendingSteps = steps.filter((s) => s.status === "pending");
+  const doneOrDismissed = steps.filter((s) => s.status !== "pending");
+  const canClose = !hasRequired;
+
+  if (!open) return null;
+
+  return (
+    <Modal open={open} onClose={canClose ? onClose : undefined} size="lg">
+      <div className="flex flex-col gap-4 p-1">
+        {/* Header */}
+        <div className="flex items-start justify-between">
+          <div>
+            <div className="flex items-center gap-2 mb-0.5">
+              <span className="text-[11px] px-1.5 py-0.5 rounded bg-green/15 text-green font-semibold">Updated</span>
+              {fromVersion && (
+                <span className="text-[11px] text-muted-foreground font-mono">{fromVersion} → <span className="text-foreground font-semibold">{toVersion}</span></span>
+              )}
+              {!fromVersion && (
+                <span className="text-[11px] text-foreground font-mono font-semibold">{toVersion}</span>
+              )}
+            </div>
+            <h2 className="text-[16px] font-bold text-foreground">Aionima upgraded</h2>
+          </div>
+          {canClose && (
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-[18px] leading-none">×</button>
+          )}
+        </div>
+
+        {/* Changelog */}
+        {commits.length > 0 && (
+          <div className="rounded-lg border border-border bg-surface1 p-3">
+            <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">What changed</div>
+            <div className="space-y-1">
+              {commits.slice(0, 6).map((c) => (
+                <div key={c.hash} className="flex items-start gap-2 text-[11px]">
+                  <span className="font-mono text-muted-foreground shrink-0">{c.hash.slice(0, 7)}</span>
+                  <span className="text-foreground leading-relaxed">{c.subject}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Pending next steps */}
+        {pendingSteps.length > 0 && (
+          <div>
+            <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+              Next steps
+              {pendingSteps.some((s) => s.required) && (
+                <span className="ml-1.5 text-red font-semibold">· some required</span>
+              )}
+            </div>
+            <div className="space-y-2">
+              {pendingSteps.map((step) => (
+                <div
+                  key={step.id}
+                  className={cn(
+                    "rounded-lg border p-3",
+                    step.required ? "border-red/30 bg-red/5" : "border-border bg-card",
+                  )}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5 mb-0.5">
+                        {step.required && (
+                          <span className="text-[9px] px-1.5 py-0.5 rounded bg-red/15 text-red font-bold uppercase tracking-wide">Required</span>
+                        )}
+                        {!step.required && (
+                          <span className="text-[9px] px-1.5 py-0.5 rounded bg-muted/30 text-muted-foreground font-semibold uppercase tracking-wide">Optional</span>
+                        )}
+                        <span className="text-[12px] font-semibold text-foreground">{step.title}</span>
+                      </div>
+                      <p className="text-[11px] text-muted-foreground leading-relaxed">{step.description}</p>
+                    </div>
+                    <div className="flex gap-1.5 shrink-0">
+                      {step.action && (
+                        <Button
+                          size="sm"
+                          variant={step.required ? "default" : "outline"}
+                          onClick={() => void handleAction(step)}
+                          disabled={working === step.id}
+                          className="text-[11px] h-7"
+                        >
+                          {working === step.id ? "…" : step.action.label}
+                        </Button>
+                      )}
+                      {!step.required && (
+                        <button
+                          onClick={() => void handleDismiss(step.id)}
+                          disabled={working === step.id}
+                          className="text-[10px] text-muted-foreground hover:text-foreground px-1.5 disabled:opacity-40"
+                        >
+                          Dismiss
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Completed / dismissed */}
+        {doneOrDismissed.length > 0 && pendingSteps.length === 0 && (
+          <div className="text-[11px] text-muted-foreground text-center py-2">
+            All steps complete.
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex items-center justify-between pt-1 border-t border-border">
+          <span className="text-[10px] text-muted-foreground">
+            {hasRequired
+              ? `${pendingSteps.filter((s) => s.required).length} required step${pendingSteps.filter((s) => s.required).length !== 1 ? "s" : ""} remaining`
+              : "Ready to close"}
+          </span>
+          <Button
+            size="sm"
+            onClick={onClose}
+            disabled={!canClose}
+            className="text-[12px]"
+          >
+            {canClose ? "Done" : "Complete required steps to continue"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/ui/dashboard/src/components/UpgradeNextStepsPanel.tsx
+++ b/ui/dashboard/src/components/UpgradeNextStepsPanel.tsx
@@ -74,8 +74,9 @@ export function UpgradeNextStepsPanel({ open, toVersion, fromVersion, onClose }:
     setWorking(null);
   }, [hasRequired]);
 
+  // Superseded steps are invisible — a later migration cancelled them before the user saw them
   const pendingSteps = steps.filter((s) => s.status === "pending");
-  const doneOrDismissed = steps.filter((s) => s.status !== "pending");
+  const doneOrDismissed = steps.filter((s) => s.status === "done" || s.status === "dismissed");
   const canClose = !hasRequired;
 
   if (!open) return null;

--- a/ui/dashboard/src/hooks.ts
+++ b/ui/dashboard/src/hooks.ts
@@ -515,7 +515,7 @@ export function useHosting() {
   const statusQuery = useQuery({
     queryKey: ["hosting", "status"],
     queryFn: fetchHostingStatus,
-    refetchInterval: 120_000, // WS events are primary; polling is fallback only
+    refetchInterval: 10_000, // WS events are primary; 10s poll catches missed events
   });
 
   const enableMutation = useMutation({

--- a/ui/dashboard/src/main.tsx
+++ b/ui/dashboard/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { registerAll as registerAllEChartTypes } from "@particle-academy/fancy-echarts";
 import "./index.css";
 import "@particle-academy/react-fancy/styles.css";
+import "@particle-academy/fancy-code/styles.css";
 import "@particle-academy/fancy-whiteboard/styles.css";
 import "@particle-academy/agent-integrations/styles.css";
 import { App } from "./App.js";

--- a/ui/dashboard/src/routes/logs.tsx
+++ b/ui/dashboard/src/routes/logs.tsx
@@ -3,21 +3,25 @@
  */
 
 import { Logs } from "@/components/Logs.js";
-import { PageScroll } from "@/components/PageScroll.js";
 import { useRootContext } from "./root.js";
 
 export default function LogsPage() {
   const { logStream } = useRootContext();
 
+  // Full-height layout — do NOT wrap in PageScroll. Logs manages its own
+  // internal scroll (entries list is flex-1 overflow-y-auto). PageScroll
+  // would create a double-scroll owner: the outer scroll moves the toolbar
+  // off-screen while the inner scroll is also present. Use flex-1 pattern
+  // (same as DocsPage / KnowledgePage) so main's flex-col constrains height.
   return (
-    <PageScroll>
-    <Logs
-      entries={logStream.entries}
-      connected={logStream.connected}
-      paused={logStream.paused}
-      onClear={logStream.clear}
-      onTogglePause={logStream.togglePause}
-    />
-    </PageScroll>
+    <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+      <Logs
+        entries={logStream.entries}
+        connected={logStream.connected}
+        paused={logStream.paused}
+        onClear={logStream.clear}
+        onTogglePause={logStream.togglePause}
+      />
+    </div>
   );
 }

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -824,8 +824,10 @@ export default function RootLayout() {
         }
       />
 
-      {/* Content area */}
-      <div className="flex-1 flex flex-col min-w-0">
+      {/* Content area — min-h-0 is required so flex-1 is constrained to
+          (100vh - header) rather than growing to content height, which would
+          prevent PageScroll's overflow-y-auto from ever triggering. */}
+      <div className="flex-1 flex flex-col min-w-0 min-h-0">
 
         {/* DNS setup notice */}
         {hostingHook.status?.dnsmasq?.running && (

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -14,7 +14,6 @@ import { cn, safeArray } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { HearthTop } from "@/components/HearthTop.js";
-import { useFocusedRoute } from "@/hooks/useFocusedRoute.js";
 import { ChatFlyout } from "@/components/ChatFlyout.js";
 import { MagicAppModal } from "@/components/MagicAppModal.js";
 import { MagicAppTray } from "@/components/MagicAppTray.js";
@@ -90,7 +89,6 @@ export default function RootLayout() {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const isFocused = useFocusedRoute();
 
 
   // FIRSTBOOT check — redirect to onboarding if not completed
@@ -109,7 +107,7 @@ export default function RootLayout() {
   const isMobile = useIsMobile();
   const [timelineBucket, setTimelineBucket] = useState<TimeBucket>("day");
   const [liveActivity, setLiveActivity] = useState<ActivityEntry[]>([]);
-  const [chatOpen, setChatOpen] = useState(false);
+  const [chatOpen, setChatOpen] = useState(true);
   const [editorFilePath, setEditorFilePath] = useState<string | null>(null);
   const [workspaceMode, setWorkspaceMode] = useState(false);
   const [projectActivity, setProjectActivity] = useState<Record<string, ProjectActivity | null>>({});
@@ -280,18 +278,18 @@ export default function RootLayout() {
     setChatOpen(true);
   }, []);
 
-  // Auto-open chat with project context when entering focused mode on a project page.
-  // Without this, the docked ChatFlyout renders with no context until the user
-  // explicitly clicks "Open chat". The effect resets when leaving the page.
+  // Context-aware chat: set project context when navigating into a project,
+  // clear to workspace chat when navigating away. Chat stays open (chatOpen=true)
+  // at all times — it's the primary UX surface.
   useEffect(() => {
-    if (!isFocused) return;
     const m = location.pathname.match(/^\/projects\/([^/]+)/);
     if (m) {
       const slug = decodeURIComponent(m[1]);
       setChatContext(slug);
-      setChatOpen(true);
+    } else {
+      setChatContext(null);
     }
-  }, [isFocused, location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOpenChatWithMessage = useCallback((context: string, message: string) => {
     setChatContext(context);
@@ -851,17 +849,14 @@ export default function RootLayout() {
               docked
             />
           </div>
-        ) : isFocused ? (
-          // Focused canvas mode (s198): 38/62 split — chat pane left, canvas right.
-          // HearthChatPane stub replaced with real docked ChatFlyout (same as
-          // workspace mode). Context is auto-set from the project path on mount.
-          <div
-            className="flex-1 min-h-0 overflow-hidden flex"
-            data-testid="hearth-focused-layout"
-          >
+        ) : (
+          // Hearth layout — chat always docked on the left, content on the right.
+          // Chat is the primary UX surface: always visible, context-aware.
+          // On /projects/:path → project chat. Everywhere else → workspace chat.
+          <div className="flex-1 min-h-0 overflow-hidden flex" data-testid="hearth-layout">
             <ChatFlyout
               open={chatOpen}
-              onClose={() => { setChatOpen(false); setChatContext(null); setChatInitialMessage(null); setChatRequestId(null); }}
+              onClose={() => { setChatOpen(false); setChatInitialMessage(null); setChatRequestId(null); }}
               theme={theme}
               projects={projectsHook.projects}
               openWithContext={chatContext}
@@ -872,43 +867,17 @@ export default function RootLayout() {
             />
             <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
               <RouteDevNotes />
+              {editorFilePath && (
+                <EditorFlyout
+                  filePath={editorFilePath}
+                  onClose={handleCloseEditor}
+                  theme={theme}
+                  position="left"
+                />
+              )}
               <Outlet context={ctx} />
             </main>
           </div>
-        ) : (
-          // Normal mode: content area with flyout overlays
-          <>
-            <main className="max-w-[1200px] w-full mx-auto flex-1 min-h-0 flex flex-col overflow-hidden">
-              {/* Route-default DevNote — registers a per-route default note
-                  to the global modal. Page components can embed inline
-                  <DevNote> instances for additional context; both stack into
-                  the same modal accessible from the header icon. */}
-              <RouteDevNotes />
-              <Outlet context={ctx} />
-            </main>
-
-            {/* Editor flyout (left side, overlay) */}
-            {editorFilePath && (
-              <EditorFlyout
-                filePath={editorFilePath}
-                onClose={handleCloseEditor}
-                theme={theme}
-                position="left"
-              />
-            )}
-
-            {/* Chat flyout (right side, overlay) */}
-            <ChatFlyout
-              open={chatOpen}
-              onClose={() => { setChatOpen(false); setChatContext(null); setChatInitialMessage(null); setChatRequestId(null); }}
-              theme={theme}
-              projects={projectsHook.projects}
-              openWithContext={chatContext}
-              openWithMessage={chatInitialMessage}
-              openRequestId={chatRequestId}
-              notifications={notifications}
-            />
-          </>
         )}
       </div>
 

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -47,10 +47,14 @@ export type View = "overview" | "entity" | "coa" | "settings" | "logs" | "projec
 // Shell panel layout
 // ---------------------------------------------------------------------------
 
-type ShellPanelId = "canvas" | "chat" | "workspace";
-const SHELL_PANELS: ShellPanelId[] = ["canvas", "chat", "workspace"];
+// Shell panel semantics:
+//   workspace = current AGI page (projects, settings, whatever the user is doing)
+//   chat      = conversation with Aion
+//   canvas    = Agent Canvas — where the agent works (plans, artifacts, iteration output)
+type ShellPanelId = "workspace" | "chat" | "canvas";
+const SHELL_PANELS: ShellPanelId[] = ["workspace", "chat", "canvas"];
 const SHELL_ORDER_KEY = "aionima-shell-panel-order";
-const DEFAULT_SHELL_ORDER: ShellPanelId[] = ["canvas", "chat", "workspace"];
+const DEFAULT_SHELL_ORDER: ShellPanelId[] = ["workspace", "chat", "canvas"];
 
 function ShellRailTrigger({ label, state }: { label: string; state: SectionRenderState }) {
   const { open, toggle } = state;
@@ -156,7 +160,11 @@ export default function RootLayout() {
     } catch { /* ignore */ }
     return DEFAULT_SHELL_ORDER;
   });
-  const [shellOpen, setShellOpen] = useState<ShellPanelId[]>(["canvas", "chat"]);
+  // workspace + chat open by default; canvas starts collapsed (expands when agent produces something)
+  const [shellOpen, setShellOpen] = useState<ShellPanelId[]>(["workspace", "chat"]);
+  // Canvas section mount point — ChatFlyout portals AgentCanvas here
+  const [canvasMountEl, setCanvasMountEl] = useState<Element | null>(null);
+  const canvasMountRef = useCallback((el: Element | null) => { setCanvasMountEl(el); }, []);
   const [chatContext, setChatContext] = useState<string | null>(null);
   const [chatInitialMessage, setChatInitialMessage] = useState<string | null>(null);
   const [chatRequestId, setChatRequestId] = useState<string | null>(null);
@@ -359,14 +367,6 @@ export default function RootLayout() {
     setEditorFilePath(null);
   }, []);
 
-  // Open/close workspace shell panel as editor file changes
-  useEffect(() => {
-    setShellOpen((prev) => {
-      if (editorFilePath && !prev.includes("workspace")) return [...prev, "workspace"];
-      if (!editorFilePath && prev.includes("workspace")) return prev.filter((id) => id !== "workspace");
-      return prev;
-    });
-  }, [editorFilePath]);
 
   const handleToolExecute = useCallback(async (projectPath: string, toolId: string) => {
     return executeProjectTool(projectPath, toolId);
@@ -851,10 +851,14 @@ export default function RootLayout() {
           </div>
         )}
 
-        {/* 3-panel shell: Canvas | Chat | Workspace.
-            User-configurable order stored in localStorage under SHELL_ORDER_KEY.
-            Canvas = route content; Chat = always-on conversation; Workspace = editor.
-            Workspace panel auto-opens when a file is being edited. */}
+        {/* 3-panel shell: Workspace | Chat | Canvas.
+            Workspace = current AGI page (projects, settings, whatever the user is doing).
+            Chat      = conversation with Aion.
+            Canvas    = Agent Canvas — where the agent works (plans, artifacts).
+            AgentCanvas renders inside the Canvas section via a React portal from
+            ChatFlyout so its state/WS events stay local to ChatFlyout's tree.
+            Panel order is user-configurable (localStorage SHELL_ORDER_KEY).
+            Canvas starts collapsed; workspace + chat open by default. */}
         <div className="flex-1 min-h-0 overflow-hidden flex flex-row" data-testid="hearth-layout">
           <AccordionPanel
             orientation={isMobile ? "vertical" : "horizontal"}
@@ -863,10 +867,6 @@ export default function RootLayout() {
               const typed = (next as string[]).filter(
                 (id): id is ShellPanelId => SHELL_PANELS.includes(id as ShellPanelId),
               );
-              // Closing the workspace rail = close the editor file
-              if (shellOpen.includes("workspace") && !typed.includes("workspace")) {
-                handleCloseEditor();
-              }
               setShellOpen(typed);
             }}
             className={cn("flex flex-1 w-full min-h-0", isMobile ? "flex-col" : "flex-row")}
@@ -878,17 +878,25 @@ export default function RootLayout() {
                 isOpen ? "flex-1" : "w-8",
               );
 
-              if (panelId === "canvas") {
+              if (panelId === "workspace") {
                 return (
-                  <AccordionPanel.Section key="canvas" id="canvas" unstyled className={sectionClass}>
+                  <AccordionPanel.Section key="workspace" id="workspace" unstyled className={sectionClass}>
                     <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
                       <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
                         <RouteDevNotes />
+                        {editorFilePath && (
+                          <EditorFlyout
+                            filePath={editorFilePath}
+                            onClose={handleCloseEditor}
+                            theme={theme}
+                            position="left"
+                          />
+                        )}
                         <Outlet context={ctx} />
                       </main>
                     </AccordionPanel.Content>
                     <AccordionPanel.Trigger>
-                      {(state) => <ShellRailTrigger label="Canvas" state={state} />}
+                      {(state) => <ShellRailTrigger label="Workspace" state={state} />}
                     </AccordionPanel.Trigger>
                   </AccordionPanel.Section>
                 );
@@ -909,6 +917,7 @@ export default function RootLayout() {
                         notifications={notifications}
                         docked
                         inShell
+                        canvasPortalTarget={canvasMountEl}
                       />
                     </AccordionPanel.Content>
                     <AccordionPanel.Trigger>
@@ -918,19 +927,15 @@ export default function RootLayout() {
                 );
               }
 
-              if (panelId === "workspace") {
+              if (panelId === "canvas") {
                 return (
-                  <AccordionPanel.Section key="workspace" id="workspace" unstyled className={sectionClass}>
+                  <AccordionPanel.Section key="canvas" id="canvas" unstyled className={sectionClass}>
                     <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0">
-                      <EditorFlyout
-                        filePath={editorFilePath}
-                        onClose={handleCloseEditor}
-                        theme={theme}
-                        panel
-                      />
+                      {/* AgentCanvas is portalled here by ChatFlyout when canvasMountEl is set */}
+                      <div ref={canvasMountRef} className="h-full w-full" />
                     </AccordionPanel.Content>
                     <AccordionPanel.Trigger>
-                      {(state) => <ShellRailTrigger label="Workspace" state={state} />}
+                      {(state) => <ShellRailTrigger label="Canvas" state={state} />}
                     </AccordionPanel.Trigger>
                   </AccordionPanel.Section>
                 );

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -56,28 +56,88 @@ const SHELL_PANELS: ShellPanelId[] = ["workspace", "chat", "canvas"];
 const SHELL_ORDER_KEY = "aionima-shell-panel-order";
 const DEFAULT_SHELL_ORDER: ShellPanelId[] = ["workspace", "chat", "canvas"];
 
-function ShellRailTrigger({ label, state }: { label: string; state: SectionRenderState }) {
+interface ShellPanelHeaderProps {
+  label: string;
+  state: SectionRenderState;
+  dragging: boolean;
+  dragOver: boolean;
+  onDragStart: () => void;
+  onDragOver: () => void;
+  onDragLeave: () => void;
+  onDrop: () => void;
+  onDragEnd: () => void;
+}
+
+function ShellPanelHeader({ label, state, dragging, dragOver, onDragStart, onDragOver, onDragLeave, onDrop, onDragEnd }: ShellPanelHeaderProps) {
   const { open, toggle } = state;
+
+  // Collapsed state: full-height narrow strip with rotated label (also draggable)
+  if (!open) {
+    return (
+      <button
+        type="button"
+        draggable
+        onClick={toggle}
+        onDragStart={(e) => { e.dataTransfer.effectAllowed = "move"; onDragStart(); }}
+        onDragEnd={onDragEnd}
+        aria-label={`Expand ${label}`}
+        aria-expanded={false}
+        className={cn(
+          "w-10 h-full flex items-center justify-center select-none",
+          "bg-surface0/40 hover:bg-secondary/30 transition-colors",
+          "cursor-grab active:cursor-grabbing",
+          dragging && "opacity-50",
+        )}
+        data-testid={`shell-panel-header-${label.toLowerCase()}`}
+      >
+        <span className="text-[10px] tracking-[0.2em] uppercase font-semibold text-muted-foreground/50 [writing-mode:vertical-rl] [transform:rotate(180deg)]">
+          {label}
+        </span>
+      </button>
+    );
+  }
+
+  // Open state: horizontal header bar with grip + label + collapse button
   return (
-    <button
-      type="button"
-      onClick={toggle}
-      aria-label={open ? `Collapse ${label}` : `Expand ${label}`}
-      aria-expanded={open}
+    <div
+      draggable
+      onDragStart={(e) => { e.dataTransfer.effectAllowed = "move"; onDragStart(); }}
+      onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; onDragOver(); }}
+      onDragLeave={onDragLeave}
+      onDrop={(e) => { e.preventDefault(); onDrop(); }}
+      onDragEnd={onDragEnd}
       className={cn(
-        "h-full flex items-center justify-center cursor-pointer select-none",
-        "transition-colors border-x border-border/50",
-        open ? "w-3 bg-background hover:bg-secondary/50" : "w-8 bg-secondary/30 hover:bg-secondary/60",
+        "flex items-center gap-2 px-3 h-9 shrink-0 select-none",
+        "border-b border-border bg-surface0/40 transition-colors",
+        "cursor-grab active:cursor-grabbing",
+        dragOver && "bg-primary/15 border-primary/40",
+        dragging && "opacity-50",
       )}
-      data-testid={`shell-rail-${label.toLowerCase()}`}
+      data-testid={`shell-panel-header-${label.toLowerCase()}`}
     >
-      <span className={cn(
-        "text-[10px] tracking-[0.2em] uppercase font-semibold text-muted-foreground/60",
-        "[writing-mode:vertical-rl] [transform:rotate(180deg)]",
-      )}>
+      {/* 4-dot grip */}
+      <svg className="w-3 h-3 shrink-0 text-muted-foreground/35 pointer-events-none" viewBox="0 0 8 8" fill="currentColor">
+        <circle cx="2" cy="2" r="1" />
+        <circle cx="6" cy="2" r="1" />
+        <circle cx="2" cy="6" r="1" />
+        <circle cx="6" cy="6" r="1" />
+      </svg>
+      <span className="flex-1 text-[10px] uppercase tracking-widest font-semibold text-muted-foreground/70 pointer-events-none">
         {label}
       </span>
-    </button>
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); toggle(); }}
+        aria-label={`Collapse ${label}`}
+        aria-expanded={true}
+        className="p-1 rounded text-muted-foreground/40 hover:text-muted-foreground hover:bg-secondary/30 transition-colors cursor-pointer"
+        data-testid={`shell-panel-toggle-${label.toLowerCase()}`}
+      >
+        <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="18 15 12 9 6 15" />
+        </svg>
+      </button>
+    </div>
   );
 }
 
@@ -148,7 +208,7 @@ export default function RootLayout() {
   const [projectActivity, setProjectActivity] = useState<Record<string, ProjectActivity | null>>({});
 
   // Shell panel layout state
-  const [panelOrder] = useState<ShellPanelId[]>(() => {
+  const [panelOrder, setPanelOrder] = useState<ShellPanelId[]>(() => {
     try {
       const stored = localStorage.getItem(SHELL_ORDER_KEY);
       if (stored) {
@@ -165,6 +225,25 @@ export default function RootLayout() {
   // Canvas section mount point — ChatFlyout portals AgentCanvas here
   const [canvasMountEl, setCanvasMountEl] = useState<Element | null>(null);
   const canvasMountRef = useCallback((el: Element | null) => { setCanvasMountEl(el); }, []);
+  // Panel drag-to-reorder state
+  const [draggingPanel, setDraggingPanel] = useState<ShellPanelId | null>(null);
+  const [dragOverPanel, setDragOverPanel] = useState<ShellPanelId | null>(null);
+
+  const handlePanelDrop = useCallback((targetId: ShellPanelId) => {
+    setDragOverPanel(null);
+    setDraggingPanel(null);
+    if (!draggingPanel || draggingPanel === targetId) return;
+    setPanelOrder((prev) => {
+      const result = [...prev];
+      const fromIdx = result.indexOf(draggingPanel);
+      const toIdx = result.indexOf(targetId);
+      if (fromIdx === -1 || toIdx === -1) return prev;
+      result.splice(fromIdx, 1);
+      result.splice(toIdx, 0, draggingPanel);
+      try { localStorage.setItem(SHELL_ORDER_KEY, JSON.stringify(result)); } catch { /* ignore */ }
+      return result;
+    });
+  }, [draggingPanel]);
   const [chatContext, setChatContext] = useState<string | null>(null);
   const [chatInitialMessage, setChatInitialMessage] = useState<string | null>(null);
   const [chatRequestId, setChatRequestId] = useState<string | null>(null);
@@ -873,14 +952,28 @@ export default function RootLayout() {
           >
             {panelOrder.map((panelId) => {
               const isOpen = shellOpen.includes(panelId);
+              // Open: flex-col (header on top, content below); closed: narrow strip
               const sectionClass = cn(
-                "min-w-0 min-h-0 flex flex-row",
-                isOpen ? "flex-1" : "w-8",
+                "min-h-0 flex flex-col",
+                isOpen ? "flex-1 min-w-0" : "w-10 shrink-0",
               );
+              const label = panelId === "workspace" ? "Workspace" : panelId === "chat" ? "Chat" : "Canvas";
+              const headerProps = {
+                dragging: draggingPanel === panelId,
+                dragOver: dragOverPanel === panelId,
+                onDragStart: () => setDraggingPanel(panelId),
+                onDragOver: () => setDragOverPanel(panelId),
+                onDragLeave: () => setDragOverPanel(null),
+                onDrop: () => handlePanelDrop(panelId),
+                onDragEnd: () => { setDraggingPanel(null); setDragOverPanel(null); },
+              };
 
               if (panelId === "workspace") {
                 return (
                   <AccordionPanel.Section key="workspace" id="workspace" unstyled className={sectionClass}>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellPanelHeader label={label} state={state} {...headerProps} />}
+                    </AccordionPanel.Trigger>
                     <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
                       <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
                         <RouteDevNotes />
@@ -895,9 +988,6 @@ export default function RootLayout() {
                         <Outlet context={ctx} />
                       </main>
                     </AccordionPanel.Content>
-                    <AccordionPanel.Trigger>
-                      {(state) => <ShellRailTrigger label="Workspace" state={state} />}
-                    </AccordionPanel.Trigger>
                   </AccordionPanel.Section>
                 );
               }
@@ -905,6 +995,9 @@ export default function RootLayout() {
               if (panelId === "chat") {
                 return (
                   <AccordionPanel.Section key="chat" id="chat" unstyled className={sectionClass}>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellPanelHeader label={label} state={state} {...headerProps} />}
+                    </AccordionPanel.Trigger>
                     <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0">
                       <ChatFlyout
                         open
@@ -920,9 +1013,6 @@ export default function RootLayout() {
                         canvasPortalTarget={canvasMountEl}
                       />
                     </AccordionPanel.Content>
-                    <AccordionPanel.Trigger>
-                      {(state) => <ShellRailTrigger label="Chat" state={state} />}
-                    </AccordionPanel.Trigger>
                   </AccordionPanel.Section>
                 );
               }
@@ -930,13 +1020,13 @@ export default function RootLayout() {
               if (panelId === "canvas") {
                 return (
                   <AccordionPanel.Section key="canvas" id="canvas" unstyled className={sectionClass}>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellPanelHeader label={label} state={state} {...headerProps} />}
+                    </AccordionPanel.Trigger>
                     <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0">
-                      {/* AgentCanvas is portalled here by ChatFlyout when canvasMountEl is set */}
+                      {/* AgentCanvas portalled here from ChatFlyout's React tree */}
                       <div ref={canvasMountRef} className="h-full w-full" />
                     </AccordionPanel.Content>
-                    <AccordionPanel.Trigger>
-                      {(state) => <ShellRailTrigger label="Canvas" state={state} />}
-                    </AccordionPanel.Trigger>
                   </AccordionPanel.Section>
                 );
               }

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -14,7 +14,6 @@ import { cn, safeArray } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { HearthTop } from "@/components/HearthTop.js";
-import { HearthChatPane } from "@/components/HearthChatPane.js";
 import { useFocusedRoute } from "@/hooks/useFocusedRoute.js";
 import { ChatFlyout } from "@/components/ChatFlyout.js";
 import { MagicAppModal } from "@/components/MagicAppModal.js";
@@ -93,24 +92,6 @@ export default function RootLayout() {
   const navigate = useNavigate();
   const isFocused = useFocusedRoute();
 
-  // Derive context title/sub for HearthChatPane from the current route
-  const focusedContext = (() => {
-    const projectMatch = location.pathname.match(/^\/projects\/([^/]+)/);
-    if (projectMatch) {
-      const slug = decodeURIComponent(projectMatch[1]);
-      const project = projectsHook.projects.find((p) => p.path === slug);
-      return { title: project?.name ?? slug, sub: project?.category ?? "Project" };
-    }
-    const commsMatch = location.pathname.match(/^\/comms\/([^/]+)/);
-    if (commsMatch) {
-      const channel = commsMatch[1];
-      return { title: channel.charAt(0).toUpperCase() + channel.slice(1), sub: "Channel" };
-    }
-    if (location.pathname.startsWith("/comms")) {
-      return { title: "Messages", sub: "All channels" };
-    }
-    return { title: "", sub: "" };
-  })();
 
   // FIRSTBOOT check — redirect to onboarding if not completed
   useEffect(() => {
@@ -298,6 +279,19 @@ export default function RootLayout() {
     setChatContext(context);
     setChatOpen(true);
   }, []);
+
+  // Auto-open chat with project context when entering focused mode on a project page.
+  // Without this, the docked ChatFlyout renders with no context until the user
+  // explicitly clicks "Open chat". The effect resets when leaving the page.
+  useEffect(() => {
+    if (!isFocused) return;
+    const m = location.pathname.match(/^\/projects\/([^/]+)/);
+    if (m) {
+      const slug = decodeURIComponent(m[1]);
+      setChatContext(slug);
+      setChatOpen(true);
+    }
+  }, [isFocused, location.pathname]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOpenChatWithMessage = useCallback((context: string, message: string) => {
     setChatContext(context);
@@ -858,16 +852,23 @@ export default function RootLayout() {
             />
           </div>
         ) : isFocused ? (
-          // Focused canvas mode (s198): 38/62 split — chat pane left, canvas right
+          // Focused canvas mode (s198): 38/62 split — chat pane left, canvas right.
+          // HearthChatPane stub replaced with real docked ChatFlyout (same as
+          // workspace mode). Context is auto-set from the project path on mount.
           <div
-            className="flex-1 min-h-0 overflow-hidden grid"
-            style={{ gridTemplateColumns: "38fr 62fr" }}
+            className="flex-1 min-h-0 overflow-hidden flex"
             data-testid="hearth-focused-layout"
           >
-            <HearthChatPane
-              contextTitle={focusedContext.title}
-              contextSub={focusedContext.sub}
-              onSendMessage={(msg) => handleOpenChatWithMessage(focusedContext.title, msg)}
+            <ChatFlyout
+              open={chatOpen}
+              onClose={() => { setChatOpen(false); setChatContext(null); setChatInitialMessage(null); setChatRequestId(null); }}
+              theme={theme}
+              projects={projectsHook.projects}
+              openWithContext={chatContext}
+              openWithMessage={chatInitialMessage}
+              openRequestId={chatRequestId}
+              notifications={notifications}
+              docked
             />
             <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
               <RouteDevNotes />

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -9,6 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { EditorFlyout } from "@/components/EditorFlyout.js";
 import { TerminalFlyout } from "@/components/TerminalFlyout.js";
 import { WhoDBFlyout } from "@/components/WhoDBFlyout.js";
+import { UpgradeNextStepsPanel } from "@/components/UpgradeNextStepsPanel.js";
 
 import { cn, safeArray } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -118,6 +119,8 @@ export default function RootLayout() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [updateCheck, setUpdateCheck] = useState<UpdateCheck | null>(null);
+  const [upgradedEvent, setUpgradedEvent] = useState<import("../types.js").SystemUpgradedEvent | null>(null);
+  const [showUpgradePanel, setShowUpgradePanel] = useState(false);
   const [providerBalances, setProviderBalances] = useState<ProviderBalance[]>([]);
   const [balanceHistories, setBalanceHistories] = useState<Record<string, number[]>>({});
   const [upgradePhase, setUpgradePhase] = useState<string | null>(null);
@@ -412,6 +415,10 @@ export default function RootLayout() {
     }
     if (event.type === "system:update_available") {
       setUpdateCheck(event.data);
+    }
+    if (event.type === "system:upgraded") {
+      setUpgradedEvent(event.data);
+      setShowUpgradePanel(true);
     }
     if (event.type === "notification:new") {
       setNotifications((prev) => {
@@ -890,6 +897,15 @@ export default function RootLayout() {
       />
 
       <WhoDBFlyout open={whodbOpen} onClose={() => setWhodbOpen(false)} />
+
+      {upgradedEvent && (
+        <UpgradeNextStepsPanel
+          open={showUpgradePanel}
+          toVersion={upgradedEvent.toVersion}
+          fromVersion={upgradedEvent.fromVersion}
+          onClose={() => setShowUpgradePanel(false)}
+        />
+      )}
 
       {/* MagicApp floating/docked modals */}
       {magicAppInstances

--- a/ui/dashboard/src/routes/root.tsx
+++ b/ui/dashboard/src/routes/root.tsx
@@ -34,7 +34,7 @@ import { ProfileCard } from "@/components/ProfileCard.js";
 import { ProfileManager } from "@/components/ProfileManager.js";
 import { useConfig, useDashboardWS, useHosting, useIsMobile, useLogStream, useOverview, useProjectConfigWS, useProjects } from "@/hooks.js";
 import { useTheme } from "@/lib/theme-provider";
-import { Chart, Icon } from "@particle-academy/react-fancy";
+import { Chart, Icon, AccordionPanel, type SectionRenderState } from "@particle-academy/react-fancy";
 import { checkForUpdates, startUpgrade, fetchUpgradeLog, fetchNotifications, markNotificationsRead, markAllNotificationsRead, executeProjectTool, fetchOnboardingState, fetchAuthStatus, fetchCurrentUser, fetchProviderBalances, fetchBalanceHistory } from "@/api.js";
 import type { ProviderBalance } from "@/api.js";
 import { LoginPage } from "@/components/LoginPage.js";
@@ -42,6 +42,40 @@ import type { ActivityEntry, DashboardEvent, Notification, ProjectActivity, Time
 import { resolveHelpContext } from "@/lib/help-context.js";
 
 export type View = "overview" | "entity" | "coa" | "settings" | "logs" | "projects" | "system";
+
+// ---------------------------------------------------------------------------
+// Shell panel layout
+// ---------------------------------------------------------------------------
+
+type ShellPanelId = "canvas" | "chat" | "workspace";
+const SHELL_PANELS: ShellPanelId[] = ["canvas", "chat", "workspace"];
+const SHELL_ORDER_KEY = "aionima-shell-panel-order";
+const DEFAULT_SHELL_ORDER: ShellPanelId[] = ["canvas", "chat", "workspace"];
+
+function ShellRailTrigger({ label, state }: { label: string; state: SectionRenderState }) {
+  const { open, toggle } = state;
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={open ? `Collapse ${label}` : `Expand ${label}`}
+      aria-expanded={open}
+      className={cn(
+        "h-full flex items-center justify-center cursor-pointer select-none",
+        "transition-colors border-x border-border/50",
+        open ? "w-3 bg-background hover:bg-secondary/50" : "w-8 bg-secondary/30 hover:bg-secondary/60",
+      )}
+      data-testid={`shell-rail-${label.toLowerCase()}`}
+    >
+      <span className={cn(
+        "text-[10px] tracking-[0.2em] uppercase font-semibold text-muted-foreground/60",
+        "[writing-mode:vertical-rl] [transform:rotate(180deg)]",
+      )}>
+        {label}
+      </span>
+    </button>
+  );
+}
 
 /** Context shared with child routes via useOutletContext(). */
 export interface RootContext {
@@ -58,10 +92,8 @@ export interface RootContext {
   onOpenChat: (context: string) => void;
   onOpenChatWithMessage: (context: string, message: string) => void;
   editorFilePath: string | null;
-  workspaceMode: boolean;
   onOpenEditor: (path: string) => void;
   onCloseEditor: () => void;
-  onToggleWorkspace: () => void;
   onToolExecute: (projectPath: string, toolId: string) => Promise<{ ok: boolean; output?: string; error?: string }>;
   onOpenTerminal: (projectPath: string) => void;
   onRefreshMagicApps?: () => void;
@@ -108,10 +140,23 @@ export default function RootLayout() {
   const isMobile = useIsMobile();
   const [timelineBucket, setTimelineBucket] = useState<TimeBucket>("day");
   const [liveActivity, setLiveActivity] = useState<ActivityEntry[]>([]);
-  const [chatOpen, setChatOpen] = useState(true);
   const [editorFilePath, setEditorFilePath] = useState<string | null>(null);
-  const [workspaceMode, setWorkspaceMode] = useState(false);
   const [projectActivity, setProjectActivity] = useState<Record<string, ProjectActivity | null>>({});
+
+  // Shell panel layout state
+  const [panelOrder] = useState<ShellPanelId[]>(() => {
+    try {
+      const stored = localStorage.getItem(SHELL_ORDER_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as unknown[];
+        if (Array.isArray(parsed) && parsed.length === 3 && parsed.every((x) => SHELL_PANELS.includes(x as ShellPanelId))) {
+          return parsed as ShellPanelId[];
+        }
+      }
+    } catch { /* ignore */ }
+    return DEFAULT_SHELL_ORDER;
+  });
+  const [shellOpen, setShellOpen] = useState<ShellPanelId[]>(["canvas", "chat"]);
   const [chatContext, setChatContext] = useState<string | null>(null);
   const [chatInitialMessage, setChatInitialMessage] = useState<string | null>(null);
   const [chatRequestId, setChatRequestId] = useState<string | null>(null);
@@ -278,7 +323,7 @@ export default function RootLayout() {
 
   const handleOpenChat = useCallback((context: string) => {
     setChatContext(context);
-    setChatOpen(true);
+    // Chat is always visible in the shell — just update context
   }, []);
 
   // Context-aware chat: set project context when navigating into a project,
@@ -298,7 +343,6 @@ export default function RootLayout() {
     setChatContext(context);
     setChatInitialMessage(message);
     setChatRequestId(crypto.randomUUID());
-    setChatOpen(true);
   }, []);
 
   // s124 cycle 86 rework — handleOpenChatForIterativeWork removed. The
@@ -313,13 +357,16 @@ export default function RootLayout() {
 
   const handleCloseEditor = useCallback(() => {
     setEditorFilePath(null);
-    setWorkspaceMode(false);
   }, []);
 
-  const handleToggleWorkspace = useCallback(() => {
-    setWorkspaceMode((p) => !p);
-    setChatOpen(true);
-  }, []);
+  // Open/close workspace shell panel as editor file changes
+  useEffect(() => {
+    setShellOpen((prev) => {
+      if (editorFilePath && !prev.includes("workspace")) return [...prev, "workspace"];
+      if (!editorFilePath && prev.includes("workspace")) return prev.filter((id) => id !== "workspace");
+      return prev;
+    });
+  }, [editorFilePath]);
 
   const handleToolExecute = useCallback(async (projectPath: string, toolId: string) => {
     return executeProjectTool(projectPath, toolId);
@@ -539,10 +586,8 @@ export default function RootLayout() {
     onOpenChat: handleOpenChat,
     onOpenChatWithMessage: handleOpenChatWithMessage,
     editorFilePath,
-    workspaceMode,
     onOpenEditor: handleOpenEditor,
     onCloseEditor: handleCloseEditor,
-    onToggleWorkspace: handleToggleWorkspace,
     onToolExecute: handleToolExecute,
     onOpenTerminal: handleOpenTerminal,
     onRefreshMagicApps: () => { void instanceMgr.refresh(); },
@@ -731,12 +776,7 @@ export default function RootLayout() {
                 as the agent can read it. */}
             <button
               onClick={() => {
-                // s137 t530 — resolve route → human-readable help context
-                // string instead of the raw pathname. The help agent gets
-                // a stable description (e.g. "providers + models
-                // management") regardless of dynamic segments in the URL.
                 setChatContext(`help:${resolveHelpContext(location.pathname)}`);
-                setChatOpen(true);
               }}
               className="p-2 rounded-lg transition-colors text-subtext0 hover:bg-surface0 hover:text-text"
               title="Get help with this page"
@@ -751,23 +791,6 @@ export default function RootLayout() {
                 </svg>
               </Icon>
             </button>
-            <button
-              onClick={() => setChatOpen((p) => !p)}
-              className={cn(
-                "p-2 rounded-lg transition-colors",
-                chatOpen
-                  ? "bg-primary text-primary-foreground"
-                  : "text-subtext0 hover:bg-surface0 hover:text-text",
-              )}
-              title="Chat"
-              data-testid="header-chat-button"
-            >
-              <Icon size="md">
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                </svg>
-              </Icon>
-            </button>
             {!isMobile && <ActivityDot active={systemActive} />}
             <NotificationBell
               notifications={notifications}
@@ -775,11 +798,6 @@ export default function RootLayout() {
               onMarkRead={handleMarkRead}
               onMarkAllRead={handleMarkAllRead}
             />
-            {!isMobile && editorFilePath && (
-              <Button variant="outline" size="sm" onClick={handleToggleWorkspace}>
-                {workspaceMode ? "Exit Workspace" : "Edit | Chat"}
-              </Button>
-            )}
             {!isMobile && (
               <Button variant="outline" size="sm" onClick={toggle}>
                 {theme === "dark" ? "Light" : "Dark"}
@@ -823,9 +841,7 @@ export default function RootLayout() {
         }
       />
 
-      {/* Content area — min-h-0 is required so flex-1 is constrained to
-          (100vh - header) rather than growing to content height, which would
-          prevent PageScroll's overflow-y-auto from ever triggering. */}
+      {/* Content area — min-h-0 required so flex-1 is constrained to (100vh - header). */}
       <div className="flex-1 flex flex-col min-w-0 min-h-0">
 
         {/* DNS setup notice */}
@@ -835,57 +851,95 @@ export default function RootLayout() {
           </div>
         )}
 
-        {workspaceMode && editorFilePath ? (
-          // Workspace mode: editor + chat side by side, sticky below header
-          <div className="flex flex-1 min-h-0">
-            <EditorFlyout
-              filePath={editorFilePath}
-              onClose={handleCloseEditor}
-              theme={theme}
-              docked
-            />
-            <ChatFlyout
-              open={chatOpen}
-              onClose={() => { setChatOpen(false); setChatContext(null); setChatInitialMessage(null); setChatRequestId(null); }}
-              theme={theme}
-              projects={projectsHook.projects}
-              openWithContext={chatContext}
-              openWithMessage={chatInitialMessage}
-              openRequestId={chatRequestId}
-              notifications={notifications}
-              docked
-            />
-          </div>
-        ) : (
-          // Hearth layout — chat always docked on the left, content on the right.
-          // Chat is the primary UX surface: always visible, context-aware.
-          // On /projects/:path → project chat. Everywhere else → workspace chat.
-          <div className="flex-1 min-h-0 overflow-hidden flex" data-testid="hearth-layout">
-            <ChatFlyout
-              open={chatOpen}
-              onClose={() => { setChatOpen(false); setChatInitialMessage(null); setChatRequestId(null); }}
-              theme={theme}
-              projects={projectsHook.projects}
-              openWithContext={chatContext}
-              openWithMessage={chatInitialMessage}
-              openRequestId={chatRequestId}
-              notifications={notifications}
-              docked
-            />
-            <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
-              <RouteDevNotes />
-              {editorFilePath && (
-                <EditorFlyout
-                  filePath={editorFilePath}
-                  onClose={handleCloseEditor}
-                  theme={theme}
-                  position="left"
-                />
-              )}
-              <Outlet context={ctx} />
-            </main>
-          </div>
-        )}
+        {/* 3-panel shell: Canvas | Chat | Workspace.
+            User-configurable order stored in localStorage under SHELL_ORDER_KEY.
+            Canvas = route content; Chat = always-on conversation; Workspace = editor.
+            Workspace panel auto-opens when a file is being edited. */}
+        <div className="flex-1 min-h-0 overflow-hidden flex flex-row" data-testid="hearth-layout">
+          <AccordionPanel
+            orientation={isMobile ? "vertical" : "horizontal"}
+            value={shellOpen}
+            onValueChange={(next) => {
+              const typed = (next as string[]).filter(
+                (id): id is ShellPanelId => SHELL_PANELS.includes(id as ShellPanelId),
+              );
+              // Closing the workspace rail = close the editor file
+              if (shellOpen.includes("workspace") && !typed.includes("workspace")) {
+                handleCloseEditor();
+              }
+              setShellOpen(typed);
+            }}
+            className={cn("flex flex-1 w-full min-h-0", isMobile ? "flex-col" : "flex-row")}
+          >
+            {panelOrder.map((panelId) => {
+              const isOpen = shellOpen.includes(panelId);
+              const sectionClass = cn(
+                "min-w-0 min-h-0 flex flex-row",
+                isOpen ? "flex-1" : "w-8",
+              );
+
+              if (panelId === "canvas") {
+                return (
+                  <AccordionPanel.Section key="canvas" id="canvas" unstyled className={sectionClass}>
+                    <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
+                      <main className="flex-1 min-h-0 flex flex-col overflow-hidden" data-testid="hearth-canvas">
+                        <RouteDevNotes />
+                        <Outlet context={ctx} />
+                      </main>
+                    </AccordionPanel.Content>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellRailTrigger label="Canvas" state={state} />}
+                    </AccordionPanel.Trigger>
+                  </AccordionPanel.Section>
+                );
+              }
+
+              if (panelId === "chat") {
+                return (
+                  <AccordionPanel.Section key="chat" id="chat" unstyled className={sectionClass}>
+                    <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0">
+                      <ChatFlyout
+                        open
+                        onClose={() => { setChatInitialMessage(null); setChatRequestId(null); }}
+                        theme={theme}
+                        projects={projectsHook.projects}
+                        openWithContext={chatContext}
+                        openWithMessage={chatInitialMessage}
+                        openRequestId={chatRequestId}
+                        notifications={notifications}
+                        docked
+                        inShell
+                      />
+                    </AccordionPanel.Content>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellRailTrigger label="Chat" state={state} />}
+                    </AccordionPanel.Trigger>
+                  </AccordionPanel.Section>
+                );
+              }
+
+              if (panelId === "workspace") {
+                return (
+                  <AccordionPanel.Section key="workspace" id="workspace" unstyled className={sectionClass}>
+                    <AccordionPanel.Content unstyled className="flex-1 min-h-0 min-w-0">
+                      <EditorFlyout
+                        filePath={editorFilePath}
+                        onClose={handleCloseEditor}
+                        theme={theme}
+                        panel
+                      />
+                    </AccordionPanel.Content>
+                    <AccordionPanel.Trigger>
+                      {(state) => <ShellRailTrigger label="Workspace" state={state} />}
+                    </AccordionPanel.Trigger>
+                  </AccordionPanel.Section>
+                );
+              }
+
+              return null;
+            })}
+          </AccordionPanel>
+        </div>
       </div>
 
       {/* Terminal flyout (bottom, overlay) */}

--- a/ui/dashboard/src/routes/settings-channels.tsx
+++ b/ui/dashboard/src/routes/settings-channels.tsx
@@ -76,7 +76,6 @@ interface DiscordStateDescriptor {
 import { ChannelModeBadge, CHANNEL_MODES, CHANNEL_MODE_META } from "@/components/ChannelModeBadge.js";
 import type { DiscordChannelMode } from "@/components/ChannelModeBadge.js";
 
-/** Fields managed visually by DiscordServerPanel — hidden in the generic config form. */
 interface ChannelExtConfig {
   memoryScope?: {
     channel?: boolean;
@@ -86,15 +85,6 @@ interface ChannelExtConfig {
   };
   promptAddendum?: string;
 }
-
-const DISCORD_VISUAL_FIELDS = new Set([
-  "allowedGuildIds",
-  "allowedChannelIds",
-  "presenceChannelIds",
-  "allowedRoleIds",
-  "channelModes",
-  "channelConfig",
-]);
 
 function parseIds(v: unknown): string[] {
   if (typeof v === "string") return v.split(",").map((s) => s.trim()).filter(Boolean);
@@ -356,7 +346,7 @@ function ChannelLogTab({ channelId }: { channelId: string }) {
           No log entries yet. Entries appear when the channel starts, receives messages, or errors.
         </div>
       ) : (
-        <div className="font-mono text-[11px] space-y-0.5 max-h-[480px] overflow-y-auto">
+        <div className="font-mono text-[11px] space-y-0.5 min-h-[200px] max-h-[60vh] overflow-y-auto">
           {entries.map((e, i) => (
             <div
               key={`${e.ts}-${String(i)}`}
@@ -944,6 +934,109 @@ function DiscordServerPanel({ channelId, cfgResponse, enabled, channelStatus, on
 }
 
 // ---------------------------------------------------------------------------
+// DiscordSettingsPanel — guided setup form for the Discord channel
+// ---------------------------------------------------------------------------
+
+interface DiscordSettingsPanelProps {
+  form: Record<string, string>;
+  onChange: (form: Record<string, string>) => void;
+}
+
+function DiscordSettingsPanel({ form, onChange }: DiscordSettingsPanelProps) {
+  const hasToken = Boolean(form.botToken?.trim());
+  const mentionOnly = form.mentionOnly === "true";
+
+  return (
+    <div className="space-y-4">
+      {!hasToken && (
+        <div className="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4">
+          <p className="text-[13px] font-semibold text-foreground mb-3">Connect Aion to Discord</p>
+          <ol className="space-y-2 text-[12px] text-muted-foreground list-decimal list-inside">
+            <li>Go to <strong>discord.com/developers/applications</strong> and create a new application</li>
+            <li>Open the <strong>Bot</strong> tab → click <strong>Reset Token</strong> → copy the token</li>
+            <li>Paste the token into <strong>Bot Token</strong> below, then click <strong>Save</strong></li>
+            <li>
+              Under <strong>OAuth2 → URL Generator</strong>, select the <code>bot</code> scope +{" "}
+              <code>Send Messages</code> and <code>Read Message History</code> permissions → copy the
+              URL → open it to invite Aion to your server
+            </li>
+            <li>Come back here and click <strong>Start</strong></li>
+          </ol>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] font-medium text-muted-foreground">Bot Token</label>
+        <input
+          type="password"
+          value={form.botToken ?? ""}
+          onChange={(e) => onChange({ ...form, botToken: e.target.value })}
+          autoComplete="off"
+          placeholder="••••••••"
+          className="h-8 px-3 rounded-lg border border-input bg-background text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <p className="text-[11px] text-muted-foreground">
+          From Discord Developer Portal → Your App → Bot → Reset Token
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] font-medium text-muted-foreground">Application ID</label>
+        <input
+          type="text"
+          value={form.applicationId ?? ""}
+          onChange={(e) => onChange({ ...form, applicationId: e.target.value })}
+          autoComplete="off"
+          className="h-8 px-3 rounded-lg border border-input bg-background text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Optional. From Developer Portal → Your App → General Information. Required only for slash commands.
+        </p>
+      </div>
+
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[12px] font-medium text-muted-foreground">Respond only when @mentioned</span>
+          <span className="text-[11px] text-muted-foreground">
+            When on, Aion replies only when @mentioned. Turn off to respond to all messages in channels
+            where Aion has Respond mode.
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => onChange({ ...form, mentionOnly: mentionOnly ? "false" : "true" })}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${mentionOnly ? "bg-emerald-500" : "bg-secondary"}`}
+          aria-label="Toggle respond only when mentioned"
+        >
+          <span
+            className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${mentionOnly ? "left-[18px] bg-white" : "left-0.5 bg-muted-foreground"}`}
+          />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] font-medium text-muted-foreground">Rate limit (messages/min)</label>
+        <input
+          type="number"
+          min="1"
+          max="1000"
+          value={form.rateLimitPerMinute ?? ""}
+          onChange={(e) => onChange({ ...form, rateLimitPerMinute: e.target.value })}
+          className="h-8 px-3 rounded-lg border border-input bg-background text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring w-32"
+        />
+        <p className="text-[11px] text-muted-foreground">
+          Max messages per user per minute before Aion pauses responses. Default: 20.
+        </p>
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        Channel presence, role permissions, and per-channel modes are managed in the <strong>Server</strong> tab.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // ChannelTab — config + controls for one channel
 // ---------------------------------------------------------------------------
 
@@ -961,6 +1054,7 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
   const [controlling, setControlling] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [discordNotConnected, setDiscordNotConnected] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const loadData = useCallback(async () => {
@@ -1006,6 +1100,18 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
       if (pollRef.current) clearInterval(pollRef.current);
     };
   }, [id, loadData]);
+
+  useEffect(() => {
+    const status = detail?.status ?? "stopped";
+    if (id !== "discord" || status !== "running") {
+      setDiscordNotConnected(false);
+      return;
+    }
+    fetch("/api/channels/discord/state")
+      .then((r) => r.json() as Promise<DiscordStateDescriptor>)
+      .then((data) => { setDiscordNotConnected(!data.connected); })
+      .catch(() => {});
+  }, [id, detail]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -1064,6 +1170,11 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
           )}
           {error && (
             <span className="text-[12px] text-destructive truncate max-w-xs">{error}</span>
+          )}
+          {discordNotConnected && (
+            <span className="text-[11px] text-amber-400 flex items-center gap-1">
+              ⚠ Not connected to Discord — check bot token
+            </span>
           )}
           <div className="ml-auto flex items-center gap-2">
             <button
@@ -1136,31 +1247,25 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
 
               {cfgResponse === null ? (
                 <p className="text-[13px] text-muted-foreground">Loading configuration…</p>
+              ) : id === "discord" ? (
+                <DiscordSettingsPanel form={form} onChange={setForm} />
               ) : fieldKeys.length === 0 ? (
                 <p className="text-[13px] text-muted-foreground">No configuration fields for this channel.</p>
               ) : (
                 <div className="grid grid-cols-1 gap-3">
-                  {fieldKeys
-                    // Discord array fields are managed visually in the Server tab
-                    .filter((key) => !(id === "discord" && DISCORD_VISUAL_FIELDS.has(key)))
-                    .map((key) => (
-                      <div key={key} className="flex flex-col gap-1">
-                        <label className="text-[12px] font-medium text-muted-foreground">{fieldLabel(key)}</label>
-                        <input
-                          type={isSensitive(key) ? "password" : "text"}
-                          value={form[key] ?? ""}
-                          onChange={(e) => setForm((prev) => ({ ...prev, [key]: e.target.value }))}
-                          autoComplete="off"
-                          className="h-8 px-3 rounded-lg border border-input bg-background text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                          placeholder={isSensitive(key) ? "••••••••" : ""}
-                        />
-                      </div>
-                    ))}
-                  {id === "discord" && (
-                    <p className="text-[11px] text-muted-foreground">
-                      Channel presence and role permissions are managed in the <strong>Server</strong> tab.
-                    </p>
-                  )}
+                  {fieldKeys.map((key) => (
+                    <div key={key} className="flex flex-col gap-1">
+                      <label className="text-[12px] font-medium text-muted-foreground">{fieldLabel(key)}</label>
+                      <input
+                        type={isSensitive(key) ? "password" : "text"}
+                        value={form[key] ?? ""}
+                        onChange={(e) => setForm((prev) => ({ ...prev, [key]: e.target.value }))}
+                        autoComplete="off"
+                        className="h-8 px-3 rounded-lg border border-input bg-background text-[13px] text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                        placeholder={isSensitive(key) ? "••••••••" : ""}
+                      />
+                    </div>
+                  ))}
                 </div>
               )}
 
@@ -1259,6 +1364,13 @@ export default function SettingsChannelsPage() {
           allowedRoleIds) is wired automatically. (2) Saving channel/role settings via the Server
           tab now triggers an immediate channel restart so config changes take effect without a
           manual restart.
+        </DevNote.Item>
+        <DevNote.Item kind="info" heading="Discord setup guide + UX overhaul">
+          Discord Settings tab replaced with a guided DiscordSettingsPanel: numbered setup steps
+          shown when botToken is empty, labeled fields with descriptions for botToken / applicationId
+          / mentionOnly (now a toggle) / rateLimitPerMinute, and a status-bar warning when the
+          process registry shows Running but the bot WebSocket is not actually connected to Discord.
+          Log tab max-height changed from fixed 480px to 60 vh so it doesn&apos;t overflow the viewport.
         </DevNote.Item>
         <DevNote.Item kind="info" heading="Discord reconnect + role access control + member registration">
           Three Discord improvements shipped together: (1) Discord now auto-reconnects after

--- a/ui/dashboard/src/routes/settings-channels.tsx
+++ b/ui/dashboard/src/routes/settings-channels.tsx
@@ -1029,6 +1029,30 @@ function DiscordSettingsPanel({ form, onChange }: DiscordSettingsPanelProps) {
         </p>
       </div>
 
+      {/* Server Members Intent toggle */}
+      <div className="flex items-start justify-between gap-3 pt-1">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[13px] font-medium text-foreground">Server Members Intent</span>
+          <p className="text-[11px] text-muted-foreground max-w-[340px]">
+            Enable only after turning on <strong>Server Members Intent</strong> in your{" "}
+            Discord Developer Portal → Bot → Privileged Gateway Intents. Required for
+            member sync and role-based access control. Without the portal toggle, enabling
+            this will prevent the bot from connecting (error 4014).
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onChange({ ...form, enableServerMembersIntent: String(!(form.enableServerMembersIntent === "true")) })}
+          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${form.enableServerMembersIntent === "true" ? "bg-primary" : "bg-muted"}`}
+          aria-checked={form.enableServerMembersIntent === "true"}
+          role="switch"
+        >
+          <span
+            className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${form.enableServerMembersIntent === "true" ? "left-[18px] bg-white" : "left-0.5 bg-muted-foreground"}`}
+          />
+        </button>
+      </div>
+
       <p className="text-[11px] text-muted-foreground">
         Channel presence, role permissions, and per-channel modes are managed in the <strong>Server</strong> tab.
       </p>
@@ -1371,6 +1395,14 @@ export default function SettingsChannelsPage() {
           / mentionOnly (now a toggle) / rateLimitPerMinute, and a status-bar warning when the
           process registry shows Running but the bot WebSocket is not actually connected to Discord.
           Log tab max-height changed from fixed 480px to 60 vh so it doesn&apos;t overflow the viewport.
+        </DevNote.Item>
+        <DevNote.Item kind="fix" heading="Discord GuildMembers intent — opt-in flag (v0.4.870)">
+          GatewayIntentBits.GuildMembers is a privileged Discord intent requiring
+          &quot;Server Members Intent&quot; to be enabled in the developer portal. It was
+          previously hardcoded, causing 4014 Disallowed Intents on bots without the
+          portal toggle → bot never connects. Now controlled by enableServerMembersIntent
+          toggle in Settings (default off). Proactive member sync is also guarded by
+          the same flag.
         </DevNote.Item>
         <DevNote.Item kind="info" heading="Discord reconnect + role access control + member registration">
           Three Discord improvements shipped together: (1) Discord now auto-reconnects after

--- a/ui/dashboard/src/routes/settings-channels.tsx
+++ b/ui/dashboard/src/routes/settings-channels.tsx
@@ -956,7 +956,7 @@ function DiscordSettingsPanel({ form, onChange }: DiscordSettingsPanelProps) {
       )}
 
       <div className="flex flex-col gap-1">
-        <label className="text-[12px] font-medium text-muted-foreground">Bot Token</label>
+        <label data-testid="discord-bot-token-label" className="text-[12px] font-medium text-muted-foreground">Bot Token</label>
         <input
           type="password"
           value={form.botToken ?? ""}

--- a/ui/dashboard/src/routes/settings-channels.tsx
+++ b/ui/dashboard/src/routes/settings-channels.tsx
@@ -96,17 +96,6 @@ function parseIds(v: unknown): string[] {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function statusColor(status: string): string {
-  if (status === "running") return "bg-emerald-500";
-  if (status === "error") return "bg-red-500";
-  if (status === "starting" || status === "stopping") return "bg-amber-400";
-  return "bg-secondary";
-}
-
-function statusLabel(status: string): string {
-  return status.charAt(0).toUpperCase() + status.slice(1);
-}
-
 /** Derive a human label from a camelCase / snake_case config field name. */
 function fieldLabel(key: string): string {
   return key
@@ -945,6 +934,7 @@ interface DiscordSettingsPanelProps {
 function DiscordSettingsPanel({ form, onChange }: DiscordSettingsPanelProps) {
   const hasToken = Boolean(form.botToken?.trim());
   const mentionOnly = form.mentionOnly === "true";
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   return (
     <div className="space-y-4">
@@ -1029,33 +1019,45 @@ function DiscordSettingsPanel({ form, onChange }: DiscordSettingsPanelProps) {
         </p>
       </div>
 
-      {/* Server Members Intent toggle */}
-      <div className="flex items-start justify-between gap-3 pt-1">
-        <div className="flex flex-col gap-0.5">
-          <span className="text-[13px] font-medium text-foreground">Server Members Intent</span>
-          <p className="text-[11px] text-muted-foreground max-w-[340px]">
-            Enable only after turning on <strong>Server Members Intent</strong> in your{" "}
-            Discord Developer Portal → Bot → Privileged Gateway Intents. Required for
-            member sync and role-based access control. Without the portal toggle, enabling
-            this will prevent the bot from connecting (error 4014).
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => onChange({ ...form, enableServerMembersIntent: String(!(form.enableServerMembersIntent === "true")) })}
-          className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${form.enableServerMembersIntent === "true" ? "bg-primary" : "bg-muted"}`}
-          aria-checked={form.enableServerMembersIntent === "true"}
-          role="switch"
-        >
-          <span
-            className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${form.enableServerMembersIntent === "true" ? "left-[18px] bg-white" : "left-0.5 bg-muted-foreground"}`}
-          />
-        </button>
-      </div>
-
       <p className="text-[11px] text-muted-foreground">
         Channel presence, role permissions, and per-channel modes are managed in the <strong>Server</strong> tab.
       </p>
+
+      {/* Advanced — collapsed by default, rarely needed */}
+      <div className="border-t border-border/40 pt-3">
+        <button
+          type="button"
+          onClick={() => setShowAdvanced((v) => !v)}
+          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <span className={`transition-transform ${showAdvanced ? "rotate-90" : ""}`}>▶</span>
+          Advanced
+        </button>
+        {showAdvanced && (
+          <div className="mt-3 space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-[12px] font-medium text-muted-foreground">Server Members Intent</span>
+                <p className="text-[11px] text-muted-foreground max-w-[320px]">
+                  Required for member sync and role-based access. You must first enable{" "}
+                  <strong>Server Members Intent</strong> in the Discord Developer Portal → Bot →
+                  Privileged Gateway Intents — without that, enabling this will prevent the bot
+                  from connecting (error 4014).
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onChange({ ...form, enableServerMembersIntent: String(form.enableServerMembersIntent !== "true") })}
+                className={`relative shrink-0 w-9 h-5 rounded-full transition-colors ${form.enableServerMembersIntent === "true" ? "bg-primary" : "bg-muted"}`}
+                role="switch"
+                aria-checked={form.enableServerMembersIntent === "true"}
+              >
+                <span className={`absolute top-0.5 w-4 h-4 rounded-full transition-all ${form.enableServerMembersIntent === "true" ? "left-[18px] bg-white" : "left-0.5 bg-muted-foreground"}`} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -1069,17 +1071,18 @@ interface ChannelTabProps {
   initialEnabled: boolean;
 }
 
-function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
+function ChannelTab({ id, initialEnabled: _initialEnabled }: ChannelTabProps) {
   const [detail, setDetail] = useState<ChannelDetail | null>(null);
   const [cfgResponse, setCfgResponse] = useState<ChannelConfigResponse | null>(null);
   const [form, setForm] = useState<Record<string, string>>({});
-  const [enabled, setEnabled] = useState(initialEnabled);
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
   const [controlling, setControlling] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [discordNotConnected, setDiscordNotConnected] = useState(false);
+  // Discord-specific: live WS connection state from /api/channels/discord/state
+  const [discordState, setDiscordState] = useState<DiscordStateDescriptor | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const discordPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const loadData = useCallback(async () => {
     try {
@@ -1089,7 +1092,6 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
       ]);
       setDetail(det);
       setCfgResponse(cfg);
-      setEnabled(cfg.enabled);
       // Only include scalar (non-object) values in the form — object/array fields
       // (memory, tools, autoMod, etc.) are owned by specialised UIs and must not
       // be coerced to "[object Object]" strings here.
@@ -1125,35 +1127,61 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
     };
   }, [id, loadData]);
 
+  // Discord WS connection state — independent poll at 3s so the indicator
+  // is always current without waiting for the 5s registry poll to tick.
   useEffect(() => {
-    const status = detail?.status ?? "stopped";
-    if (id !== "discord" || status !== "running") {
-      setDiscordNotConnected(false);
-      return;
-    }
-    fetch("/api/channels/discord/state")
-      .then((r) => r.json() as Promise<DiscordStateDescriptor>)
-      .then((data) => { setDiscordNotConnected(!data.connected); })
-      .catch(() => {});
-  }, [id, detail]);
+    if (id !== "discord") return;
+    const poll = () => {
+      fetch("/api/channels/discord/state")
+        .then((r) => r.json() as Promise<DiscordStateDescriptor>)
+        .then(setDiscordState)
+        .catch(() => {});
+    };
+    poll();
+    discordPollRef.current = setInterval(poll, 3_000);
+    return () => {
+      if (discordPollRef.current) clearInterval(discordPollRef.current);
+    };
+  }, [id]);
 
   const handleSave = async () => {
     setSaving(true);
     setSaveMsg(null);
     try {
-      // Start from the full current config so non-scalar fields (owned by other UIs)
-      // are preserved verbatim, then overlay the scalar form values on top.
+      // Preserve non-scalar fields (owned by other UIs), overlay scalar form values on top.
       const config: Record<string, unknown> = { ...cfgResponse?.config };
       for (const [k, v] of Object.entries(form)) {
         config[k] = v;
       }
-      await updateChannelConfig(id, { enabled, config });
-      setSaveMsg("Saved.");
+      // Preserve the existing enabled state — Start/Stop buttons own that flag.
+      await updateChannelConfig(id, { enabled: cfgResponse?.enabled ?? true, config });
+
       if (detail?.status === "running") {
         await restartChannel(id);
-        setSaveMsg("Saved and restarted.");
-        loadData();
+      } else {
+        await startChannel(id);
       }
+
+      if (id === "discord") {
+        setSaveMsg("Connecting...");
+        const deadline = Date.now() + 20_000;
+        let finalMsg = "Saved — check status indicator";
+        while (Date.now() < deadline) {
+          await new Promise<void>((r) => setTimeout(r, 1_500));
+          try {
+            const r = await fetch("/api/channels/discord/state");
+            const state = await (r.json() as Promise<DiscordStateDescriptor>);
+            if (state.connected) { finalMsg = "Saved — bot connected ✓"; break; }
+            const det = await fetchChannelDetail(id);
+            setDetail(det);
+            if (det.status === "error") { finalMsg = `Error: ${det.error ?? "connection failed"}`; break; }
+          } catch { break; }
+        }
+        setSaveMsg(finalMsg);
+      } else {
+        setSaveMsg("Saved and restarted.");
+      }
+      void loadData();
     } catch (err) {
       setSaveMsg(`Error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
@@ -1175,10 +1203,33 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
     }
   };
 
-  const currentStatus = detail?.status ?? "stopped";
+  const registryStatus = detail?.status ?? "stopped";
+
+  // For Discord, derive the displayed status from the live WS state poll, not
+  // the registry. "running" in the registry only means login was initiated;
+  // "connected" means the bot received READY and is online in Discord.
+  const isDiscord = id === "discord";
+  const discordConnected = discordState?.connected ?? false;
+  const displayStatus = isDiscord
+    ? registryStatus === "running"
+      ? (discordConnected ? "running" : "starting")
+      : registryStatus
+    : registryStatus;
+
   const fieldKeys = cfgResponse
     ? [...new Set([...Object.keys(cfgResponse.defaults), ...Object.keys(cfgResponse.config)])]
     : [];
+
+  const statusDot =
+    displayStatus === "running" ? "bg-emerald-500" :
+    displayStatus === "starting" || displayStatus === "stopping" ? "bg-amber-400 animate-pulse" :
+    displayStatus === "error" ? "bg-red-500" : "bg-secondary";
+
+  const statusText =
+    displayStatus === "running" ? (isDiscord ? "Connected" : "Running") :
+    displayStatus === "starting" ? (isDiscord ? "Connecting..." : "Starting...") :
+    displayStatus === "stopping" ? "Stopping..." :
+    displayStatus === "error" ? "Error" : "Stopped";
 
   return (
     <div className="space-y-4">
@@ -1186,8 +1237,8 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
       <Card className="p-4">
         <div className="flex items-center gap-3 flex-wrap">
           <div className="flex items-center gap-2">
-            <span className={`w-2.5 h-2.5 rounded-full ${statusColor(currentStatus)}`} />
-            <span className="text-[13px] font-medium">{statusLabel(currentStatus)}</span>
+            <span className={`w-2.5 h-2.5 rounded-full ${statusDot}`} />
+            <span className="text-[13px] font-medium">{statusText}</span>
           </div>
           {detail?.error && (
             <span className="text-[12px] text-destructive truncate max-w-xs">{detail.error}</span>
@@ -1195,29 +1246,24 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
           {error && (
             <span className="text-[12px] text-destructive truncate max-w-xs">{error}</span>
           )}
-          {discordNotConnected && (
-            <span className="text-[11px] text-amber-400 flex items-center gap-1">
-              ⚠ Not connected to Discord — check bot token
-            </span>
-          )}
           <div className="ml-auto flex items-center gap-2">
             <button
               onClick={() => handleControl("start")}
-              disabled={controlling || currentStatus === "running"}
+              disabled={controlling || registryStatus === "running"}
               className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               Start
             </button>
             <button
               onClick={() => handleControl("stop")}
-              disabled={controlling || currentStatus !== "running"}
+              disabled={controlling || registryStatus !== "running"}
               className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-secondary text-foreground hover:bg-secondary/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               Stop
             </button>
             <button
               onClick={() => handleControl("restart")}
-              disabled={controlling || currentStatus !== "running"}
+              disabled={controlling || registryStatus !== "running"}
               className="px-3 py-1.5 rounded-lg text-[12px] font-medium bg-secondary text-foreground hover:bg-secondary/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               Restart
@@ -1240,8 +1286,8 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
             <DiscordServerPanel
               channelId={id}
               cfgResponse={cfgResponse}
-              enabled={enabled}
-              channelStatus={currentStatus}
+              enabled={cfgResponse?.enabled ?? true}
+              channelStatus={registryStatus}
               onSaved={loadData}
             />
           </TabsContent>
@@ -1251,23 +1297,7 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
           <div className="space-y-5">
             {/* Config form */}
             <Card className="p-5 space-y-4">
-              <div className="flex items-center justify-between mb-1">
-                <h3 className="text-[13px] font-semibold text-foreground">Configuration</h3>
-                {/* Enabled toggle */}
-                <label className="flex items-center gap-2 cursor-pointer select-none">
-                  <button
-                    type="button"
-                    onClick={() => setEnabled((v) => !v)}
-                    className={`relative w-9 h-5 rounded-full transition-colors ${enabled ? "bg-emerald-500" : "bg-secondary"}`}
-                    aria-label="Toggle channel enabled"
-                  >
-                    <span
-                      className={`absolute top-0.5 ${enabled ? "left-[18px] bg-white" : "left-0.5 bg-muted-foreground"} w-4 h-4 rounded-full transition-all`}
-                    />
-                  </button>
-                  <span className="text-[12px] text-muted-foreground">{enabled ? "Enabled" : "Disabled"}</span>
-                </label>
-              </div>
+              <h3 className="text-[13px] font-semibold text-foreground">Configuration</h3>
 
               {cfgResponse === null ? (
                 <p className="text-[13px] text-muted-foreground">Loading configuration…</p>
@@ -1306,7 +1336,7 @@ function ChannelTab({ id, initialEnabled }: ChannelTabProps) {
                     {saveMsg}
                   </span>
                 )}
-                {currentStatus === "running" && !saveMsg && (
+                {registryStatus === "running" && !saveMsg && (
                   <span className="text-[11px] text-muted-foreground">
                     Saving will restart the channel to apply new credentials.
                   </span>

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -428,6 +428,10 @@ export interface ProjectHostingInfo {
   internalPort: number | null;
   runtimeId?: string | null;
   status: "running" | "stopped" | "error" | "unconfigured";
+  /** True when the most recent TCP probe to the container's port succeeded.
+   *  Green = running + serving. Yellow = running + !serving (starting/degraded).
+   *  Only meaningful when status === "running"; always false otherwise. */
+  serving?: boolean;
   tunnelUrl?: string | null;
   containerName?: string;
   image?: string;

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -106,6 +106,30 @@ export interface SystemUpgradeEvent {
   status?: string;
 }
 
+/** Emitted once on gateway boot when a new version is detected. */
+export interface SystemUpgradedEvent {
+  toVersion: string;
+  fromVersion: string | null;
+  pendingSteps: number;
+  hasRequired: boolean;
+}
+
+/** A single post-upgrade action item (required or optional). */
+export interface UpgradeNextStep {
+  id: string;
+  title: string;
+  description: string;
+  required: boolean;
+  status: "pending" | "done" | "dismissed";
+  addedAt: string;
+  fromVersion: string;
+  action?: {
+    label: string;
+    kind: "navigate" | "external-url" | "chat";
+    target: string;
+  };
+}
+
 /** Hosting infrastructure status from WebSocket. */
 export interface HostingStatusData {
   ready: boolean;
@@ -397,6 +421,7 @@ export type DashboardEvent =
   | { type: "overview:updated"; data: DashboardOverview }
   | { type: "project:activity"; data: ProjectActivity }
   | { type: "system:upgrade"; data: SystemUpgradeEvent }
+  | { type: "system:upgraded"; data: SystemUpgradedEvent }
   | { type: "system:update_available"; data: UpdateCheck }
   | { type: "hosting:status"; data: HostingStatusData }
   | { type: "project:config_changed"; data: ProjectConfigChangedData }

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -120,7 +120,8 @@ export interface UpgradeNextStep {
   title: string;
   description: string;
   required: boolean;
-  status: "pending" | "done" | "dismissed";
+  /** pending = actionable. done/dismissed = resolved. superseded = cancelled by a later migration. */
+  status: "pending" | "done" | "dismissed" | "superseded";
   addedAt: string;
   fromVersion: string;
   action?: {
@@ -128,6 +129,8 @@ export interface UpgradeNextStep {
     kind: "navigate" | "external-url" | "chat";
     target: string;
   };
+  /** IDs of earlier steps this step supersedes. */
+  cancels?: string[];
 }
 
 /** Hosting infrastructure status from WebSocket. */

--- a/ui/dashboard/src/types.ts
+++ b/ui/dashboard/src/types.ts
@@ -444,6 +444,10 @@ export interface ProjectHostingInfo {
   containerKind?: "static" | "code" | "mapp";
   /** s145 t585 — installed MApp IDs for the MApp container kind. */
   mapps?: string[];
+  /** When false, the Caddy offline-page error block is omitted — raw app errors pass through. */
+  friendlyErrors?: boolean;
+  /** Custom container image for multi-repo projects (overrides agi-runtime:lamp). */
+  baseImage?: string | null;
   /** Circuit-breaker state for this project's hosting service id, when not closed.
    *  Surfaces "open" / "half-open" so the dashboard can render a distinct chip. */
   breaker?: {


### PR DESCRIPTION
## Summary

- **3-panel shell (Workspace | Chat | Canvas)** — AccordionPanel with draggable headers, persistent user ordering, always-on chat, AgentCanvas via React portal
- **Discord channel** — fix `isDiscordConfig` string-bool/number coercion; empty fields treated as "not set"
- **Hosting** — TCP health probe (3-state status dot), stack-resolved internalPort persisted to Caddyfile on container start, polyglot Docker image (Python 3.11 + Node 24)
- **Editor** — `fancy-code/styles.css` import for syntax highlighting, Ctrl+S save, panel mode in shell
- **Upgrade system** — `UpgradeNextStepsPanel` post-upgrade modal, versioned migration runner with `cancels[]` support, PAx upstream sync in upgrade.sh
- **Projects page** — health-sorted list, platform hero card for Aionima
- **E2E specs** — hearth-layout, settings-channels-discord, chat/flyout/shell specs updated throughout

## Test plan

- [ ] `agi test --e2e hearth-focused-layout` — shell layout present on all routes
- [ ] `agi test --e2e flyout-panel` — chat always visible, rail headers present
- [ ] `agi test --e2e settings-channels-discord` — Discord settings panel renders correctly
- [ ] `agi test --e2e project-workspace-mode-picker` — no chat aside present
- [ ] Manual: drag panel headers to reorder Workspace/Chat/Canvas, verify localStorage persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)